### PR TITLE
Reverting back to use github action for importing gpg key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,21 +29,18 @@ jobs:
       - name: Describe plugin
         id: plugin_describe
         run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"
-      -
-        name: Import key for archive signing
-        run: echo -e "${{ secrets.GPG_PRIVATE_KEY_DECRYPTED }}" | gpg --import --batch --no-tty
-      # - name: Import GPG key
-      #   id: import_gpg
-      #   uses: hashicorp/ghaction-import-gpg@v2.1.0
-      #   env:
-      #     GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-      #     PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Import GPG key
+        id: import_gpg
+        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist
         env:
-          GPG_FINGERPRINT: ${{ secrets.GPG_PUBLIC_KEY_ID }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           API_VERSION: ${{ steps.plugin_describe.outputs.api_version }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,7 +67,6 @@ signs:
       # if you are using this is in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
-      - "--no-tty"
       - "--local-user"
       - "{{ .Env.GPG_FINGERPRINT }}"
       - "--output"


### PR DESCRIPTION
See https://github.com/hashicorp/ghaction-import-gpg/pull/4 for the update to default-cache-ttl.

