### PR TITLE
Adding support for private DTL VMs

### DIFF
--- a/builder/azure/chroot/builder_test.go
+++ b/builder/azure/chroot/builder_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestBuilder_Prepare(t *testing.T) {
 	type config map[string]interface{}
-	type regexMatchers map[string]string // map of regex : error message
 
 	tests := []struct {
 		name     string

--- a/builder/azure/chroot/diskattacher_test.go
+++ b/builder/azure/chroot/diskattacher_test.go
@@ -12,11 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	testvm   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/testGroup/Microsoft.Compute/virtualMachines/testVM"
-	testdisk = "/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/testGroup2/Microsoft.Compute/disks/testDisk"
-)
-
 // Tests assume current machine is capable of running chroot builder (i.e. an Azure VM)
 
 func Test_DiskAttacherAttachesDiskToVM(t *testing.T) {

--- a/builder/azure/chroot/step_verify_source_disk_test.go
+++ b/builder/azure/chroot/step_verify_source_disk_test.go
@@ -150,8 +150,3 @@ func Test_StepVerifySourceDisk_Run(t *testing.T) {
 		})
 	}
 }
-
-type uiThatRemebersErrors struct {
-	packersdk.Ui
-	LastError string
-}

--- a/builder/azure/chroot/step_verify_source_disk_test.go
+++ b/builder/azure/chroot/step_verify_source_disk_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/client"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
-	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
 func Test_StepVerifySourceDisk_Run(t *testing.T) {

--- a/builder/azure/common/client/azure_client_set.go
+++ b/builder/azure/common/client/azure_client_set.go
@@ -3,7 +3,6 @@ package client
 import (
 	"log"
 	"net/http"
-	"regexp"
 	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/useragent"
@@ -32,8 +31,6 @@ type AzureClientSet interface {
 	// SubscriptionID returns the subscription ID that this client set was created for
 	SubscriptionID() string
 }
-
-var subscriptionPathRegex = regexp.MustCompile(`/subscriptions/([[:xdigit:]]{8}(-[[:xdigit:]]{4}){3}-[[:xdigit:]]{12})`)
 
 var _ AzureClientSet = &azureClientSet{}
 

--- a/builder/azure/common/client/config_test.go
+++ b/builder/azure/common/client/config_test.go
@@ -418,7 +418,7 @@ func Test_getJWT(t *testing.T) {
 
 func newRandReader() io.Reader {
 	var seed int64
-	binary.Read(crand.Reader, binary.LittleEndian, &seed)
+	_ = binary.Read(crand.Reader, binary.LittleEndian, &seed)
 
 	return mrand.New(mrand.NewSource(seed))
 }

--- a/builder/azure/common/client/detect_azure_linux.go
+++ b/builder/azure/common/client/detect_azure_linux.go
@@ -17,7 +17,7 @@ func IsAzure() bool {
 
 func isAzureAssetTag(filename string) bool {
 	if d, err := ioutil.ReadFile(filename); err == nil {
-		return bytes.Compare(d, azureAssetTag) == 0
+		return bytes.Equal(d, azureAssetTag)
 	}
 	return false
 }

--- a/builder/azure/common/client/detect_azure_linux_test.go
+++ b/builder/azure/common/client/detect_azure_linux_test.go
@@ -47,6 +47,5 @@ func TestIsAzure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-
 	assert.True(t, isAzureAssetTag(f.Name()), "asset tag is Azure's")
 }

--- a/builder/azure/common/client/detect_azure_linux_test.go
+++ b/builder/azure/common/client/detect_azure_linux_test.go
@@ -37,7 +37,7 @@ func TestIsAzure(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = f.Truncate(0)
+	err = f.Truncate(0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/builder/azure/common/client/detect_azure_linux_test.go
+++ b/builder/azure/common/client/detect_azure_linux_test.go
@@ -15,15 +15,38 @@ func TestIsAzure(t *testing.T) {
 	}
 	defer os.Remove(f.Name())
 
-	f.Seek(0, 0)
-	f.Truncate(0)
-	f.Write([]byte("not the azure assettag"))
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = f.Truncate(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = f.Write([]byte("not the azure assettag"))
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.False(t, isAzureAssetTag(f.Name()), "asset tag is not Azure's")
 
-	f.Seek(0, 0)
-	f.Truncate(0)
-	f.Write(azureAssetTag)
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = f.Truncate(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = f.Write(azureAssetTag)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 
 	assert.True(t, isAzureAssetTag(f.Name()), "asset tag is Azure's")
 }

--- a/builder/azure/common/dump_config.go
+++ b/builder/azure/common/dump_config.go
@@ -66,5 +66,5 @@ func (s *walker) isMaskable(name string) bool {
 
 func DumpConfig(config interface{}, say func(string)) {
 	walker := newDumpConfig(say)
-	reflectwalk.Walk(config, walker)
+	_ = reflectwalk.Walk(config, walker)
 }

--- a/builder/azure/common/dump_config_test.go
+++ b/builder/azure/common/dump_config_test.go
@@ -5,7 +5,6 @@ import "testing"
 func TestShouldDumpPublicValues(t *testing.T) {
 	type S struct {
 		MyString string
-		myString string
 	}
 
 	data := &S{

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -369,7 +369,10 @@ func (s *TemplateBuilder) SetNetworkSecurityGroup(ipAddresses []string, port int
 		ID: to.StringPtr(resourceId),
 	}
 
-	s.addResource(vnetResource)
+	err = s.addResource(vnetResource)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/builder/azure/dtl/azure_client.go
+++ b/builder/azure/dtl/azure_client.go
@@ -132,7 +132,7 @@ func byConcatDecorators(decorators ...autorest.RespondDecorator) autorest.Respon
 }
 
 func NewAzureClient(subscriptionID, resourceGroupName string,
-	cloud *azure.Environment, SharedGalleryTimeout time.Duration, PollingDuration time.Duration,
+	cloud *azure.Environment, SharedGalleryTimeout time.Duration, CustomImageCaptureTimeout time.Duration, PollingDuration time.Duration,
 	servicePrincipalToken *adal.ServicePrincipalToken) (*AzureClient, error) {
 
 	var azureClient = &AzureClient{}
@@ -166,7 +166,7 @@ func NewAzureClient(subscriptionID, resourceGroupName string,
 	azureClient.DtlCustomImageClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), templateCapture(azureClient), errorCapture(azureClient))
 	azureClient.DtlCustomImageClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.DtlCustomImageClient.UserAgent)
 	azureClient.DtlCustomImageClient.PollingDuration = autorest.DefaultPollingDuration
-	azureClient.DtlCustomImageClient.Client.PollingDuration = PollingDuration
+	azureClient.DtlCustomImageClient.Client.PollingDuration = CustomImageCaptureTimeout
 
 	azureClient.DtlVirtualNetworksClient = dtl.NewVirtualNetworksClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.DtlVirtualNetworksClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
@@ -188,6 +188,13 @@ func NewAzureClient(subscriptionID, resourceGroupName string,
 	azureClient.GalleryImagesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
 	azureClient.GalleryImagesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.GalleryImagesClient.UserAgent)
 	azureClient.GalleryImagesClient.Client.PollingDuration = PollingDuration
+
+	azureClient.InterfacesClient = network.NewInterfacesClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
+	azureClient.InterfacesClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
+	azureClient.InterfacesClient.RequestInspector = withInspection(maxlen)
+	azureClient.InterfacesClient.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))
+	azureClient.InterfacesClient.UserAgent = fmt.Sprintf("%s %s", useragent.String(version.AzurePluginVersion.FormattedVersion()), azureClient.InterfacesClient.UserAgent)
+	azureClient.InterfacesClient.Client.PollingDuration = PollingDuration
 
 	return azureClient, nil
 }

--- a/builder/azure/dtl/builder.go
+++ b/builder/azure/dtl/builder.go
@@ -75,12 +75,13 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		return nil, err
 	}
 
-	ui.Message("Creating Azure Resource Manager (ARM) client ...")
+	ui.Message("Creating Azure DevTestLab (DTL) client ...")
 	azureClient, err := NewAzureClient(
 		b.config.ClientConfig.SubscriptionID,
 		b.config.LabResourceGroupName,
 		b.config.ClientConfig.CloudEnvironment(),
 		b.config.SharedGalleryTimeout,
+		b.config.CustomImageCaptureTimeout,
 		b.config.PollingDurationTimeout,
 		spnCloud)
 
@@ -168,12 +169,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	b.config.Location = *lab.Location
 
 	if b.config.LabVirtualNetworkName == "" || b.config.LabSubnetName == "" {
-		virtualNetowrk, subnet, err := b.getSubnetInformation(ctx, ui, *azureClient)
+		virtualNetwork, subnet, err := b.getSubnetInformation(ctx, ui, *azureClient)
 
 		if err != nil {
 			return nil, err
 		}
-		b.config.LabVirtualNetworkName = *virtualNetowrk
+		b.config.LabVirtualNetworkName = *virtualNetwork
 		b.config.LabSubnetName = *subnet
 
 		ui.Message(fmt.Sprintf("No lab network information provided. Using %s Virtual network and %s subnet for Virtual Machine creation", b.config.LabVirtualNetworkName, b.config.LabSubnetName))

--- a/builder/azure/dtl/builder_acc_test.go
+++ b/builder/azure/dtl/builder_acc_test.go
@@ -33,8 +33,6 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/acctest"
 )
 
-const DeviceLoginAcceptanceTest = "DEVICELOGIN_TEST"
-
 func TestBuilderAcc_ManagedDisk_Windows(t *testing.T) {
 	acctest.TestPlugin(t, &acctest.PluginTestCase{
 		Name: "test-azure-managedisk-windows",
@@ -73,8 +71,6 @@ func TestBuilderAcc_ManagedDisk_Linux_Artifacts(t *testing.T) {
 		},
 	})
 }
-
-func testAccPreCheck(*testing.T) {}
 
 const testBuilderAccManagedDiskWindows = `
 {

--- a/builder/azure/dtl/config.go
+++ b/builder/azure/dtl/config.go
@@ -38,6 +38,8 @@ const (
 	DefaultUserName                          = "packer"
 	DefaultPrivateVirtualNetworkWithPublicIp = false
 	DefaultVMSize                            = "Standard_A1"
+	DefaultSharedGalleryTimeout              = 60 * time.Minute
+	DefaultCustomImageCaptureTimeout         = 30 * time.Minute
 )
 
 const (
@@ -141,6 +143,14 @@ type Config struct {
 	// its default of "60m" (valid time units include `s` for seconds, `m` for
 	// minutes, and `h` for hours.)
 	SharedGalleryTimeout time.Duration `mapstructure:"shared_image_gallery_timeout"`
+
+	// How long to wait for an image to be captured before timing out
+	// If your Packer build is failing on the Capture Image step with the
+	// error `Original Error: context deadline exceeded`, but the image is
+	// present when you check your custom image repository, then you probably
+	// need to increase this timeout from its default of "30m" (valid time units
+	// include `s` for seconds, `m` for minutes, and `h` for hours.)
+	CustomImageCaptureTimeout time.Duration `mapstructure:"custom_image_capture_timeout"`
 
 	// PublisherName for your base image. See
 	// [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
@@ -275,8 +285,9 @@ type Config struct {
 	LabSubnetName         string `mapstructure:"lab_subnet_name"`
 	LabResourceGroupName  string `mapstructure:"lab_resource_group_name"`
 
-	DtlArtifacts []DtlArtifact `mapstructure:"dtl_artifacts"`
-	VMName       string        `mapstructure:"vm_name"`
+	DtlArtifacts     []DtlArtifact `mapstructure:"dtl_artifacts"`
+	VMName           string        `mapstructure:"vm_name"`
+	DisallowPublicIP bool          `mapstructure:"disallow_public_ip" required:"false"`
 
 	// Runtime Values
 	UserName                string
@@ -539,6 +550,14 @@ func provideDefaultValues(c *Config) {
 
 	if c.ImagePublisher != "" && c.ImageVersion == "" {
 		c.ImageVersion = DefaultImageVersion
+	}
+
+	if c.SharedGalleryTimeout == 0 {
+		c.SharedGalleryTimeout = DefaultSharedGalleryTimeout
+	}
+
+	if c.CustomImageCaptureTimeout == 0 {
+		c.CustomImageCaptureTimeout = DefaultCustomImageCaptureTimeout
 	}
 }
 

--- a/builder/azure/dtl/config.hcl2spec.go
+++ b/builder/azure/dtl/config.hcl2spec.go
@@ -61,6 +61,7 @@ type FlatConfig struct {
 	SharedGallery                       *FlatSharedImageGallery            `mapstructure:"shared_image_gallery" cty:"shared_image_gallery" hcl:"shared_image_gallery"`
 	SharedGalleryDestination            *FlatSharedImageGalleryDestination `mapstructure:"shared_image_gallery_destination" cty:"shared_image_gallery_destination" hcl:"shared_image_gallery_destination"`
 	SharedGalleryTimeout                *string                            `mapstructure:"shared_image_gallery_timeout" cty:"shared_image_gallery_timeout" hcl:"shared_image_gallery_timeout"`
+	CustomImageCaptureTimeout           *string                            `mapstructure:"custom_image_capture_timeout" cty:"custom_image_capture_timeout" hcl:"custom_image_capture_timeout"`
 	ImagePublisher                      *string                            `mapstructure:"image_publisher" cty:"image_publisher" hcl:"image_publisher"`
 	ImageOffer                          *string                            `mapstructure:"image_offer" cty:"image_offer" hcl:"image_offer"`
 	ImageSku                            *string                            `mapstructure:"image_sku" cty:"image_sku" hcl:"image_sku"`
@@ -87,6 +88,7 @@ type FlatConfig struct {
 	LabResourceGroupName                *string                            `mapstructure:"lab_resource_group_name" cty:"lab_resource_group_name" hcl:"lab_resource_group_name"`
 	DtlArtifacts                        []FlatDtlArtifact                  `mapstructure:"dtl_artifacts" cty:"dtl_artifacts" hcl:"dtl_artifacts"`
 	VMName                              *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
+	DisallowPublicIP                    *bool                              `mapstructure:"disallow_public_ip" required:"false" cty:"disallow_public_ip" hcl:"disallow_public_ip"`
 	UserName                            *string                            `cty:"user_name" hcl:"user_name"`
 	Password                            *string                            `cty:"password" hcl:"password"`
 	VMCreationResourceGroup             *string                            `cty:"vm_creation_resource_group" hcl:"vm_creation_resource_group"`
@@ -177,6 +179,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"shared_image_gallery":                     &hcldec.BlockSpec{TypeName: "shared_image_gallery", Nested: hcldec.ObjectSpec((*FlatSharedImageGallery)(nil).HCL2Spec())},
 		"shared_image_gallery_destination":         &hcldec.BlockSpec{TypeName: "shared_image_gallery_destination", Nested: hcldec.ObjectSpec((*FlatSharedImageGalleryDestination)(nil).HCL2Spec())},
 		"shared_image_gallery_timeout":             &hcldec.AttrSpec{Name: "shared_image_gallery_timeout", Type: cty.String, Required: false},
+		"custom_image_capture_timeout":             &hcldec.AttrSpec{Name: "custom_image_capture_timeout", Type: cty.String, Required: false},
 		"image_publisher":                          &hcldec.AttrSpec{Name: "image_publisher", Type: cty.String, Required: false},
 		"image_offer":                              &hcldec.AttrSpec{Name: "image_offer", Type: cty.String, Required: false},
 		"image_sku":                                &hcldec.AttrSpec{Name: "image_sku", Type: cty.String, Required: false},
@@ -203,6 +206,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"lab_resource_group_name":                  &hcldec.AttrSpec{Name: "lab_resource_group_name", Type: cty.String, Required: false},
 		"dtl_artifacts":                            &hcldec.BlockListSpec{TypeName: "dtl_artifacts", Nested: hcldec.ObjectSpec((*FlatDtlArtifact)(nil).HCL2Spec())},
 		"vm_name":                                  &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
+		"disallow_public_ip":                       &hcldec.AttrSpec{Name: "disallow_public_ip", Type: cty.Bool, Required: false},
 		"user_name":                                &hcldec.AttrSpec{Name: "user_name", Type: cty.String, Required: false},
 		"password":                                 &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
 		"vm_creation_resource_group":               &hcldec.AttrSpec{Name: "vm_creation_resource_group", Type: cty.String, Required: false},

--- a/builder/azure/dtl/step_capture_image.go
+++ b/builder/azure/dtl/step_capture_image.go
@@ -77,6 +77,7 @@ func (s *StepCaptureImage) captureImageFromVM(ctx context.Context) error {
 
 	f, err := s.client.DtlCustomImageClient.CreateOrUpdate(ctx, s.config.LabResourceGroupName, s.config.LabName, s.config.ManagedImageName, *customImage)
 	if err == nil {
+		s.say("Waiting for Capture Image to complete")
 		err = f.WaitForCompletionRef(ctx, s.client.DtlCustomImageClient.Client)
 	}
 	if err != nil {

--- a/builder/azure/dtl/step_deploy_template.go
+++ b/builder/azure/dtl/step_deploy_template.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/services/devtestlabs/mgmt/2018-09-15/dtl"
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/constants"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -65,7 +66,6 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 	}
 
 	f, err := s.client.DtlLabsClient.CreateEnvironment(ctx, s.config.tmpResourceGroupName, s.config.LabName, *labMachine)
-
 	if err == nil {
 		err = f.WaitForCompletionRef(ctx, s.client.DtlLabsClient.Client)
 	}
@@ -73,19 +73,65 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 		s.say(s.client.LastError.Error())
 		return err
 	}
-	expand := "Properties($expand=ComputeVm,Artifacts,NetworkInterface)"
 
+	expand := "Properties($expand=ComputeVm,Artifacts,NetworkInterface)"
 	vm, err := s.client.DtlVirtualMachineClient.Get(ctx, s.config.tmpResourceGroupName, s.config.LabName, s.config.tmpComputeName, expand)
 	if err != nil {
 		s.say(s.client.LastError.Error())
 	}
+
+	// set tmpFQDN to the PrivateIP or to the real FQDN depending on
+	// publicIP being allowed or not
+	if s.config.DisallowPublicIP {
+		resp, err := s.client.InterfacesClient.Get(ctx, s.config.tmpResourceGroupName, s.config.tmpNicName, "")
+		if err != nil {
+			s.say(s.client.LastError.Error())
+			return err
+		}
+		s.config.tmpFQDN = *(*resp.IPConfigurations)[0].PrivateIPAddress
+	} else {
+		s.config.tmpFQDN = *vm.Fqdn
+	}
+	s.say(fmt.Sprintf(" -> VM FQDN/IP : '%s'", s.config.tmpFQDN))
+	state.Put(constants.SSHHost, s.config.tmpFQDN)
+
+	// In a windows VM, add the winrm artifact. Doing it after the machine has been
+	// created allows us to use its IP address as FQDN
+	if strings.ToLower(s.config.OSType) == "windows" {
+		// Add mandatory Artifact
+		var winrma = "windows-winrm"
+		var artifactid = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DevTestLab/labs/%s/artifactSources/public repo/artifacts/%s",
+			s.config.ClientConfig.SubscriptionID,
+			s.config.tmpResourceGroupName,
+			s.config.LabName,
+			winrma)
+
+		var hostname = "hostName"
+		dp := &dtl.ArtifactParameterProperties{}
+		dp.Name = &hostname
+		dp.Value = &s.config.tmpFQDN
+		dparams := []dtl.ArtifactParameterProperties{*dp}
+
+		winrmArtifact := &dtl.ArtifactInstallProperties{
+			ArtifactTitle: &winrma,
+			ArtifactID:    &artifactid,
+			Parameters:    &dparams,
+		}
+
+		dtlArtifacts := []dtl.ArtifactInstallProperties{*winrmArtifact}
+		dtlArtifactsRequest := dtl.ApplyArtifactsRequest{Artifacts: &dtlArtifacts}
+		f, err := s.client.DtlVirtualMachineClient.ApplyArtifacts(ctx, s.config.tmpResourceGroupName, s.config.LabName, s.config.tmpComputeName, dtlArtifactsRequest)
+		if err == nil {
+			err = f.WaitForCompletionRef(ctx, s.client.DtlVirtualMachineClient.Client)
+		}
+		if err != nil {
+			s.say(s.client.LastError.Error())
+			return err
+		}
+	}
+
 	xs := strings.Split(*vm.LabVirtualMachineProperties.ComputeID, "/")
 	s.config.VMCreationResourceGroup = xs[4]
-
-	s.say(fmt.Sprintf(" -> VM FQDN : '%s'", *vm.Fqdn))
-
-	state.Put(constants.SSHHost, *vm.Fqdn)
-	s.config.tmpFQDN = *vm.Fqdn
 
 	// Resuing the Resource group name from common constants as all steps depend on it.
 	state.Put(constants.ArmResourceGroupName, s.config.VMCreationResourceGroup)

--- a/builder/azure/dtl/template_factory.go
+++ b/builder/azure/dtl/template_factory.go
@@ -2,7 +2,6 @@ package dtl
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/devtestlabs/mgmt/2018-09-15/dtl"
 )
@@ -78,31 +77,6 @@ func GetVirtualMachineDeployment(config *Config) (*dtl.LabVirtualMachineCreation
 		}
 	}
 
-	if strings.ToLower(config.OSType) == "windows" {
-		// Add mandatory Artifact
-		var winrma = "windows-winrm"
-		var artifactid = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DevTestLab/labs/%s/artifactSources/public repo/artifacts/%s",
-			config.ClientConfig.SubscriptionID,
-			config.tmpResourceGroupName,
-			config.LabName,
-			winrma)
-
-		var hostname = "hostName"
-		//var hostNameValue = fmt.Sprintf("%s.%s.cloudapp.azure.com", config.VMName, config.Location)
-		dparams := []dtl.ArtifactParameterProperties{}
-		dp := &dtl.ArtifactParameterProperties{}
-		dp.Name = &hostname
-		dp.Value = &config.tmpFQDN
-		dparams = append(dparams, *dp)
-
-		winrmArtifact := &dtl.ArtifactInstallProperties{
-			ArtifactTitle: &winrma,
-			ArtifactID:    &artifactid,
-			Parameters:    &dparams,
-		}
-		dtlArtifacts = append(dtlArtifacts, *winrmArtifact)
-	}
-
 	labMachineProps := &dtl.LabVirtualMachineCreationParameterProperties{
 		CreatedByUserID:            &config.ClientConfig.ClientID,
 		OwnerObjectID:              &config.ClientConfig.ObjectID,
@@ -114,7 +88,7 @@ func GetVirtualMachineDeployment(config *Config) (*dtl.LabVirtualMachineCreation
 		IsAuthenticationWithSSHKey: newBool(true),
 		LabSubnetName:              &config.LabSubnetName,
 		LabVirtualNetworkID:        &labVirtualNetworkID,
-		DisallowPublicIPAddress:    newBool(false),
+		DisallowPublicIPAddress:    &config.DisallowPublicIP,
 		GalleryImageReference:      &galleryImageRef,
 		CustomImageID:              getCustomImageId(config),
 		PlanID:                     &config.PlanID,

--- a/builder/azure/pkcs12/crypto.go
+++ b/builder/azure/pkcs12/crypto.go
@@ -124,7 +124,7 @@ func pbDecrypt(info decryptable, password []byte) (decrypted []byte, err error) 
 	}
 	ps := decrypted[len(decrypted)-psLen:]
 	decrypted = decrypted[:len(decrypted)-psLen]
-	if bytes.Compare(ps, bytes.Repeat([]byte{byte(psLen)}, psLen)) != 0 {
+	if !bytes.Equal(ps, bytes.Repeat([]byte{byte(psLen)}, psLen)) {
 		return nil, ErrDecryption
 	}
 

--- a/builder/azure/pkcs12/crypto_test.go
+++ b/builder/azure/pkcs12/crypto_test.go
@@ -48,7 +48,7 @@ func TestPbDecrypterFor(t *testing.T) {
 	ciphertext := make([]byte, len(plaintext))
 	cbc.CryptBlocks(ciphertext, plaintext)
 
-	if bytes.Compare(ciphertext, expectedCiphertext) != 0 {
+	if !bytes.Equal(ciphertext, expectedCiphertext) {
 		t.Errorf("bad ciphertext, got %x but wanted %x", ciphertext, expectedCiphertext)
 	}
 }

--- a/builder/azure/pkcs12/mac.go
+++ b/builder/azure/pkcs12/mac.go
@@ -44,7 +44,7 @@ func computeMac(message []byte, iterations int, salt, password []byte) []byte {
 	key := pbkdf(sha1Sum, 20, 64, salt, password, iterations, 3, 20)
 
 	mac := hmac.New(sha1.New, key)
-	_, _= mac.Write(message)
+	_, _ = mac.Write(message)
 
 	return mac.Sum(nil)
 }

--- a/builder/azure/pkcs12/mac.go
+++ b/builder/azure/pkcs12/mac.go
@@ -44,7 +44,7 @@ func computeMac(message []byte, iterations int, salt, password []byte) []byte {
 	key := pbkdf(sha1Sum, 20, 64, salt, password, iterations, 3, 20)
 
 	mac := hmac.New(sha1.New, key)
-	mac.Write(message)
+	_, _= mac.Write(message)
 
 	return mac.Sum(nil)
 }

--- a/builder/azure/pkcs12/pbkdf_test.go
+++ b/builder/azure/pkcs12/pbkdf_test.go
@@ -16,7 +16,7 @@ func TestThatPBKDFWorksCorrectlyForLongKeys(t *testing.T) {
 	password, _ := bmpString("sesame")
 	key := cipherInfo.deriveKey(salt, password, 2048)
 
-	if expected := []byte("\x7c\xd9\xfd\x3e\x2b\x3b\xe7\x69\x1a\x44\xe3\xbe\xf0\xf9\xea\x0f\xb9\xb8\x97\xd4\xe3\x25\xd9\xd1"); bytes.Compare(key, expected) != 0 {
+	if expected := []byte("\x7c\xd9\xfd\x3e\x2b\x3b\xe7\x69\x1a\x44\xe3\xbe\xf0\xf9\xea\x0f\xb9\xb8\x97\xd4\xe3\x25\xd9\xd1"); !bytes.Equal(key, expected) {
 		t.Fatalf("expected key '%x', but found '%x'", expected, key)
 	}
 }
@@ -28,7 +28,7 @@ func TestThatPBKDFHandlesLeadingZeros(t *testing.T) {
 	// derivation and produce the wrong output.
 	key := pbkdf(sha1Sum, 20, 64, []byte("\xf3\x7e\x05\xb5\x18\x32\x4b\x4b"), []byte("\x00\x00"), 2048, 1, 24)
 	expected := []byte("\x00\xf7\x59\xff\x47\xd1\x4d\xd0\x36\x65\xd5\x94\x3c\xb3\xc4\xa3\x9a\x25\x55\xc0\x2a\xed\x66\xe1")
-	if bytes.Compare(key, expected) != 0 {
+	if !bytes.Equal(key, expected) {
 		t.Fatalf("expected key '%x', but found '%x'", expected, key)
 	}
 }

--- a/builder/azure/pkcs12/pkcs12.go
+++ b/builder/azure/pkcs12/pkcs12.go
@@ -112,6 +112,9 @@ func ToPEM(pfxData []byte, password string) ([]*pem.Block, error) {
 	}
 
 	bags, encodedPassword, err := getSafeContents(pfxData, encodedPassword)
+	if err != nil {
+		return nil, err
+	}
 
 	blocks := make([]*pem.Block, 0, len(bags))
 	for _, bag := range bags {
@@ -288,6 +291,10 @@ func convertToRawVal(val interface{}) (raw asn1.RawValue, err error) {
 	}
 
 	_, err = asn1.Unmarshal(bytes, &raw)
+	if err != nil {
+		return
+	}
+
 	return raw, nil
 }
 

--- a/docs-partials/builder/azure/dtl/Config-not-required.mdx
+++ b/docs-partials/builder/azure/dtl/Config-not-required.mdx
@@ -45,6 +45,13 @@
   its default of "60m" (valid time units include `s` for seconds, `m` for
   minutes, and `h` for hours.)
 
+- `custom_image_capture_timeout` (duration string | ex: "1h5m2s") - How long to wait for an image to be captured before timing out
+  If your Packer build is failing on the Capture Image step with the
+  error `Original Error: context deadline exceeded`, but the image is
+  present when you check your custom image repository, then you probably
+  need to increase this timeout from its default of "30m" (valid time
+  units include `s` for seconds, `m` for minutes, and `h` for hours.)
+
 - `image_publisher` (string) - PublisherName for your base image. See
   [documentation](https://docs.microsoft.com/en-us/cli/azure/vm/image)
   for details.

--- a/provisioner/azure-dtlartifact/provisioner.go
+++ b/provisioner/azure-dtlartifact/provisioner.go
@@ -98,6 +98,8 @@ func (p *Provisioner) Communicator() packersdk.Communicator {
 
 func (p *Provisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packersdk.Communicator, _ map[string]interface{}) error {
 
+	ui.Say("Running provisioner ...")
+
 	p.communicator = comm
 
 	err := p.config.ClientConfig.SetDefaultValues()
@@ -123,11 +125,12 @@ func (p *Provisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packe
 		return err
 	}
 
-	ui.Message("Creating Azure Resource Manager (ARM) client ...")
+	ui.Message("Creating Azure DevTestLab (DTL) client ...")
 	azureClient, err := dtlBuilder.NewAzureClient(
 		p.config.ClientConfig.SubscriptionID,
 		"",
 		p.config.ClientConfig.CloudEnvironment(),
+		p.config.PollingDurationTimeout,
 		p.config.PollingDurationTimeout,
 		p.config.PollingDurationTimeout,
 		spnCloud)


### PR DESCRIPTION
In Azure DTL builder, currently only VMs with public IP were taken into account. This PR adds support for private IP VMs also (through the addition of a config parameter), by setting the SSHHost to be the IP address in case a private IP is request or the tmpFQDN otherwise. Also, this PR introduces a specific timeout for the image capture step.