### PR TITLE
add the "no-tty" flag to goreleaser sign

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,6 +67,7 @@ signs:
       # if you are using this is in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
+      - "--no-tty"
       - "--local-user"
       - "{{ .Env.GPG_FINGERPRINT }}"
       - "--output"


### PR DESCRIPTION
Adding as per - https://github.com/hashicorp/terraform-ls/pull/475

We can't re-produce this error when testing a similar configuration to this repo but worth a try!

```
gpg apparently uses tty for printing warnings (in this case likely about trust level for the new key)

Because there's no valid tty in GitHub Actions (or any other CI) we reflect that by passing extra flags to gpg.
```

