### PR TITLE
Update VaultClientDelete to pass correct Azure cloud environment endpoint

### DIFF
--- a/builder/azure/arm/azure_client.go
+++ b/builder/azure/arm/azure_client.go
@@ -261,7 +261,7 @@ func NewAzureClient(subscriptionID, sigSubscriptionID, resourceGroupName, storag
 
 	// This client is different than the above because it manages the vault
 	// itself rather than the contents of the vault.
-	azureClient.VaultClientDelete = keyvault.NewVaultsClient(subscriptionID)
+	azureClient.VaultClientDelete = keyvault.NewVaultsClientWithBaseURI(cloud.ResourceManagerEndpoint, subscriptionID)
 	azureClient.VaultClientDelete.Authorizer = autorest.NewBearerAuthorizer(servicePrincipalToken)
 	azureClient.VaultClientDelete.RequestInspector = withInspection(maxlen)
 	azureClient.VaultClientDelete.ResponseInspector = byConcatDecorators(byInspecting(maxlen), errorCapture(azureClient))


### PR DESCRIPTION
Closes #90 

Updated the `VaultClientDelete` object from the default [`NewVaultsClient`](https://github.com/Azure/azure-sdk-for-go/blob/607fc6eea18d2990abc7b8d3ffdb151be003aeb8/services/keyvault/mgmt/2018-02-14/keyvault/vaults.go#L25) method which uses the [default commercial cloud URI](https://github.com/Azure/azure-sdk-for-go/blob/607fc6eea18d2990abc7b8d3ffdb151be003aeb8/services/keyvault/mgmt/2018-02-14/keyvault/client.go#L18) to [`NewVaultsClientWithBaseURI`](https://github.com/Azure/azure-sdk-for-go/blob/607fc6eea18d2990abc7b8d3ffdb151be003aeb8/services/keyvault/mgmt/2018-02-14/keyvault/vaults.go#L31) which also accepts the base URI passed by `cloud.ResourceManagerEndpoint`.

Testing in my own Azure Gov cloud worked for me. Reduced and redacted logs are posted here: https://gist.github.com/mikeybot/765e657d408e48389668439e1f450d30 

I've also tested this on an Azure Commercial subscription and it works as expected.

In both instances, I've recieved the [error](https://gist.github.com/mikeybot/765e657d408e48389668439e1f450d30#file-gistfile1-txt-L23) on line 23 regarding `Failed to find temporary OS disk on VM`. I believe that's unrelated to this change, but would be happy to get confirmation from someone else.
