### PR TITLE
Enable specifying client_id and/or subscription_id when using managed identity auth

### DIFF
--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -30,6 +30,7 @@ type FlatConfig struct {
 	TenantID                                   *string                            `mapstructure:"tenant_id" required:"false" cty:"tenant_id" hcl:"tenant_id"`
 	SubscriptionID                             *string                            `mapstructure:"subscription_id" cty:"subscription_id" hcl:"subscription_id"`
 	UseAzureCLIAuth                            *bool                              `mapstructure:"use_azure_cli_auth" required:"false" cty:"use_azure_cli_auth" hcl:"use_azure_cli_auth"`
+	UseInteractiveAuth                         *bool                              `mapstructure:"use_interactive_auth" required:"false" cty:"use_interactive_auth" hcl:"use_interactive_auth"`
 	UserAssignedManagedIdentities              []string                           `mapstructure:"user_assigned_managed_identities" required:"false" cty:"user_assigned_managed_identities" hcl:"user_assigned_managed_identities"`
 	CaptureNamePrefix                          *string                            `mapstructure:"capture_name_prefix" cty:"capture_name_prefix" hcl:"capture_name_prefix"`
 	CaptureContainerName                       *string                            `mapstructure:"capture_container_name" cty:"capture_container_name" hcl:"capture_container_name"`
@@ -164,6 +165,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"tenant_id":                                        &hcldec.AttrSpec{Name: "tenant_id", Type: cty.String, Required: false},
 		"subscription_id":                                  &hcldec.AttrSpec{Name: "subscription_id", Type: cty.String, Required: false},
 		"use_azure_cli_auth":                               &hcldec.AttrSpec{Name: "use_azure_cli_auth", Type: cty.Bool, Required: false},
+		"use_interactive_auth":                             &hcldec.AttrSpec{Name: "use_interactive_auth", Type: cty.Bool, Required: false},
 		"user_assigned_managed_identities":                 &hcldec.AttrSpec{Name: "user_assigned_managed_identities", Type: cty.List(cty.String), Required: false},
 		"capture_name_prefix":                              &hcldec.AttrSpec{Name: "capture_name_prefix", Type: cty.String, Required: false},
 		"capture_container_name":                           &hcldec.AttrSpec{Name: "capture_container_name", Type: cty.String, Required: false},

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -15,8 +15,6 @@ import (
 var requiredConfigValues = []string{
 	"capture_name_prefix",
 	"capture_container_name",
-	"client_id",
-	"client_secret",
 	"image_offer",
 	"image_publisher",
 	"image_sku",
@@ -24,7 +22,6 @@ var requiredConfigValues = []string{
 	"os_type",
 	"storage_account",
 	"resource_group_name",
-	"subscription_id",
 }
 
 func TestConfigShouldProvideReasonableDefaultValues(t *testing.T) {

--- a/builder/azure/chroot/builder.hcl2spec.go
+++ b/builder/azure/chroot/builder.hcl2spec.go
@@ -29,6 +29,7 @@ type FlatConfig struct {
 	TenantID                          *string                            `mapstructure:"tenant_id" required:"false" cty:"tenant_id" hcl:"tenant_id"`
 	SubscriptionID                    *string                            `mapstructure:"subscription_id" cty:"subscription_id" hcl:"subscription_id"`
 	UseAzureCLIAuth                   *bool                              `mapstructure:"use_azure_cli_auth" required:"false" cty:"use_azure_cli_auth" hcl:"use_azure_cli_auth"`
+	UseInteractiveAuth                *bool                              `mapstructure:"use_interactive_auth" required:"false" cty:"use_interactive_auth" hcl:"use_interactive_auth"`
 	FromScratch                       *bool                              `mapstructure:"from_scratch" cty:"from_scratch" hcl:"from_scratch"`
 	Source                            *string                            `mapstructure:"source" required:"true" cty:"source" hcl:"source"`
 	CommandWrapper                    *string                            `mapstructure:"command_wrapper" cty:"command_wrapper" hcl:"command_wrapper"`
@@ -85,6 +86,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"tenant_id":                       &hcldec.AttrSpec{Name: "tenant_id", Type: cty.String, Required: false},
 		"subscription_id":                 &hcldec.AttrSpec{Name: "subscription_id", Type: cty.String, Required: false},
 		"use_azure_cli_auth":              &hcldec.AttrSpec{Name: "use_azure_cli_auth", Type: cty.Bool, Required: false},
+		"use_interactive_auth":            &hcldec.AttrSpec{Name: "use_interactive_auth", Type: cty.Bool, Required: false},
 		"from_scratch":                    &hcldec.AttrSpec{Name: "from_scratch", Type: cty.Bool, Required: false},
 		"source":                          &hcldec.AttrSpec{Name: "source", Type: cty.String, Required: false},
 		"command_wrapper":                 &hcldec.AttrSpec{Name: "command_wrapper", Type: cty.String, Required: false},

--- a/builder/azure/common/client/config_test.go
+++ b/builder/azure/common/client/config_test.go
@@ -44,16 +44,16 @@ func Test_ClientConfig_RequiredParametersSet(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "subscription_id is set will trigger device flow",
+			name: "use_interactive_auth will trigger device code flow",
 			config: Config{
-				SubscriptionID: "error",
+				UseInteractiveAuth: true,
 			},
 			wantErr: false,
 		},
 		{
 			name: "client_id without client_secret, client_cert_path or client_jwt should not error",
 			config: Config{
-				ClientID: "error",
+				SubscriptionID: "error",
 			},
 			wantErr: false,
 		},
@@ -315,14 +315,16 @@ func Test_ClientConfig_CanUseDeviceCode(t *testing.T) {
 	// TenantID is optional, but Builder will look up tenant ID before requesting
 	t.Run("without TenantID", func(t *testing.T) {
 		cfg := Config{
-			SubscriptionID: "12345",
+			UseInteractiveAuth: true,
+			SubscriptionID:     "12345",
 		}
 		assertValid(t, cfg)
 	})
 	t.Run("with TenantID", func(t *testing.T) {
 		cfg := Config{
-			SubscriptionID: "12345",
-			TenantID:       "12345",
+			UseInteractiveAuth: true,
+			SubscriptionID:     "12345",
+			TenantID:           "12345",
 		}
 		assertValid(t, cfg)
 	})

--- a/builder/azure/common/client/tokenprovider_msi.go
+++ b/builder/azure/common/client/tokenprovider_msi.go
@@ -8,11 +8,11 @@ import (
 // for managed identity auth
 type msiOAuthTokenProvider struct {
 	env      azure.Environment
-	ClientID string
+	clientID string
 }
 
-func NewMSIOAuthTokenProvider(env azure.Environment, ClientID string) oAuthTokenProvider {
-	return &msiOAuthTokenProvider{env, ClientID}
+func NewMSIOAuthTokenProvider(env azure.Environment, clientID string) oAuthTokenProvider {
+	return &msiOAuthTokenProvider{env: env, clientID: clientID}
 }
 
 func (tp *msiOAuthTokenProvider) getServicePrincipalToken() (*adal.ServicePrincipalToken, error) {
@@ -21,6 +21,6 @@ func (tp *msiOAuthTokenProvider) getServicePrincipalToken() (*adal.ServicePrinci
 
 func (tp *msiOAuthTokenProvider) getServicePrincipalTokenWithResource(resource string) (*adal.ServicePrincipalToken, error) {
 	return adal.NewServicePrincipalTokenFromManagedIdentity(resource, &adal.ManagedIdentityOptions{
-		ClientID: tp.ClientID,
+		ClientID: tp.clientID,
 	})
 }

--- a/builder/azure/dtl/config.hcl2spec.go
+++ b/builder/azure/dtl/config.hcl2spec.go
@@ -56,6 +56,7 @@ type FlatConfig struct {
 	TenantID                            *string                            `mapstructure:"tenant_id" required:"false" cty:"tenant_id" hcl:"tenant_id"`
 	SubscriptionID                      *string                            `mapstructure:"subscription_id" cty:"subscription_id" hcl:"subscription_id"`
 	UseAzureCLIAuth                     *bool                              `mapstructure:"use_azure_cli_auth" required:"false" cty:"use_azure_cli_auth" hcl:"use_azure_cli_auth"`
+	UseInteractiveAuth                  *bool                              `mapstructure:"use_interactive_auth" required:"false" cty:"use_interactive_auth" hcl:"use_interactive_auth"`
 	CaptureNamePrefix                   *string                            `mapstructure:"capture_name_prefix" cty:"capture_name_prefix" hcl:"capture_name_prefix"`
 	CaptureContainerName                *string                            `mapstructure:"capture_container_name" cty:"capture_container_name" hcl:"capture_container_name"`
 	SharedGallery                       *FlatSharedImageGallery            `mapstructure:"shared_image_gallery" cty:"shared_image_gallery" hcl:"shared_image_gallery"`
@@ -173,6 +174,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"tenant_id":                                &hcldec.AttrSpec{Name: "tenant_id", Type: cty.String, Required: false},
 		"subscription_id":                          &hcldec.AttrSpec{Name: "subscription_id", Type: cty.String, Required: false},
 		"use_azure_cli_auth":                       &hcldec.AttrSpec{Name: "use_azure_cli_auth", Type: cty.Bool, Required: false},
+		"use_interactive_auth":                     &hcldec.AttrSpec{Name: "use_interactive_auth", Type: cty.Bool, Required: false},
 		"capture_name_prefix":                      &hcldec.AttrSpec{Name: "capture_name_prefix", Type: cty.String, Required: false},
 		"capture_container_name":                   &hcldec.AttrSpec{Name: "capture_container_name", Type: cty.String, Required: false},
 		"shared_image_gallery":                     &hcldec.BlockSpec{TypeName: "shared_image_gallery", Nested: hcldec.ObjectSpec((*FlatSharedImageGallery)(nil).HCL2Spec())},

--- a/docs-partials/builder/azure/common/client/Config-not-required.mdx
+++ b/docs-partials/builder/azure/common/client/Config-not-required.mdx
@@ -40,4 +40,7 @@
   Works with normal authentication (`az login`) and service principals (`az login --service-principal --username APP_ID --password PASSWORD --tenant TENANT_ID`).
   Ignores all other configurations if enabled.
 
+- `use_interactive_auth` (bool) - Flag to use device code authentication. Defaults to false.
+  If enabled, it will use interactive authentication.
+
 <!-- End of code generated from the comments of the Config struct in builder/azure/common/client/config.go; -->

--- a/docs-partials/builder/azure/common/client/Config-not-required.mdx
+++ b/docs-partials/builder/azure/common/client/Config-not-required.mdx
@@ -40,7 +40,7 @@
   Works with normal authentication (`az login`) and service principals (`az login --service-principal --username APP_ID --password PASSWORD --tenant TENANT_ID`).
   Ignores all other configurations if enabled.
 
-- `use_interactive_auth` (bool) - Flag to use device code authentication. Defaults to false.
+- `use_interactive_auth` (bool) - Flag to use interactive login (use device code) authentication. Defaults to false.
   If enabled, it will use interactive authentication.
 
 <!-- End of code generated from the comments of the Config struct in builder/azure/common/client/config.go; -->

--- a/docs-partials/builder/azure/common/client/Config.mdx
+++ b/docs-partials/builder/azure/common/client/Config.mdx
@@ -1,12 +1,14 @@
 <!-- Code generated from the comments of the Config struct in builder/azure/common/client/config.go; DO NOT EDIT MANUALLY -->
 
-Config allows for various ways to authenticate Azure clients.
-When `client_id` and `subscription_id` are specified, Packer will use the
-specified Azure Active Directory (AAD) Service Principal (SP).
-If only `subscription_id` is specified, Packer will try to interactively
-log on the current user (tokens will be cached).
-If none of these options are specified, Packer will attempt to use the
-Managed Identity and subscription of the VM that Packer is running on.
-This will only work if Packer is running on an Azure VM.
+Config allows for various ways to authenticate Azure clients.  When
+`client_id` and `subscription_id` are specified in addition to one and only
+one of the following: `client_secret`, `client_jwt`, `client_cert_path` --
+Packer will use the specified Azure Active Directory (AAD) Service Principal
+(SP).  If only `use_interactive_auth` is specified, Packer will try to
+interactively log on the current user (tokens will be cached).  If none of
+these options are specified, Packer will attempt to use the Managed Identity
+and subscription of the VM that Packer is running on.  This will only work if
+Packer is running on an Azure VM with either a System Assigned Managed
+Identity or User Assigned Managed Identity.
 
 <!-- End of code generated from the comments of the Config struct in builder/azure/common/client/config.go; -->

--- a/docs/builders/arm.mdx
+++ b/docs/builders/arm.mdx
@@ -34,12 +34,21 @@ options. In addition to the options listed here, a [communicator](https://packer
 
 #### Managed Identity
 
-If you're running Packer on an Azure VM with a [managed identity](https://packer.io/docs/builders/azure#azure-managed-identity) you don't need to specify any additional configuration options. As Packer will attempt to use the Managed Identity and subscription of the VM that Packer is running on.
+If you're running Packer on an Azure VM with a [managed
+identity](https://packer.io/docs/builders/azure#azure-managed-identity) you
+don't need to specify any additional configuration options. As Packer will
+attempt to use the Managed Identity and subscription of the VM that Packer is
+running on.
+
+You can use a different subscription if you set `subscription_id`.  If your VM
+has multiple user assigned managed identities you will need to set `client_id`
+too.
 
 #### Interactive User Authentication
 
-To use interactive user authentication, you should specify `subscription_id` only.
-Packer will use cached credentials or redirect you to a website to log in.
+To use interactive user authentication, you should specify
+`use_interactive_auth` only.  Packer will use cached credentials or redirect you
+to a website to log in.
 
 #### Service Principal
 

--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -55,12 +55,12 @@ the subscription level.
 
 If your organization allows it, you can use a command line interactive login
 method based on oAuth 'device code flow'. Packer will select this method when
-you only specify a `subscription_id` in your builder configuration. When you
+you only specify `use_interactive_auth` in your builder configuration. When you
 run Packer, it will ask you to visit a web site and input a code. This web site
 will then authenticate you, satisfying any two-factor authentication policies
-that your organization might have. The tokens are cached under the `.azure/packer`
-directory in your home directory and will be reused if they are still valid
-on subsequent runs.
+that your organization might have. The tokens are cached under the
+`.azure/packer` directory in your home directory and will be reused if they are
+still valid on subsequent runs.
 
 Please note that the interactive login is only available on the Azure public
 cloud, not on sovereign/government clouds.

--- a/provisioner/azure-dtlartifact/provisioner.hcl2spec.go
+++ b/provisioner/azure-dtlartifact/provisioner.hcl2spec.go
@@ -56,6 +56,7 @@ type FlatConfig struct {
 	TenantID                *string                `mapstructure:"tenant_id" required:"false" cty:"tenant_id" hcl:"tenant_id"`
 	SubscriptionID          *string                `mapstructure:"subscription_id" cty:"subscription_id" hcl:"subscription_id"`
 	UseAzureCLIAuth         *bool                  `mapstructure:"use_azure_cli_auth" required:"false" cty:"use_azure_cli_auth" hcl:"use_azure_cli_auth"`
+	UseInteractiveAuth      *bool                  `mapstructure:"use_interactive_auth" required:"false" cty:"use_interactive_auth" hcl:"use_interactive_auth"`
 	DtlArtifacts            []FlatDtlArtifact      `mapstructure:"dtl_artifacts" required:"true" cty:"dtl_artifacts" hcl:"dtl_artifacts"`
 	LabName                 *string                `mapstructure:"lab_name" required:"true" cty:"lab_name" hcl:"lab_name"`
 	ResourceGroupName       *string                `mapstructure:"lab_resource_group_name" required:"true" cty:"lab_resource_group_name" hcl:"lab_resource_group_name"`
@@ -96,6 +97,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"tenant_id":                  &hcldec.AttrSpec{Name: "tenant_id", Type: cty.String, Required: false},
 		"subscription_id":            &hcldec.AttrSpec{Name: "subscription_id", Type: cty.String, Required: false},
 		"use_azure_cli_auth":         &hcldec.AttrSpec{Name: "use_azure_cli_auth", Type: cty.Bool, Required: false},
+		"use_interactive_auth":       &hcldec.AttrSpec{Name: "use_interactive_auth", Type: cty.Bool, Required: false},
 		"dtl_artifacts":              &hcldec.BlockListSpec{TypeName: "dtl_artifacts", Nested: hcldec.ObjectSpec((*FlatDtlArtifact)(nil).HCL2Spec())},
 		"lab_name":                   &hcldec.AttrSpec{Name: "lab_name", Type: cty.String, Required: false},
 		"lab_resource_group_name":    &hcldec.AttrSpec{Name: "lab_resource_group_name", Type: cty.String, Required: false},


### PR DESCRIPTION
This PR does the following:

1. Only uses Interactive User Authentication if `use_interactive_auth` is set to `true`. This enables you to specify a `subscription_id` and `client_id` and still use a Managed Identity to authenticate. Which ultimately enables support for VM's that have more than one User Assigned Managed Identities, giving you a choice to select which MSI to use. This also enables you to set the subscription to something other than where the VM lives which is useful if you're building in a separate subscription.

Closes #140