### PR TITLE
Removed line as it overwrites custom nicname

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -726,7 +726,6 @@ func setRuntimeValues(c *Config) {
 	} else {
 		c.tmpNicName = c.TempNicName
 	}
-	c.tmpNicName = tempName.NicName
 	c.tmpPublicIPAddressName = tempName.PublicIPAddressName
 	if c.TempOSDiskName == "" {
 		c.tmpOSDiskName = tempName.OSDiskName


### PR DESCRIPTION
When I added the functionality of adding custom nicname and osdiskname I apparently forgot to remove a line.
This line overwrites the custom nicname with the temp.nicname.

I've removed the line so it should work with the next release, as the custom osdiskname works with no error.

