### PR TITLE
Fix mistyped builder in website's documentation

### DIFF
--- a/docs/builders/arm.mdx
+++ b/docs/builders/arm.mdx
@@ -171,7 +171,7 @@ Usage example:
 // won't be easily resolvable until legacy json templates are deprecated:
 
 {
-source "amazon-arm" "basic-example" {
+source "azure-arm" "basic-example" {
   os_type = "Linux"
   image_publisher = "Canonical"
   image_offer = "UbuntuServer"


### PR DESCRIPTION
There is a mistyped type for builder type in the documentation. It says the builder type is "amazon-arm" instead of "azure-arm"

This is my first pull request and I'm making it via GitHub's _Propose changes_ tool so I hope this pull request will be up to standards.