### PR TITLE
fix: support multiple user managed identities

### DIFF
--- a/builder/azure/common/client/config.go
+++ b/builder/azure/common/client/config.go
@@ -250,7 +250,6 @@ func (c Config) UseCLI() bool {
 
 func (c Config) UseMSI() bool {
 	return c.SubscriptionID == "" &&
-		c.ClientID == "" &&
 		c.ClientSecret == "" &&
 		c.ClientJWT == "" &&
 		c.ClientCertPath == "" &&
@@ -290,7 +289,7 @@ func (c Config) GetServicePrincipalToken(
 		auth = NewCliOAuthTokenProvider(*c.cloudEnvironment, say, c.TenantID)
 	case authTypeMSI:
 		say("Getting tokens using Managed Identity for Azure")
-		auth = NewMSIOAuthTokenProvider(*c.cloudEnvironment)
+		auth = NewMSIOAuthTokenProvider(*c.cloudEnvironment, c.ClientID)
 	case authTypeClientSecret:
 		say("Getting tokens using client secret")
 		auth = NewSecretOAuthTokenProvider(*c.cloudEnvironment, c.ClientID, c.ClientSecret, c.TenantID)

--- a/builder/azure/common/client/config_test.go
+++ b/builder/azure/common/client/config_test.go
@@ -30,6 +30,13 @@ func Test_ClientConfig_RequiredParametersSet(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "client_id, with no client_secret or subscription_id should enable MSI auth",
+			config: Config{
+				ClientID: "fake-id",
+			},
+			wantErr: false,
+		},
+		{
 			name: "use_azure_cli_auth will trigger Azure CLI auth",
 			config: Config{
 				UseAzureCLIAuth: true,

--- a/builder/azure/common/client/config_test.go
+++ b/builder/azure/common/client/config_test.go
@@ -44,11 +44,11 @@ func Test_ClientConfig_RequiredParametersSet(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "client_id without client_secret, client_cert_path or client_jwt should error",
+			name: "client_id without client_secret, client_cert_path or client_jwt should not error",
 			config: Config{
 				ClientID: "error",
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "client_secret without client_id should error",

--- a/builder/azure/common/client/tokenprovider_msi.go
+++ b/builder/azure/common/client/tokenprovider_msi.go
@@ -7,11 +7,12 @@ import (
 
 // for managed identity auth
 type msiOAuthTokenProvider struct {
-	env azure.Environment
+	env      azure.Environment
+	ClientID string
 }
 
-func NewMSIOAuthTokenProvider(env azure.Environment) oAuthTokenProvider {
-	return &msiOAuthTokenProvider{env}
+func NewMSIOAuthTokenProvider(env azure.Environment, ClientID string) oAuthTokenProvider {
+	return &msiOAuthTokenProvider{env, ClientID}
 }
 
 func (tp *msiOAuthTokenProvider) getServicePrincipalToken() (*adal.ServicePrincipalToken, error) {
@@ -19,5 +20,7 @@ func (tp *msiOAuthTokenProvider) getServicePrincipalToken() (*adal.ServicePrinci
 }
 
 func (tp *msiOAuthTokenProvider) getServicePrincipalTokenWithResource(resource string) (*adal.ServicePrincipalToken, error) {
-	return adal.NewServicePrincipalTokenFromMSI("http://169.254.169.254/metadata/identity/oauth2/token", resource)
+	return adal.NewServicePrincipalTokenFromManagedIdentity(resource, &adal.ManagedIdentityOptions{
+		ClientID: tp.ClientID,
+	})
 }

--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -75,7 +75,28 @@ properties to be set. It does, however, require that you run Packer on an
 Azure VM.
 
 To enable this method, [let Azure assign a system-assigned identity to your VM](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/qs-configure-portal-windows-vm).
-Then, [grant your VM access to the appropriate resources](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/howto-assign-access-portal).
+Then, [grant your VM access to the appropriate resources](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/howto-assign-access-portal). If the Azure VM has more than one managed identity assigned to it (e.g both system-assigned and user-assigned identities) the `client_id` configuration argument can be specified to select the appropriate managed identity to be used.
+
+```hcl
+source "azure-arm" "basic-example" {
+  client_id = "fe354398-d7sf-4dc9-87fd-c432cd8a7e09"
+  resource_group_name = "packerdemo"
+  storage_account = "virtualmachines"
+
+  capture_container_name = "images"
+  capture_name_prefix = "packer"
+
+  os_type = "Linux"
+  image_publisher = "Canonical"
+  image_offer = "UbuntuServer"
+  image_sku = "14.04.4-LTS"
+
+  location = "West US"
+  vm_size = "Standard_A2"
+}
+
+```
+
 To get started, try assigning the `Contributor` role at the subscription level to
 your VM. Then, when you discover your exact scenario, scope the permissions
 appropriately or isolate Packer builds in a separate subscription.


### PR DESCRIPTION
Hey guys,

This PR solves the issue of login to Azure when running on a VM with multiple User Assigned MSI IDs.
I've upgraded the `tokenprovider_msi.go` to use the most recent Azure Active Directory Login `NewServicePrincipalTokenFromManagedIdentity` method instead of the deprecated `NewServicePrincipalTokenFromMSI`.

Now, when this case happens, the user needs to specify the `client_id` parameter.

Co-authored-by: @eduardolmedeiros
Closes #64 #144