### PR TITLE
Add SIG information as labels to HCP Packer Registry Image metadata

### DIFF
--- a/builder/azure/arm/step_publish_to_shared_image_gallery.go
+++ b/builder/azure/arm/step_publish_to_shared_image_gallery.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/constants"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
 )
 
 type StepPublishToSharedImageGallery struct {
@@ -184,6 +185,13 @@ func (s *StepPublishToSharedImageGallery) Run(ctx context.Context, stateBag mult
 
 		return multistep.ActionHalt
 	}
+
+	generatedData := packerbuilderdata.GeneratedData{State: stateBag}
+	generatedData.Put("SharedImageGalleryName", sharedImageGallery.SigDestinationGalleryName)
+	generatedData.Put("SharedImageGalleryImageName", sharedImageGallery.SigDestinationImageName)
+	generatedData.Put("SharedImageGalleryImageVersion", sharedImageGallery.SigDestinationImageVersion)
+	generatedData.Put("SharedImageGalleryResourceGroup", sharedImageGallery.SigDestinationResourceGroup)
+	generatedData.Put("SharedImageGalleryReplicationRegions", sharedImageGallery.SigDestinationReplicationRegions)
 
 	stateBag.Put(constants.ArmManagedImageSharedGalleryId, createdGalleryImageVersionID)
 	return multistep.ActionContinue


### PR DESCRIPTION
This change adds the Shared Image Gallery data to a builders generated data so that it can be included as part of the HCP Image metadata as labels. 