### PR TITLE
fix: allow Premium_LRS as SIG storage account type

### DIFF
--- a/builder/azure/arm/azure_client.go
+++ b/builder/azure/arm/azure_client.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-04-01/compute"
-	newCompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-03-01/compute"
+	newCompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-03-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2018-02-14/keyvault"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-01-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-02-01/resources"

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -96,7 +96,7 @@ type SharedImageGalleryDestination struct {
 	SigDestinationImageVersion       string   `mapstructure:"image_version"`
 	SigDestinationReplicationRegions []string `mapstructure:"replication_regions"`
 	// Specify a storage account type for the Shared Image Gallery Image Version.
-	// Defaults to `Standard_LRS`. Accepted values are `Standard_LRS` and `Standard_ZRS`
+	// Defaults to `Standard_LRS`. Accepted values are `Standard_LRS`, `Standard_ZRS` and `Premium_LRS`
 	SigDestinationStorageAccountType string `mapstructure:"storage_account_type"`
 }
 

--- a/docs-partials/builder/azure/arm/SharedImageGalleryDestination-not-required.mdx
+++ b/docs-partials/builder/azure/arm/SharedImageGalleryDestination-not-required.mdx
@@ -13,6 +13,6 @@
 - `replication_regions` ([]string) - Sig Destination Replication Regions
 
 - `storage_account_type` (string) - Specify a storage account type for the Shared Image Gallery Image Version.
-  Defaults to `Standard_LRS`. Accepted values are `Standard_LRS` and `Standard_ZRS`
+  Defaults to `Standard_LRS`. Accepted values are `Standard_LRS`, `Standard_ZRS` and `Premium_LRS`
 
 <!-- End of code generated from the comments of the SharedImageGalleryDestination struct in builder/azure/arm/config.go; -->

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/packer-plugin-azure
 go 1.16
 
 require (
-	github.com/Azure/azure-sdk-for-go v53.0.0+incompatible
+	github.com/Azure/azure-sdk-for-go v55.7.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.19
 	github.com/Azure/go-autorest/autorest/adal v0.9.14
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -34,10 +34,11 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0 h1:STgFzyU5/8miMl0//zKh2aQeTyeaUH3WN9bSUiJ09bA=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/Azure/azure-sdk-for-go v51.2.0+incompatible h1:qQNk//OOHK0GZcgMMgdJ4tZuuh0zcOeUkpTxjvKFpSQ=
 github.com/Azure/azure-sdk-for-go v51.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v53.0.0+incompatible h1:DHeVnEdW3l7C/vXSdig9IJzoEpxgukIpYDfKBq6zNSI=
 github.com/Azure/azure-sdk-for-go v53.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v55.7.0+incompatible h1:BhYuQTWEb5qRIHp9+UKQdeJqcgq5pyOwHGFraV/QBlQ=
+github.com/Azure/azure-sdk-for-go v55.7.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=


### PR DESCRIPTION
since version 2019-12-01 `Premium_LRS` is an allowed storage account
type for shared image gallery destination.

See
https://docs.microsoft.com/en-us/azure/templates/microsoft.compute/2019-12-01/galleries/images/versions?tabs=json#galleryimageversionpublishingprofile-object
for reference.

