### PR TITLE
Converged (a bit) to azure-arm coding style, added sysprep_done flag …

### DIFF
--- a/builder/azure/dtl/builder_acc_test.go
+++ b/builder/azure/dtl/builder_acc_test.go
@@ -95,7 +95,7 @@ const testBuilderAccManagedDiskWindows = `
 	  "communicator": "winrm",
 	  "winrm_use_ssl": "true",
 	  "winrm_insecure": "true",
-	  "winrm_timeout": "3m",
+	  "winrm_timeout": "10m",
 	  "winrm_username": "packer",
 
 	  "location": "South Central US",

--- a/builder/azure/dtl/config.go
+++ b/builder/azure/dtl/config.go
@@ -525,7 +525,7 @@ func setUserNamePassword(c *Config) error {
 		c.Password = c.tmpAdminPassword
 	}
 
-        return nil
+	return nil
 }
 
 func provideDefaultValues(c *Config) error {

--- a/builder/azure/dtl/config.go
+++ b/builder/azure/dtl/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/masterzen/winrm"
 
+	azcommon "github.com/hashicorp/packer-plugin-azure/builder/azure/common"
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/client"
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/constants"
 
@@ -278,6 +279,9 @@ type Config struct {
 	// DisallowPublicIPAddress - Indicates whether the virtual machine is to be created without a public IP address.
 	DisallowPublicIP bool `mapstructure:"disallow_public_ip" required:"false"`
 
+        // SysPrepDone - Indicates whether SysPrep is to be requested to the DTL or has been already applied.
+        SysPrepDone bool `mapstructure:"sysprep_done" required:"false"`
+
 	// Runtime Values
 	UserName                string `mapstructure-to-hcl2:",skip"`
 	Password                string
@@ -385,42 +389,40 @@ func (c *Config) createCertificate() (string, string, error) {
 	return base64.StdEncoding.EncodeToString(bytes), certifcatePassowrd, nil
 }
 
-func newConfig(raws ...interface{}) (*Config, []string, error) {
-	var c Config
-	c.ctx.Funcs = TemplateFuncs
-	err := config.Decode(&c, &config.DecodeOpts{
+func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
+	c.ctx.Funcs = azcommon.TemplateFuncs
+	err := config.Decode(c, &config.DecodeOpts{
 		PluginType:         BuilderId,
 		Interpolate:        true,
 		InterpolateContext: &c.ctx,
 	}, raws...)
 
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	provideDefaultValues(&c)
-	setRuntimeValues(&c)
-	setUserNamePassword(&c)
-	err = c.ClientConfig.SetDefaultValues()
+	provideDefaultValues(c)
+	setRuntimeValues(c)
+	err = setUserNamePassword(c)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// NOTE: if the user did not specify a communicator, then default to both
 	// SSH and WinRM.  This is for backwards compatibility because the code did
 	// not specifically force the user to set a communicator.
 	if c.Comm.Type == "" || strings.EqualFold(c.Comm.Type, "ssh") {
-		err = setSshValues(&c)
+		err = setSshValues(c)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
 	//For DTL, communication is done by installing Mandatory public artifact "windows-winrm"
 	if c.Comm.Type == "" || strings.EqualFold(c.Comm.Type, "winrm") {
-		err = setWinRMCertificate(&c)
+		err = setWinRMCertificate(c)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
@@ -429,13 +431,13 @@ func newConfig(raws ...interface{}) (*Config, []string, error) {
 
 	c.ClientConfig.Validate(errs)
 
-	assertRequiredParametersSet(&c, errs)
-	assertTagProperties(&c, errs)
+	assertRequiredParametersSet(c, errs)
+	assertTagProperties(c, errs)
 	if errs != nil && len(errs.Errors) > 0 {
-		return nil, nil, errs
+		return nil, errs
 	}
 
-	return &c, nil, nil
+	return nil, nil
 }
 
 func setSshValues(c *Config) error {
@@ -510,11 +512,7 @@ func setRuntimeValues(c *Config) {
 	c.tmpKeyVaultName = tempName.KeyVaultName
 }
 
-func setUserNamePassword(c *Config) {
-	if c.Comm.SSHUsername == "" {
-		c.Comm.SSHUsername = DefaultUserName
-	}
-
+func setUserNamePassword(c *Config) error {
 	c.UserName = c.Comm.SSHUsername
 
 	if c.Comm.SSHPassword != "" {
@@ -522,6 +520,8 @@ func setUserNamePassword(c *Config) {
 	} else {
 		c.Password = c.tmpAdminPassword
 	}
+
+        return nil
 }
 
 func provideDefaultValues(c *Config) {
@@ -548,6 +548,12 @@ func provideDefaultValues(c *Config) {
 	if c.CustomImageCaptureTimeout == 0 {
 		c.CustomImageCaptureTimeout = DefaultCustomImageCaptureTimeout
 	}
+
+	if c.Comm.SSHUsername == "" {
+		c.Comm.SSHUsername = DefaultUserName
+	}
+
+	c.ClientConfig.SetDefaultValues()
 }
 
 func assertTagProperties(c *Config, errs *packersdk.MultiError) {

--- a/builder/azure/dtl/config.go
+++ b/builder/azure/dtl/config.go
@@ -279,8 +279,8 @@ type Config struct {
 	// DisallowPublicIPAddress - Indicates whether the virtual machine is to be created without a public IP address.
 	DisallowPublicIP bool `mapstructure:"disallow_public_ip" required:"false"`
 
-	// SysPrepDone - Indicates whether SysPrep is to be requested to the DTL or has been already applied.
-	SysPrepDone bool `mapstructure:"sysprep_done" required:"false"`
+	// SkipSysprep - Indicates whether SysPrep is to be requested to the DTL or if it should be skipped because it has already been applied. Defaults to false.
+	SkipSysprep bool `mapstructure:"skip_sysprep" required:"false"`
 
 	// Runtime Values
 	UserName                string `mapstructure-to-hcl2:",skip"`

--- a/builder/azure/dtl/config.go
+++ b/builder/azure/dtl/config.go
@@ -401,7 +401,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		return nil, err
 	}
 
-	provideDefaultValues(c)
+	err = provideDefaultValues(c)
+	if err != nil {
+		return nil, err
+	}
+
 	setRuntimeValues(c)
 	err = setUserNamePassword(c)
 	if err != nil {
@@ -524,7 +528,7 @@ func setUserNamePassword(c *Config) error {
         return nil
 }
 
-func provideDefaultValues(c *Config) {
+func provideDefaultValues(c *Config) error {
 	if c.VMSize == "" {
 		c.VMSize = DefaultVMSize
 	}
@@ -553,7 +557,8 @@ func provideDefaultValues(c *Config) {
 		c.Comm.SSHUsername = DefaultUserName
 	}
 
-	c.ClientConfig.SetDefaultValues()
+	err := c.ClientConfig.SetDefaultValues()
+	return err
 }
 
 func assertTagProperties(c *Config, errs *packersdk.MultiError) {

--- a/builder/azure/dtl/config.go
+++ b/builder/azure/dtl/config.go
@@ -279,8 +279,8 @@ type Config struct {
 	// DisallowPublicIPAddress - Indicates whether the virtual machine is to be created without a public IP address.
 	DisallowPublicIP bool `mapstructure:"disallow_public_ip" required:"false"`
 
-        // SysPrepDone - Indicates whether SysPrep is to be requested to the DTL or has been already applied.
-        SysPrepDone bool `mapstructure:"sysprep_done" required:"false"`
+	// SysPrepDone - Indicates whether SysPrep is to be requested to the DTL or has been already applied.
+	SysPrepDone bool `mapstructure:"sysprep_done" required:"false"`
 
 	// Runtime Values
 	UserName                string `mapstructure-to-hcl2:",skip"`

--- a/builder/azure/dtl/config.hcl2spec.go
+++ b/builder/azure/dtl/config.hcl2spec.go
@@ -89,7 +89,7 @@ type FlatConfig struct {
 	DtlArtifacts                        []FlatDtlArtifact                  `mapstructure:"dtl_artifacts" cty:"dtl_artifacts" hcl:"dtl_artifacts"`
 	VMName                              *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	DisallowPublicIP                    *bool                              `mapstructure:"disallow_public_ip" required:"false" cty:"disallow_public_ip" hcl:"disallow_public_ip"`
-	SysPrepDone                         *bool                              `mapstructure:"sysprep_done" required:"false" cty:"sysprep_done" hcl:"sysprep_done"`
+	SkipSysprep                         *bool                              `mapstructure:"skip_sysprep" required:"false" cty:"skip_sysprep" hcl:"skip_sysprep"`
 	Password                            *string                            `cty:"password" hcl:"password"`
 	Type                                *string                            `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect                  *string                            `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
@@ -206,7 +206,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"dtl_artifacts":                            &hcldec.BlockListSpec{TypeName: "dtl_artifacts", Nested: hcldec.ObjectSpec((*FlatDtlArtifact)(nil).HCL2Spec())},
 		"vm_name":                                  &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"disallow_public_ip":                       &hcldec.AttrSpec{Name: "disallow_public_ip", Type: cty.Bool, Required: false},
-		"sysprep_done":                             &hcldec.AttrSpec{Name: "sysprep_done", Type: cty.Bool, Required: false},
+		"skip_sysprep":                             &hcldec.AttrSpec{Name: "skip_sysprep", Type: cty.Bool, Required: false},
 		"password":                                 &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
 		"communicator":                             &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":                  &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},

--- a/builder/azure/dtl/config.hcl2spec.go
+++ b/builder/azure/dtl/config.hcl2spec.go
@@ -89,6 +89,7 @@ type FlatConfig struct {
 	DtlArtifacts                        []FlatDtlArtifact                  `mapstructure:"dtl_artifacts" cty:"dtl_artifacts" hcl:"dtl_artifacts"`
 	VMName                              *string                            `mapstructure:"vm_name" cty:"vm_name" hcl:"vm_name"`
 	DisallowPublicIP                    *bool                              `mapstructure:"disallow_public_ip" required:"false" cty:"disallow_public_ip" hcl:"disallow_public_ip"`
+	SysPrepDone                         *bool                              `mapstructure:"sysprep_done" required:"false" cty:"sysprep_done" hcl:"sysprep_done"`
 	Password                            *string                            `cty:"password" hcl:"password"`
 	Type                                *string                            `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect                  *string                            `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
@@ -205,6 +206,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"dtl_artifacts":                            &hcldec.BlockListSpec{TypeName: "dtl_artifacts", Nested: hcldec.ObjectSpec((*FlatDtlArtifact)(nil).HCL2Spec())},
 		"vm_name":                                  &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"disallow_public_ip":                       &hcldec.AttrSpec{Name: "disallow_public_ip", Type: cty.Bool, Required: false},
+		"sysprep_done":                             &hcldec.AttrSpec{Name: "sysprep_done", Type: cty.Bool, Required: false},
 		"password":                                 &hcldec.AttrSpec{Name: "password", Type: cty.String, Required: false},
 		"communicator":                             &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":                  &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},

--- a/builder/azure/dtl/config_test.go
+++ b/builder/azure/dtl/config_test.go
@@ -25,7 +25,7 @@ var requiredConfigValues = []string{
 }
 
 func TestConfigShouldProvideReasonableDefaultValues(t *testing.T) {
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
 	if err != nil {
 		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
@@ -53,7 +53,7 @@ func TestConfigShouldProvideReasonableDefaultValues(t *testing.T) {
 }
 
 func TestConfigShouldDefaultVMSizeToStandardA1(t *testing.T) {
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
 	if err != nil {
 		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
@@ -65,7 +65,7 @@ func TestConfigShouldDefaultVMSizeToStandardA1(t *testing.T) {
 }
 
 func TestConfigShouldDefaultImageVersionToLatest(t *testing.T) {
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
 	if err != nil {
 		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
@@ -91,7 +91,7 @@ func TestConfigVirtualNetworkResourceGroupNameMustBeSetWithVirtualNetworkName(t 
 		"virtual_network_resource_group_name": "MyVirtualNetworkRG",
 	}
 
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err == nil {
 		t.Error("Expected Config to reject virtual_network_resource_group_name, if virtual_network_name is not set.")
@@ -113,7 +113,7 @@ func TestConfigVirtualNetworkSubnetNameMustBeSetWithVirtualNetworkName(t *testin
 		"virtual_network_subnet_name": "MyVirtualNetworkRG",
 	}
 
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err == nil {
 		t.Error("Expected Config to reject virtual_network_subnet_name, if virtual_network_name is not set.")
@@ -121,7 +121,7 @@ func TestConfigVirtualNetworkSubnetNameMustBeSetWithVirtualNetworkName(t *testin
 }
 
 func TestSystemShouldDefineRuntimeValues(t *testing.T) {
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
 	if err != nil {
 		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
@@ -149,7 +149,7 @@ func TestSystemShouldDefineRuntimeValues(t *testing.T) {
 }
 
 func TestConfigShouldTransformToVirtualMachineCaptureParameters(t *testing.T) {
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
 	if err != nil {
 		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
@@ -171,7 +171,7 @@ func TestConfigShouldTransformToVirtualMachineCaptureParameters(t *testing.T) {
 }
 
 func TestConfigShouldSupportPackersConfigElements(t *testing.T) {
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration(), getPackerCommunicatorConfiguration())
 	if err != nil {
 		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
@@ -192,7 +192,7 @@ func TestWinRMConfigShouldSetRoundTripDecorator(t *testing.T) {
 	config_dtl["winrm_username"] = "username"
 	config_dtl["winrm_password"] = "password"
 
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(config_dtl, getPackerConfiguration())
 	if err != nil {
 		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
@@ -218,7 +218,7 @@ func TestUserDeviceLoginIsEnabledForLinux(t *testing.T) {
 		"lab_virtual_network_name": "ignore",
 	}
 
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err != nil {
 		t.Fatalf("failed to use device login for Linux: %s", err)
@@ -245,7 +245,7 @@ func TestConfigShouldAcceptTags(t *testing.T) {
 		},
 	}
 
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err != nil {
 		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
@@ -295,7 +295,7 @@ func TestConfigShouldRejectTagsInExcessOf15AcceptTags(t *testing.T) {
 		"azure_tags": tooManyTags,
 	}
 
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err == nil {
 		t.Fatal("expected config to reject based on an excessive amount of tags (> 15)")
@@ -327,7 +327,7 @@ func TestConfigShouldRejectExcessiveTagNameLength(t *testing.T) {
 		"azure_tags": tags,
 	}
 
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err == nil {
 		t.Fatal("expected config to reject tag name based on length (> 512)")
@@ -359,7 +359,7 @@ func TestConfigShouldRejectExcessiveTagValueLength(t *testing.T) {
 		"azure_tags": tags,
 	}
 
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err == nil {
 		t.Fatal("expected config to reject tag value based on length (> 256)")
@@ -383,7 +383,7 @@ func TestConfigShouldAcceptPlatformManagedImageBuild(t *testing.T) {
 		"os_type": constants.Target_Linux,
 	}
 
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err != nil {
 		t.Fatal("expected config to accept platform managed image build")
@@ -410,7 +410,7 @@ func TestConfigShouldAcceptManagedImageStorageAccountTypes(t *testing.T) {
 
 	for _, x := range storage_account_types {
 		config_map["managed_image_storage_account_type"] = x
-                config := Config{}
+		config := Config{}
 		_, err := config.Prepare(config_map, getPackerConfiguration())
 		if err != nil {
 			t.Fatalf("expected config to accept a managed_image_storage_account_type of %q", x)
@@ -438,7 +438,7 @@ func TestConfigShouldAcceptDiskCachingTypes(t *testing.T) {
 
 	for _, x := range storage_account_types {
 		config_map["disk_caching_type"] = x
-                config := Config{}
+		config := Config{}
 		_, err := config.Prepare(config_map, getPackerConfiguration())
 		if err != nil {
 			t.Fatalf("expected config to accept a disk_caching_type of %q", x)
@@ -447,7 +447,7 @@ func TestConfigShouldAcceptDiskCachingTypes(t *testing.T) {
 }
 
 func TestConfigAdditionalDiskDefaultIsNil(t *testing.T) {
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
 	if err != nil {
 		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
@@ -475,7 +475,7 @@ func TestConfigAdditionalDiskOverrideDefault(t *testing.T) {
 		"disk_additional_size": {32, 64},
 	}
 
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(config_map, diskconfig, getPackerConfiguration())
 	if err != nil {
 		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
@@ -511,7 +511,7 @@ func TestConfigShouldAllowSharedImageGalleryOptions(t *testing.T) {
 		},
 	}
 
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err == nil {
 		t.Log("expected config to accept Shared Image Gallery options", err)
@@ -537,7 +537,7 @@ func TestConfigShouldRejectSharedImageGalleryWithVhdTarget(t *testing.T) {
 		"lab_virtual_network_name": "ignore",
 	}
 
-        config := Config{}
+	config := Config{}
 	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err != nil {
 		t.Log("expected an error if Shared Image Gallery source is used with VHD target", err)

--- a/builder/azure/dtl/config_test.go
+++ b/builder/azure/dtl/config_test.go
@@ -27,10 +27,8 @@ var requiredConfigValues = []string{
 func TestConfigShouldProvideReasonableDefaultValues(t *testing.T) {
         config := Config{}
 	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
-
 	if err != nil {
-		t.Error("Expected configuration creation to succeed, but it failed!\n")
-		t.Fatalf(" errors: %s\n", err)
+		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
 	}
 
 	if config.UserName == "" {
@@ -56,7 +54,10 @@ func TestConfigShouldProvideReasonableDefaultValues(t *testing.T) {
 
 func TestConfigShouldDefaultVMSizeToStandardA1(t *testing.T) {
         config := Config{}
-	config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
+	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
+	}
 
 	if config.VMSize != "Standard_A1" {
 		t.Errorf("Expected 'VMSize' to default to 'Standard_A1', but got '%s'.", config.VMSize)
@@ -65,7 +66,10 @@ func TestConfigShouldDefaultVMSizeToStandardA1(t *testing.T) {
 
 func TestConfigShouldDefaultImageVersionToLatest(t *testing.T) {
         config := Config{}
-	config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
+	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
+	}
 
 	if config.ImageVersion != "latest" {
 		t.Errorf("Expected 'ImageVersion' to default to 'latest', but got '%s'.", config.ImageVersion)
@@ -118,7 +122,10 @@ func TestConfigVirtualNetworkSubnetNameMustBeSetWithVirtualNetworkName(t *testin
 
 func TestSystemShouldDefineRuntimeValues(t *testing.T) {
         config := Config{}
-	config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
+	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
+	}
 
 	if config.Password == "" {
 		t.Errorf("Expected Password to not be empty, but it was '%s'!", config.Password)
@@ -143,7 +150,10 @@ func TestSystemShouldDefineRuntimeValues(t *testing.T) {
 
 func TestConfigShouldTransformToVirtualMachineCaptureParameters(t *testing.T) {
         config := Config{}
-	config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
+	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
+	}
 
 	parameters := config.toVirtualMachineCaptureParameters()
 
@@ -163,9 +173,8 @@ func TestConfigShouldTransformToVirtualMachineCaptureParameters(t *testing.T) {
 func TestConfigShouldSupportPackersConfigElements(t *testing.T) {
         config := Config{}
 	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration(), getPackerCommunicatorConfiguration())
-
 	if err != nil {
-		t.Fatal(err)
+		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
 	}
 
 	if config.Comm.SSHTimeout != 1*time.Hour {
@@ -186,7 +195,7 @@ func TestWinRMConfigShouldSetRoundTripDecorator(t *testing.T) {
         config := Config{}
 	_, err := config.Prepare(config_dtl, getPackerConfiguration())
 	if err != nil {
-		t.Fatal(err)
+		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
 	}
 
 	if config.Comm.WinRMTransportDecorator == nil {
@@ -239,7 +248,7 @@ func TestConfigShouldAcceptTags(t *testing.T) {
         config := Config{}
 	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err != nil {
-		t.Fatal(err)
+		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
 	}
 
 	if len(config.AzureTags) != 2 {
@@ -439,7 +448,11 @@ func TestConfigShouldAcceptDiskCachingTypes(t *testing.T) {
 
 func TestConfigAdditionalDiskDefaultIsNil(t *testing.T) {
         config := Config{}
-	config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
+	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
+	}
+
 	if config.AdditionalDiskSize != nil {
 		t.Errorf("Expected Config to not have a set of additional disks, but got a non nil value")
 	}
@@ -463,7 +476,11 @@ func TestConfigAdditionalDiskOverrideDefault(t *testing.T) {
 	}
 
         config := Config{}
-	config.Prepare(config_map, diskconfig, getPackerConfiguration())
+	_, err := config.Prepare(config_map, diskconfig, getPackerConfiguration())
+	if err != nil {
+		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
+	}
+
 	if config.AdditionalDiskSize == nil {
 		t.Errorf("Expected Config to have a set of additional disks, but got nil")
 	}

--- a/builder/azure/dtl/config_test.go
+++ b/builder/azure/dtl/config_test.go
@@ -25,47 +25,50 @@ var requiredConfigValues = []string{
 }
 
 func TestConfigShouldProvideReasonableDefaultValues(t *testing.T) {
-	c, _, err := newConfig(getDtlBuilderConfiguration(), getPackerConfiguration())
+        config := Config{}
+	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
 
 	if err != nil {
 		t.Error("Expected configuration creation to succeed, but it failed!\n")
 		t.Fatalf(" errors: %s\n", err)
 	}
 
-	if c.UserName == "" {
+	if config.UserName == "" {
 		t.Error("Expected 'UserName' to be populated, but it was empty!")
 	}
 
-	if c.VMSize == "" {
+	if config.VMSize == "" {
 		t.Error("Expected 'VMSize' to be populated, but it was empty!")
 	}
 
-	if c.ClientConfig.ObjectID != "" {
-		t.Errorf("Expected 'ObjectID' to be nil, but it was '%s'!", c.ClientConfig.ObjectID)
+	if config.ClientConfig.ObjectID != "" {
+		t.Errorf("Expected 'ObjectID' to be nil, but it was '%s'!", config.ClientConfig.ObjectID)
 	}
 
-	if c.managedImageStorageAccountType == "" {
+	if config.managedImageStorageAccountType == "" {
 		t.Errorf("Expected 'managedImageStorageAccountType' to be populated, but it was empty!")
 	}
 
-	if c.diskCachingType == "" {
+	if config.diskCachingType == "" {
 		t.Errorf("Expected 'diskCachingType' to be populated, but it was empty!")
 	}
 }
 
 func TestConfigShouldDefaultVMSizeToStandardA1(t *testing.T) {
-	c, _, _ := newConfig(getDtlBuilderConfiguration(), getPackerConfiguration())
+        config := Config{}
+	config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
 
-	if c.VMSize != "Standard_A1" {
-		t.Errorf("Expected 'VMSize' to default to 'Standard_A1', but got '%s'.", c.VMSize)
+	if config.VMSize != "Standard_A1" {
+		t.Errorf("Expected 'VMSize' to default to 'Standard_A1', but got '%s'.", config.VMSize)
 	}
 }
 
 func TestConfigShouldDefaultImageVersionToLatest(t *testing.T) {
-	c, _, _ := newConfig(getDtlBuilderConfiguration(), getPackerConfiguration())
+        config := Config{}
+	config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
 
-	if c.ImageVersion != "latest" {
-		t.Errorf("Expected 'ImageVersion' to default to 'latest', but got '%s'.", c.ImageVersion)
+	if config.ImageVersion != "latest" {
+		t.Errorf("Expected 'ImageVersion' to default to 'latest', but got '%s'.", config.ImageVersion)
 	}
 }
 
@@ -73,7 +76,7 @@ func TestConfigShouldDefaultImageVersionToLatest(t *testing.T) {
 // a virtual network's resource group, or to help with disambiguation.  The value should
 // only be set if virtual_network_name was set.
 func TestConfigVirtualNetworkResourceGroupNameMustBeSetWithVirtualNetworkName(t *testing.T) {
-	config := map[string]string{
+	config_map := map[string]string{
 		"capture_name_prefix":                 "ignore",
 		"capture_container_name":              "ignore",
 		"location":                            "ignore",
@@ -84,7 +87,8 @@ func TestConfigVirtualNetworkResourceGroupNameMustBeSetWithVirtualNetworkName(t 
 		"virtual_network_resource_group_name": "MyVirtualNetworkRG",
 	}
 
-	_, _, err := newConfig(config, getPackerConfiguration())
+        config := Config{}
+	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err == nil {
 		t.Error("Expected Config to reject virtual_network_resource_group_name, if virtual_network_name is not set.")
 	}
@@ -94,7 +98,7 @@ func TestConfigVirtualNetworkResourceGroupNameMustBeSetWithVirtualNetworkName(t 
 // a virtual network subnet's name, or to help with disambiguation.  The value should
 // only be set if virtual_network_name was set.
 func TestConfigVirtualNetworkSubnetNameMustBeSetWithVirtualNetworkName(t *testing.T) {
-	config := map[string]string{
+	config_map := map[string]string{
 		"capture_name_prefix":         "ignore",
 		"capture_container_name":      "ignore",
 		"location":                    "ignore",
@@ -105,46 +109,50 @@ func TestConfigVirtualNetworkSubnetNameMustBeSetWithVirtualNetworkName(t *testin
 		"virtual_network_subnet_name": "MyVirtualNetworkRG",
 	}
 
-	_, _, err := newConfig(config, getPackerConfiguration())
+        config := Config{}
+	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err == nil {
 		t.Error("Expected Config to reject virtual_network_subnet_name, if virtual_network_name is not set.")
 	}
 }
 
 func TestSystemShouldDefineRuntimeValues(t *testing.T) {
-	c, _, _ := newConfig(getDtlBuilderConfiguration(), getPackerConfiguration())
+        config := Config{}
+	config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
 
-	if c.Password == "" {
-		t.Errorf("Expected Password to not be empty, but it was '%s'!", c.Password)
+	if config.Password == "" {
+		t.Errorf("Expected Password to not be empty, but it was '%s'!", config.Password)
 	}
 
-	if c.tmpComputeName == "" {
-		t.Errorf("Expected tmpComputeName to not be empty, but it was '%s'!", c.tmpComputeName)
+	if config.tmpComputeName == "" {
+		t.Errorf("Expected tmpComputeName to not be empty, but it was '%s'!", config.tmpComputeName)
 	}
 
-	if c.tmpDeploymentName == "" {
-		t.Errorf("Expected tmpDeploymentName to not be empty, but it was '%s'!", c.tmpDeploymentName)
+	if config.tmpDeploymentName == "" {
+		t.Errorf("Expected tmpDeploymentName to not be empty, but it was '%s'!", config.tmpDeploymentName)
 	}
 
-	if c.tmpResourceGroupName == "" {
-		t.Errorf("Expected tmpResourceGroupName to not be empty, but it was '%s'!", c.tmpResourceGroupName)
+	if config.tmpResourceGroupName == "" {
+		t.Errorf("Expected tmpResourceGroupName to not be empty, but it was '%s'!", config.tmpResourceGroupName)
 	}
 
-	if c.tmpOSDiskName == "" {
-		t.Errorf("Expected tmpOSDiskName to not be empty, but it was '%s'!", c.tmpOSDiskName)
+	if config.tmpOSDiskName == "" {
+		t.Errorf("Expected tmpOSDiskName to not be empty, but it was '%s'!", config.tmpOSDiskName)
 	}
 }
 
 func TestConfigShouldTransformToVirtualMachineCaptureParameters(t *testing.T) {
-	c, _, _ := newConfig(getDtlBuilderConfiguration(), getPackerConfiguration())
-	parameters := c.toVirtualMachineCaptureParameters()
+        config := Config{}
+	config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
 
-	if *parameters.DestinationContainerName != c.CaptureContainerName {
-		t.Errorf("Expected DestinationContainerName to be equal to config's CaptureContainerName, but they were '%s' and '%s' respectively.", *parameters.DestinationContainerName, c.CaptureContainerName)
+	parameters := config.toVirtualMachineCaptureParameters()
+
+	if *parameters.DestinationContainerName != config.CaptureContainerName {
+		t.Errorf("Expected DestinationContainerName to be equal to config's CaptureContainerName, but they were '%s' and '%s' respectively.", *parameters.DestinationContainerName, config.CaptureContainerName)
 	}
 
-	if *parameters.VhdPrefix != c.CaptureNamePrefix {
-		t.Errorf("Expected DestinationContainerName to be equal to config's CaptureContainerName, but they were '%s' and '%s' respectively.", *parameters.VhdPrefix, c.CaptureNamePrefix)
+	if *parameters.VhdPrefix != config.CaptureNamePrefix {
+		t.Errorf("Expected DestinationContainerName to be equal to config's CaptureContainerName, but they were '%s' and '%s' respectively.", *parameters.VhdPrefix, config.CaptureNamePrefix)
 	}
 
 	if *parameters.OverwriteVhds != false {
@@ -153,42 +161,41 @@ func TestConfigShouldTransformToVirtualMachineCaptureParameters(t *testing.T) {
 }
 
 func TestConfigShouldSupportPackersConfigElements(t *testing.T) {
-	c, _, err := newConfig(
-		getDtlBuilderConfiguration(),
-		getPackerConfiguration(),
-		getPackerCommunicatorConfiguration())
+        config := Config{}
+	_, err := config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration(), getPackerCommunicatorConfiguration())
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if c.Comm.SSHTimeout != 1*time.Hour {
-		t.Errorf("Expected Comm.SSHTimeout to be a duration of an hour, but got '%s' instead.", c.Comm.SSHTimeout)
+	if config.Comm.SSHTimeout != 1*time.Hour {
+		t.Errorf("Expected Comm.SSHTimeout to be a duration of an hour, but got '%s' instead.", config.Comm.SSHTimeout)
 	}
 
-	if c.Comm.WinRMTimeout != 2*time.Hour {
-		t.Errorf("Expected Comm.WinRMTimeout to be a durationof two hours, but got '%s' instead.", c.Comm.WinRMTimeout)
+	if config.Comm.WinRMTimeout != 2*time.Hour {
+		t.Errorf("Expected Comm.WinRMTimeout to be a durationof two hours, but got '%s' instead.", config.Comm.WinRMTimeout)
 	}
 }
 
 func TestWinRMConfigShouldSetRoundTripDecorator(t *testing.T) {
-	config := getDtlBuilderConfiguration()
-	config["communicator"] = "winrm"
-	config["winrm_username"] = "username"
-	config["winrm_password"] = "password"
+	config_dtl := getDtlBuilderConfiguration()
+	config_dtl["communicator"] = "winrm"
+	config_dtl["winrm_username"] = "username"
+	config_dtl["winrm_password"] = "password"
 
-	c, _, err := newConfig(config, getPackerConfiguration())
+        config := Config{}
+	_, err := config.Prepare(config_dtl, getPackerConfiguration())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if c.Comm.WinRMTransportDecorator == nil {
+	if config.Comm.WinRMTransportDecorator == nil {
 		t.Error("Expected WinRMTransportDecorator to be set, but it was nil")
 	}
 }
 
 func TestUserDeviceLoginIsEnabledForLinux(t *testing.T) {
-	config := map[string]string{
+	config_map := map[string]string{
 		"capture_name_prefix":      "ignore",
 		"capture_container_name":   "ignore",
 		"image_offer":              "ignore",
@@ -202,14 +209,15 @@ func TestUserDeviceLoginIsEnabledForLinux(t *testing.T) {
 		"lab_virtual_network_name": "ignore",
 	}
 
-	_, _, err := newConfig(config, getPackerConfiguration())
+        config := Config{}
+	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err != nil {
 		t.Fatalf("failed to use device login for Linux: %s", err)
 	}
 }
 
 func TestConfigShouldAcceptTags(t *testing.T) {
-	config := map[string]interface{}{
+	config_map := map[string]interface{}{
 		"capture_name_prefix":      "ignore",
 		"capture_container_name":   "ignore",
 		"image_offer":              "ignore",
@@ -228,29 +236,29 @@ func TestConfigShouldAcceptTags(t *testing.T) {
 		},
 	}
 
-	c, _, err := newConfig(config, getPackerConfiguration())
-
+        config := Config{}
+	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if len(c.AzureTags) != 2 {
-		t.Fatalf("expected to find 2 tags, but got %d", len(c.AzureTags))
+	if len(config.AzureTags) != 2 {
+		t.Fatalf("expected to find 2 tags, but got %d", len(config.AzureTags))
 	}
 
-	if _, ok := c.AzureTags["tag01"]; !ok {
+	if _, ok := config.AzureTags["tag01"]; !ok {
 		t.Error("expected to find key=\"tag01\", but did not")
 	}
-	if _, ok := c.AzureTags["tag02"]; !ok {
+	if _, ok := config.AzureTags["tag02"]; !ok {
 		t.Error("expected to find key=\"tag02\", but did not")
 	}
 
-	value := c.AzureTags["tag01"]
+	value := config.AzureTags["tag01"]
 	if *value != "value01" {
 		t.Errorf("expected AzureTags[\"tag01\"] to have value \"value01\", but got %q", *value)
 	}
 
-	value = c.AzureTags["tag02"]
+	value = config.AzureTags["tag02"]
 	if *value != "value02" {
 		t.Errorf("expected AzureTags[\"tag02\"] to have value \"value02\", but got %q", *value)
 	}
@@ -262,7 +270,7 @@ func TestConfigShouldRejectTagsInExcessOf15AcceptTags(t *testing.T) {
 		tooManyTags[fmt.Sprintf("tag%.2d", i)] = "ignored"
 	}
 
-	config := map[string]interface{}{
+	config_map := map[string]interface{}{
 		"capture_name_prefix":      "ignore",
 		"capture_container_name":   "ignore",
 		"image_offer":              "ignore",
@@ -278,8 +286,8 @@ func TestConfigShouldRejectTagsInExcessOf15AcceptTags(t *testing.T) {
 		"azure_tags": tooManyTags,
 	}
 
-	_, _, err := newConfig(config, getPackerConfiguration())
-
+        config := Config{}
+	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err == nil {
 		t.Fatal("expected config to reject based on an excessive amount of tags (> 15)")
 	}
@@ -294,7 +302,7 @@ func TestConfigShouldRejectExcessiveTagNameLength(t *testing.T) {
 	tags := map[string]string{}
 	tags[string(nameTooLong)] = "ignored"
 
-	config := map[string]interface{}{
+	config_map := map[string]interface{}{
 		"capture_name_prefix":      "ignore",
 		"capture_container_name":   "ignore",
 		"image_offer":              "ignore",
@@ -310,7 +318,8 @@ func TestConfigShouldRejectExcessiveTagNameLength(t *testing.T) {
 		"azure_tags": tags,
 	}
 
-	_, _, err := newConfig(config, getPackerConfiguration())
+        config := Config{}
+	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err == nil {
 		t.Fatal("expected config to reject tag name based on length (> 512)")
 	}
@@ -325,7 +334,7 @@ func TestConfigShouldRejectExcessiveTagValueLength(t *testing.T) {
 	tags := map[string]string{}
 	tags["tag01"] = string(valueTooLong)
 
-	config := map[string]interface{}{
+	config_map := map[string]interface{}{
 		"capture_name_prefix":      "ignore",
 		"capture_container_name":   "ignore",
 		"image_offer":              "ignore",
@@ -341,14 +350,15 @@ func TestConfigShouldRejectExcessiveTagValueLength(t *testing.T) {
 		"azure_tags": tags,
 	}
 
-	_, _, err := newConfig(config, getPackerConfiguration())
+        config := Config{}
+	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err == nil {
 		t.Fatal("expected config to reject tag value based on length (> 256)")
 	}
 }
 
 func TestConfigShouldAcceptPlatformManagedImageBuild(t *testing.T) {
-	config := map[string]interface{}{
+	config_map := map[string]interface{}{
 		"image_offer":                       "ignore",
 		"image_publisher":                   "ignore",
 		"image_sku":                         "ignore",
@@ -364,14 +374,15 @@ func TestConfigShouldAcceptPlatformManagedImageBuild(t *testing.T) {
 		"os_type": constants.Target_Linux,
 	}
 
-	_, _, err := newConfig(config, getPackerConfiguration())
+        config := Config{}
+	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err != nil {
 		t.Fatal("expected config to accept platform managed image build")
 	}
 }
 
 func TestConfigShouldAcceptManagedImageStorageAccountTypes(t *testing.T) {
-	config := map[string]interface{}{
+	config_map := map[string]interface{}{
 		"custom_managed_image_resource_group_name": "ignore",
 		"custom_managed_image_name":                "ignore",
 		"location":                                 "ignore",
@@ -389,8 +400,9 @@ func TestConfigShouldAcceptManagedImageStorageAccountTypes(t *testing.T) {
 	storage_account_types := []string{"Premium_LRS", "Standard_LRS"}
 
 	for _, x := range storage_account_types {
-		config["managed_image_storage_account_type"] = x
-		_, _, err := newConfig(config, getPackerConfiguration())
+		config_map["managed_image_storage_account_type"] = x
+                config := Config{}
+		_, err := config.Prepare(config_map, getPackerConfiguration())
 		if err != nil {
 			t.Fatalf("expected config to accept a managed_image_storage_account_type of %q", x)
 		}
@@ -398,7 +410,7 @@ func TestConfigShouldAcceptManagedImageStorageAccountTypes(t *testing.T) {
 }
 
 func TestConfigShouldAcceptDiskCachingTypes(t *testing.T) {
-	config := map[string]interface{}{
+	config_map := map[string]interface{}{
 		"custom_managed_image_resource_group_name": "ignore",
 		"custom_managed_image_name":                "ignore",
 		"location":                                 "ignore",
@@ -416,8 +428,9 @@ func TestConfigShouldAcceptDiskCachingTypes(t *testing.T) {
 	storage_account_types := []string{"None", "ReadOnly", "ReadWrite"}
 
 	for _, x := range storage_account_types {
-		config["disk_caching_type"] = x
-		_, _, err := newConfig(config, getPackerConfiguration())
+		config_map["disk_caching_type"] = x
+                config := Config{}
+		_, err := config.Prepare(config_map, getPackerConfiguration())
 		if err != nil {
 			t.Fatalf("expected config to accept a disk_caching_type of %q", x)
 		}
@@ -425,14 +438,15 @@ func TestConfigShouldAcceptDiskCachingTypes(t *testing.T) {
 }
 
 func TestConfigAdditionalDiskDefaultIsNil(t *testing.T) {
-	c, _, _ := newConfig(getDtlBuilderConfiguration(), getPackerConfiguration())
-	if c.AdditionalDiskSize != nil {
+        config := Config{}
+	config.Prepare(getDtlBuilderConfiguration(), getPackerConfiguration())
+	if config.AdditionalDiskSize != nil {
 		t.Errorf("Expected Config to not have a set of additional disks, but got a non nil value")
 	}
 }
 
 func TestConfigAdditionalDiskOverrideDefault(t *testing.T) {
-	config := map[string]string{
+	config_map := map[string]string{
 		"capture_name_prefix":      "ignore",
 		"capture_container_name":   "ignore",
 		"location":                 "ignore",
@@ -448,23 +462,24 @@ func TestConfigAdditionalDiskOverrideDefault(t *testing.T) {
 		"disk_additional_size": {32, 64},
 	}
 
-	c, _, _ := newConfig(config, diskconfig, getPackerConfiguration())
-	if c.AdditionalDiskSize == nil {
+        config := Config{}
+	config.Prepare(config_map, diskconfig, getPackerConfiguration())
+	if config.AdditionalDiskSize == nil {
 		t.Errorf("Expected Config to have a set of additional disks, but got nil")
 	}
-	if len(c.AdditionalDiskSize) != 2 {
-		t.Errorf("Expected Config to have a 2 additional disks, but got %d additional disks", len(c.AdditionalDiskSize))
+	if len(config.AdditionalDiskSize) != 2 {
+		t.Errorf("Expected Config to have a 2 additional disks, but got %d additional disks", len(config.AdditionalDiskSize))
 	}
-	if c.AdditionalDiskSize[0] != 32 {
-		t.Errorf("Expected Config to have the first additional disks of size 32Gb, but got %dGb", c.AdditionalDiskSize[0])
+	if config.AdditionalDiskSize[0] != 32 {
+		t.Errorf("Expected Config to have the first additional disks of size 32Gb, but got %dGb", config.AdditionalDiskSize[0])
 	}
-	if c.AdditionalDiskSize[1] != 64 {
-		t.Errorf("Expected Config to have the second additional disks of size 64Gb, but got %dGb", c.AdditionalDiskSize[1])
+	if config.AdditionalDiskSize[1] != 64 {
+		t.Errorf("Expected Config to have the second additional disks of size 64Gb, but got %dGb", config.AdditionalDiskSize[1])
 	}
 }
 
 func TestConfigShouldAllowSharedImageGalleryOptions(t *testing.T) {
-	config := map[string]interface{}{
+	config_map := map[string]interface{}{
 		"location":                 "ignore",
 		"subscription_id":          "ignore",
 		"os_type":                  "linux",
@@ -479,7 +494,8 @@ func TestConfigShouldAllowSharedImageGalleryOptions(t *testing.T) {
 		},
 	}
 
-	_, _, err := newConfig(config, getPackerConfiguration())
+        config := Config{}
+	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err == nil {
 		t.Log("expected config to accept Shared Image Gallery options", err)
 	}
@@ -487,7 +503,7 @@ func TestConfigShouldAllowSharedImageGalleryOptions(t *testing.T) {
 }
 
 func TestConfigShouldRejectSharedImageGalleryWithVhdTarget(t *testing.T) {
-	config := map[string]interface{}{
+	config_map := map[string]interface{}{
 		"location":        "ignore",
 		"subscription_id": "ignore",
 		"os_type":         "linux",
@@ -504,7 +520,8 @@ func TestConfigShouldRejectSharedImageGalleryWithVhdTarget(t *testing.T) {
 		"lab_virtual_network_name": "ignore",
 	}
 
-	_, _, err := newConfig(config, getPackerConfiguration())
+        config := Config{}
+	_, err := config.Prepare(config_map, getPackerConfiguration())
 	if err != nil {
 		t.Log("expected an error if Shared Image Gallery source is used with VHD target", err)
 	}

--- a/builder/azure/dtl/step_capture_image.go
+++ b/builder/azure/dtl/step_capture_image.go
@@ -51,10 +51,10 @@ func (s *StepCaptureImage) captureImageFromVM(ctx context.Context) error {
 	customImageProperties := dtl.CustomImageProperties{}
 
 	if s.config.OSType == constants.Target_Linux {
-                deprovision := dtl.DeprovisionRequested
-                if s.config.SysPrepDone {
-                    deprovision = dtl.DeprovisionApplied
-                }
+		deprovision := dtl.DeprovisionRequested
+		if s.config.SysPrepDone {
+			deprovision = dtl.DeprovisionApplied
+		}
 		customImageProperties = dtl.CustomImageProperties{
 			VM: &dtl.CustomImagePropertiesFromVM{
 				LinuxOsInfo: &dtl.LinuxOsInfo{
@@ -64,11 +64,10 @@ func (s *StepCaptureImage) captureImageFromVM(ctx context.Context) error {
 			},
 		}
 	} else if s.config.OSType == constants.Target_Windows {
-                deprovision := dtl.SysprepRequested
-                if s.config.SysPrepDone {
-                    deprovision = dtl.SysprepApplied
-                }
-
+		deprovision := dtl.SysprepRequested
+		if s.config.SysPrepDone {
+			deprovision = dtl.SysprepApplied
+		}
 		customImageProperties = dtl.CustomImageProperties{
 			VM: &dtl.CustomImagePropertiesFromVM{
 				WindowsOsInfo: &dtl.WindowsOsInfo{

--- a/builder/azure/dtl/step_capture_image.go
+++ b/builder/azure/dtl/step_capture_image.go
@@ -52,7 +52,7 @@ func (s *StepCaptureImage) captureImageFromVM(ctx context.Context) error {
 
 	if s.config.OSType == constants.Target_Linux {
 		deprovision := dtl.DeprovisionRequested
-		if s.config.SysPrepDone {
+		if s.config.SkipSysprep {
 			deprovision = dtl.DeprovisionApplied
 		}
 		customImageProperties = dtl.CustomImageProperties{
@@ -65,7 +65,7 @@ func (s *StepCaptureImage) captureImageFromVM(ctx context.Context) error {
 		}
 	} else if s.config.OSType == constants.Target_Windows {
 		deprovision := dtl.SysprepRequested
-		if s.config.SysPrepDone {
+		if s.config.SkipSysprep {
 			deprovision = dtl.SysprepApplied
 		}
 		customImageProperties = dtl.CustomImageProperties{

--- a/builder/azure/dtl/step_capture_image.go
+++ b/builder/azure/dtl/step_capture_image.go
@@ -51,19 +51,28 @@ func (s *StepCaptureImage) captureImageFromVM(ctx context.Context) error {
 	customImageProperties := dtl.CustomImageProperties{}
 
 	if s.config.OSType == constants.Target_Linux {
+                deprovision := dtl.DeprovisionRequested
+                if s.config.SysPrepDone {
+                    deprovision = dtl.DeprovisionApplied
+                }
 		customImageProperties = dtl.CustomImageProperties{
 			VM: &dtl.CustomImagePropertiesFromVM{
 				LinuxOsInfo: &dtl.LinuxOsInfo{
-					LinuxOsState: dtl.DeprovisionRequested,
+					LinuxOsState: deprovision,
 				},
 				SourceVMID: &imageID,
 			},
 		}
 	} else if s.config.OSType == constants.Target_Windows {
+                deprovision := dtl.SysprepRequested
+                if s.config.SysPrepDone {
+                    deprovision = dtl.SysprepApplied
+                }
+
 		customImageProperties = dtl.CustomImageProperties{
 			VM: &dtl.CustomImagePropertiesFromVM{
 				WindowsOsInfo: &dtl.WindowsOsInfo{
-					WindowsOsState: dtl.SysprepRequested,
+					WindowsOsState: deprovision,
 				},
 				SourceVMID: &imageID,
 			},

--- a/builder/azure/dtl/step_deploy_template.go
+++ b/builder/azure/dtl/step_deploy_template.go
@@ -122,7 +122,8 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 		dtlArtifacts := []dtl.ArtifactInstallProperties{*winrmArtifact}
 		dtlArtifactsRequest := dtl.ApplyArtifactsRequest{Artifacts: &dtlArtifacts}
 
-		for i := 0; i < 3; i++ {
+		// infinite loop until the artifacts have been applied
+		for {
 			f, err := s.client.DtlVirtualMachineClient.ApplyArtifacts(ctx, s.config.tmpResourceGroupName, s.config.LabName, s.config.tmpComputeName, dtlArtifactsRequest)
 			if err == nil {
 				s.say(fmt.Sprintf("WinRM artifact deployment started, waiting for completion"))
@@ -132,12 +133,9 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 					return err
 				}
 				break
-			} else if i < 2 {
+			} else {
 				s.say(fmt.Sprintf("WinRM artifact deployment failed, sleeping a minute and retrying"))
 				time.Sleep(60 * time.Second)
-			} else if err != nil {
-				s.say(s.client.LastError.Error())
-				return err
 			}
 		}
 	}

--- a/builder/azure/dtl/step_deploy_template.go
+++ b/builder/azure/dtl/step_deploy_template.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+        "time"
 
 	"github.com/Azure/azure-sdk-for-go/services/devtestlabs/mgmt/2018-09-15/dtl"
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/constants"
@@ -120,14 +121,25 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 
 		dtlArtifacts := []dtl.ArtifactInstallProperties{*winrmArtifact}
 		dtlArtifactsRequest := dtl.ApplyArtifactsRequest{Artifacts: &dtlArtifacts}
-		f, err := s.client.DtlVirtualMachineClient.ApplyArtifacts(ctx, s.config.tmpResourceGroupName, s.config.LabName, s.config.tmpComputeName, dtlArtifactsRequest)
-		if err == nil {
-			err = f.WaitForCompletionRef(ctx, s.client.DtlVirtualMachineClient.Client)
-		}
-		if err != nil {
-			s.say(s.client.LastError.Error())
-			return err
-		}
+
+                for i := 0; i < 3; i++ {
+			f, err := s.client.DtlVirtualMachineClient.ApplyArtifacts(ctx, s.config.tmpResourceGroupName, s.config.LabName, s.config.tmpComputeName, dtlArtifactsRequest)
+			if err == nil {
+				s.say(fmt.Sprintf("WinRM artifact deployment started, waiting for completion"))
+				err = f.WaitForCompletionRef(ctx, s.client.DtlVirtualMachineClient.Client)
+				if err != nil {
+					s.say(s.client.LastError.Error())
+					return err
+				}
+				break
+			} else if i < 2 {
+				s.say(fmt.Sprintf("WinRM artifact deployment failed, sleeping a minute and retrying"))
+				time.Sleep(60 * time.Second)
+			} else if err != nil {
+				s.say(s.client.LastError.Error())
+				return err
+			}
+                }
 	}
 
 	xs := strings.Split(*vm.LabVirtualMachineProperties.ComputeID, "/")

--- a/builder/azure/dtl/step_deploy_template.go
+++ b/builder/azure/dtl/step_deploy_template.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-        "time"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/devtestlabs/mgmt/2018-09-15/dtl"
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/constants"
@@ -122,7 +122,7 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 		dtlArtifacts := []dtl.ArtifactInstallProperties{*winrmArtifact}
 		dtlArtifactsRequest := dtl.ApplyArtifactsRequest{Artifacts: &dtlArtifacts}
 
-                for i := 0; i < 3; i++ {
+		for i := 0; i < 3; i++ {
 			f, err := s.client.DtlVirtualMachineClient.ApplyArtifacts(ctx, s.config.tmpResourceGroupName, s.config.LabName, s.config.tmpComputeName, dtlArtifactsRequest)
 			if err == nil {
 				s.say(fmt.Sprintf("WinRM artifact deployment started, waiting for completion"))
@@ -139,7 +139,7 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 				s.say(s.client.LastError.Error())
 				return err
 			}
-                }
+		}
 	}
 
 	xs := strings.Split(*vm.LabVirtualMachineProperties.ComputeID, "/")

--- a/docs-partials/builder/azure/dtl/Config-not-required.mdx
+++ b/docs-partials/builder/azure/dtl/Config-not-required.mdx
@@ -134,4 +134,6 @@
 
 - `disallow_public_ip` (bool) - DisallowPublicIPAddress - Indicates whether the virtual machine is to be created without a public IP address.
 
+- `sysprep_done` (bool) - SysPrepDone - Indicates whether SysPrep is to be requested to the DTL or has been already applied.
+
 <!-- End of code generated from the comments of the Config struct in builder/azure/dtl/config.go; -->

--- a/docs-partials/builder/azure/dtl/Config-not-required.mdx
+++ b/docs-partials/builder/azure/dtl/Config-not-required.mdx
@@ -134,6 +134,6 @@
 
 - `disallow_public_ip` (bool) - DisallowPublicIPAddress - Indicates whether the virtual machine is to be created without a public IP address.
 
-- `sysprep_done` (bool) - SysPrepDone - Indicates whether SysPrep is to be requested to the DTL or has been already applied.
+- `skip_sysprep` (bool) - SkipSysprep - Indicates whether SysPrep is to be requested to the DTL or if it should be skipped because it has already been applied. Defaults to false.
 
 <!-- End of code generated from the comments of the Config struct in builder/azure/dtl/config.go; -->


### PR DESCRIPTION
Sometimes, on win images, sysprep does not work as expected. The recommendation then is to perform the sysprep manually (removing the agent extensions, then calling sysprep, etc.), in which case packer can skip the sysprep. This PR provides that functionality and also performs some small refactoring to make the azure-arm and azure-dtl builders more alike.