### PR TITLE
Change adminPassword type from string to securestring in VM deployment

### DIFF
--- a/builder/azure/arm/template_factory_test.TestPlanInfo01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestPlanInfo01.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestPlanInfo02.approved.json
+++ b/builder/azure/arm/template_factory_test.TestPlanInfo02.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment03.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment03.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment04.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment04.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment05.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment05.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment06.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment06.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment07.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment07.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment08.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment08.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment09.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment09.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment10.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment10.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment12.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment12.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment13.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment13.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment14.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment14.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -611,7 +611,7 @@ const BasicTemplate = `{
       "type": "string"
     },
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "dnsNameForPublicIP": {
       "type": "string"

--- a/builder/azure/common/template/template_builder_test.TestBuildLinux00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildLinux00.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/common/template/template_builder_test.TestBuildLinux01.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildLinux01.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/common/template/template_builder_test.TestBuildLinux02.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildLinux02.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/common/template/template_builder_test.TestBuildWindows00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildWindows00.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/common/template/template_builder_test.TestBuildWindows01.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildWindows01.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/common/template/template_builder_test.TestBuildWindows02.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestBuildWindows02.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/common/template/template_builder_test.TestNetworkSecurityGroup00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestNetworkSecurityGroup00.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/common/template/template_builder_test.TestSetIdentity00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestSetIdentity00.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"

--- a/builder/azure/common/template/template_builder_test.TestSharedImageGallery00.approved.json
+++ b/builder/azure/common/template/template_builder_test.TestSharedImageGallery00.approved.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminPassword": {
-      "type": "string"
+      "type": "securestring"
     },
     "adminUsername": {
       "type": "string"


### PR DESCRIPTION
This PR changes the `adminPassword` type from `string` to `securestring` in VM deployment for enhanced security.
