### PR TITLE
Add user_data_file to arm builder

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -359,6 +359,15 @@ type Config struct {
 	// provisioning process.
 	CustomDataFile string `mapstructure:"custom_data_file" required:"false"`
 	customData     string
+	// Specify a file containing user data to inject into the cloud-init
+	// process. The contents of the file are read and injected into the ARM
+	// template. The user data will be available from the provision until the vm is
+	// deleted. Any application on the virtual machine can access the user data
+	// from the Azure Instance Metadata Service (IMDS) after provision.
+	// See [documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/user-data)
+	// to learn more about user data.
+	UserDataFile string `mapstructure:"user_data_file" required:"false"`
+	userData     string
 	// Used for creating images from Marketplace images. Please refer to
 	// [Deploy an image with Marketplace
 	// terms](https://aka.ms/azuremarketplaceapideployment) for more details.
@@ -625,6 +634,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		return nil, err
 	}
 
+	err = setUserData(c)
+	if err != nil {
+		return nil, err
+	}
+
 	// NOTE: if the user did not specify a communicator, then default to both
 	// SSH and WinRM.  This is for backwards compatibility because the code did
 	// not specifically force the user to set a communicator.
@@ -794,6 +808,20 @@ func setCustomData(c *Config) error {
 	}
 
 	c.customData = base64.StdEncoding.EncodeToString(b)
+	return nil
+}
+
+func setUserData(c *Config) error {
+	if c.UserDataFile == "" {
+		return nil
+	}
+
+	b, err := ioutil.ReadFile(c.UserDataFile)
+	if err != nil {
+		return err
+	}
+
+	c.userData = base64.StdEncoding.EncodeToString(b)
 	return nil
 }
 

--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -70,6 +70,7 @@ type FlatConfig struct {
 	VirtualNetworkSubnetName                   *string                            `mapstructure:"virtual_network_subnet_name" required:"false" cty:"virtual_network_subnet_name" hcl:"virtual_network_subnet_name"`
 	VirtualNetworkResourceGroupName            *string                            `mapstructure:"virtual_network_resource_group_name" required:"false" cty:"virtual_network_resource_group_name" hcl:"virtual_network_resource_group_name"`
 	CustomDataFile                             *string                            `mapstructure:"custom_data_file" required:"false" cty:"custom_data_file" hcl:"custom_data_file"`
+	UserDataFile                               *string                            `mapstructure:"user_data_file" required:"false" cty:"user_data_file" hcl:"user_data_file"`
 	PlanInfo                                   *FlatPlanInformation               `mapstructure:"plan_info" required:"false" cty:"plan_info" hcl:"plan_info"`
 	PollingDurationTimeout                     *string                            `mapstructure:"polling_duration_timeout" required:"false" cty:"polling_duration_timeout" hcl:"polling_duration_timeout"`
 	OSType                                     *string                            `mapstructure:"os_type" required:"false" cty:"os_type" hcl:"os_type"`
@@ -203,6 +204,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"virtual_network_subnet_name":                      &hcldec.AttrSpec{Name: "virtual_network_subnet_name", Type: cty.String, Required: false},
 		"virtual_network_resource_group_name":              &hcldec.AttrSpec{Name: "virtual_network_resource_group_name", Type: cty.String, Required: false},
 		"custom_data_file":                                 &hcldec.AttrSpec{Name: "custom_data_file", Type: cty.String, Required: false},
+		"user_data_file":                                   &hcldec.AttrSpec{Name: "user_data_file", Type: cty.String, Required: false},
 		"plan_info":                                        &hcldec.BlockSpec{TypeName: "plan_info", Nested: hcldec.ObjectSpec((*FlatPlanInformation)(nil).HCL2Spec())},
 		"polling_duration_timeout":                         &hcldec.AttrSpec{Name: "polling_duration_timeout", Type: cty.String, Required: false},
 		"os_type":                                          &hcldec.AttrSpec{Name: "os_type", Type: cty.String, Required: false},

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -137,6 +137,13 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 		}
 	}
 
+	if config.userData != "" {
+		err = builder.SetUserData(config.userData)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	if config.PlanInfo.PlanName != "" {
 		err = builder.SetPlanInfo(config.PlanInfo.PlanName, config.PlanInfo.PlanProduct, config.PlanInfo.PlanPublisher, config.PlanInfo.PlanPromotionCode)
 		if err != nil {

--- a/builder/azure/common/template/template.go
+++ b/builder/azure/common/template/template.go
@@ -92,6 +92,7 @@ type Properties struct {
 	OsProfile                    *compute.OSProfile                  `json:"osProfile,omitempty"`
 	PublicIPAllocatedMethod      *network.IPAllocationMethod         `json:"publicIPAllocationMethod,omitempty"`
 	Sku                          *Sku                                `json:"sku,omitempty"`
+	UserData                     *string                             `json:"userData,omitempty"`
 	//StorageProfile3              *compute.StorageProfile             `json:"storageProfile,omitempty"`
 	StorageProfile *StorageProfileUnion    `json:"storageProfile,omitempty"`
 	Subnets        *[]network.Subnet       `json:"subnets,omitempty"`

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -301,6 +301,18 @@ func (s *TemplateBuilder) SetCustomData(customData string) error {
 	return nil
 }
 
+func (s *TemplateBuilder) SetUserData(userData string) error {
+	s.setVariable("apiVersion", "2021-03-01") // Userdata value only added in this schema
+	resource, err := s.getResourceByType(resourceVirtualMachine)
+	if err != nil {
+		return err
+	}
+
+	resource.Properties.UserData = to.StringPtr(userData)
+
+	return nil
+}
+
 func (s *TemplateBuilder) SetVirtualNetwork(virtualNetworkResourceGroup, virtualNetworkName, subnetName string) error {
 	s.setVariable("virtualNetworkResourceGroup", virtualNetworkResourceGroup)
 	s.setVariable("virtualNetworkName", virtualNetworkName)

--- a/docs-partials/builder/azure/arm/Config-not-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-not-required.mdx
@@ -208,6 +208,14 @@
   to learn more about custom data, and how it can be used to influence the
   provisioning process.
 
+- `user_data_file` (string) - Specify a file containing user data to inject into the cloud-init
+  process. The contents of the file are read and injected into the ARM
+  template. The user data will be available from the provision until the vm is
+  deleted. Any application on the virtual machine can access the user data
+  from the Azure Instance Metadata Service (IMDS) after provision.
+  See [documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/user-data)
+  to learn more about user data.
+
 - `plan_info` (PlanInformation) - Used for creating images from Marketplace images. Please refer to
   [Deploy an image with Marketplace
   terms](https://aka.ms/azuremarketplaceapideployment) for more details.


### PR DESCRIPTION
There is the possibilityof using user_data when launching a vm, which
provides user data during the whole lifecycle, its easily accessible by
all apps (so no cloud-init or waagent required) and can even be modified
(not applicable here but its nice)

This PR adds an user_data_file that mimicks the custom_data_file option
and basically does the same. This causes the API version of the schema
to be 2021-03-01 if there is user data provided.

https://docs.microsoft.com/en-us/azure/virtual-machines/user-data

Closes #121 

Signed-off-by: Itxaka <igarcia@suse.com>

