### PR TITLE
Removed Shared Image Gallery values from generated_data

### DIFF
--- a/builder/azure/arm/artifact.go
+++ b/builder/azure/arm/artifact.go
@@ -273,9 +273,6 @@ func (a *Artifact) hcpPackerRegistryMetadata() *registryimage.Image {
 		labels["managed_image_name"] = a.ManagedImageName
 
 		if a.ManagedImageSharedImageGalleryId != "" {
-			//subscription := a.State(constants.ArmManagedImageSubscription).(string)
-			//storageAccountType := state.Get(constants.ArmManagedImageSharedGalleryImageVersionStorageAccountType).(string)
-
 			labels["sig_resource_group"] = a.State(constants.ArmManagedImageSigPublishResourceGroup).(string)
 			labels["sig_name"] = a.State(constants.ArmManagedImageSharedGalleryName).(string)
 			labels["sig_image_name"] = a.State(constants.ArmManagedImageSharedGalleryImageName).(string)

--- a/builder/azure/arm/artifact.go
+++ b/builder/azure/arm/artifact.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/constants"
 	registryimage "github.com/hashicorp/packer-plugin-sdk/packer/registry/image"
 )
 
@@ -272,12 +273,14 @@ func (a *Artifact) hcpPackerRegistryMetadata() *registryimage.Image {
 		labels["managed_image_name"] = a.ManagedImageName
 
 		if a.ManagedImageSharedImageGalleryId != "" {
-			labels["sig_name"] = generatedData["SharedImageGalleryName"]
-			labels["sig_resource_group"] = generatedData["SharedImageGalleryResourceGroup"]
-			labels["sig_image_name"] = generatedData["SharedImageGalleryImageName"]
-			labels["sig_image_version"] = generatedData["SharedImageGalleryImageVersion"]
+			//subscription := a.State(constants.ArmManagedImageSubscription).(string)
+			//storageAccountType := state.Get(constants.ArmManagedImageSharedGalleryImageVersionStorageAccountType).(string)
 
-			if rr, ok := generatedData["SharedImageGalleryReplicationRegions"].([]string); ok {
+			labels["sig_resource_group"] = a.State(constants.ArmManagedImageSigPublishResourceGroup).(string)
+			labels["sig_name"] = a.State(constants.ArmManagedImageSharedGalleryName).(string)
+			labels["sig_image_name"] = a.State(constants.ArmManagedImageSharedGalleryImageName).(string)
+			labels["sig_image_version"] = a.State(constants.ArmManagedImageSharedGalleryImageVersion).(string)
+			if rr, ok := a.State(constants.ArmManagedImageSharedGalleryReplicationRegions).([]string); ok {
 				labels["sig_replicated_regions"] = strings.Join(rr, ", ")
 			}
 		}

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -511,11 +511,21 @@ func normalizeAzureRegion(name string) string {
 
 func (b *Builder) managedImageArtifactWithSIGAsDestination(managedImageID string, stateData map[string]interface{}) (*Artifact, error) {
 
-	stateData[constants.ArmManagedImageSigPublishResourceGroup] = b.stateBag.Get(constants.ArmManagedImageSigPublishResourceGroup).(string)
-	stateData[constants.ArmManagedImageSharedGalleryName] = b.stateBag.Get(constants.ArmManagedImageSharedGalleryName).(string)
-	stateData[constants.ArmManagedImageSharedGalleryImageName] = b.stateBag.Get(constants.ArmManagedImageSharedGalleryImageName).(string)
-	stateData[constants.ArmManagedImageSharedGalleryImageVersion] = b.stateBag.Get(constants.ArmManagedImageSharedGalleryImageVersion).(string)
-	stateData[constants.ArmManagedImageSharedGalleryReplicationRegions] = b.stateBag.Get(constants.ArmManagedImageSharedGalleryReplicationRegions).([]string)
+	sigDestinationStateKeys := []string{
+		constants.ArmManagedImageSigPublishResourceGroup,
+		constants.ArmManagedImageSharedGalleryName,
+		constants.ArmManagedImageSharedGalleryImageName,
+		constants.ArmManagedImageSharedGalleryImageVersion,
+		constants.ArmManagedImageSharedGalleryReplicationRegions,
+	}
+
+	for _, key := range sigDestinationStateKeys {
+		v, ok := b.stateBag.GetOk(key)
+		if !ok {
+			continue
+		}
+		stateData[key] = v
+	}
 
 	return NewManagedImageArtifactWithSIGAsDestination(b.config.OSType,
 		b.config.ManagedImageResourceGroupName,

--- a/builder/azure/arm/step_publish_to_shared_image_gallery.go
+++ b/builder/azure/arm/step_publish_to_shared_image_gallery.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/constants"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
-	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
 )
 
 type StepPublishToSharedImageGallery struct {
@@ -185,13 +184,6 @@ func (s *StepPublishToSharedImageGallery) Run(ctx context.Context, stateBag mult
 
 		return multistep.ActionHalt
 	}
-
-	generatedData := packerbuilderdata.GeneratedData{State: stateBag}
-	generatedData.Put("SharedImageGalleryName", sharedImageGallery.SigDestinationGalleryName)
-	generatedData.Put("SharedImageGalleryImageName", sharedImageGallery.SigDestinationImageName)
-	generatedData.Put("SharedImageGalleryImageVersion", sharedImageGallery.SigDestinationImageVersion)
-	generatedData.Put("SharedImageGalleryResourceGroup", sharedImageGallery.SigDestinationResourceGroup)
-	generatedData.Put("SharedImageGalleryReplicationRegions", sharedImageGallery.SigDestinationReplicationRegions)
 
 	stateBag.Put(constants.ArmManagedImageSharedGalleryId, createdGalleryImageVersionID)
 	return multistep.ActionContinue


### PR DESCRIPTION
This change removes the duplicated shared image gallery data used in the Artifact, and now relies on the state data that gets set during the publish to SIG destination step.

The changes use the provided constants to ensure the correct data is being read from state. In addition to the constants a new method was added to the builder for ensuring that the SIG Artifact is generated consistently at the end of a build.


Closes #168

<details>
<summary>Validated fix for #168 using the following template </summary>

```hcl

variable "resource_group_name" {
  type    = string
  default = ""
}

variable "subscription_id" {
  type    = string
  default = ""
}

source "azure-arm" "autogenerated_1" {
  azure_tags = {
    dept = "Engineering"
    task = "Image deployment"
  }
  image_offer                       = "UbuntuServer"
  image_publisher                   = "Canonical"
  image_sku                         = "16.04-LTS"
  location                          = "East US"
  managed_image_name                = "PackerImage-6"
  managed_image_resource_group_name = "${var.resource_group_name}"
  os_type                           = "Linux"
  shared_image_gallery_destination {
    gallery_name        = "PackerTestGallery"
    image_name          = "packer-test"
    image_version       = "0.0.6"
    replication_regions = ["South Central US"]
    resource_group      = "${var.resource_group_name}"
  }
  subscription_id = "${var.subscription_id}"
  vm_size         = "Standard_DS2_v2"
}

build {
  sources = ["source.azure-arm.autogenerated_1"]

  provisioner "shell-local" {
    inline = [
    "echo ${build.SourceImageName}",
    ]
  }

  post-processor "manifest" {
  }
}
```

Results of build
```
==> Wait completed after 11 minutes 27 seconds

==> Builds finished. The artifacts of successful builds are:
--> azure-arm.autogenerated_1: Azure.ResourceManagement.VMImage:

OSType: Linux
ManagedImageResourceGroupName: ....
ManagedImageName: PackerImage-6
ManagedImageId: /subscriptions/...../resourceGroups/...../providers/Microsoft.Compute/images/PackerImage-6
ManagedImageLocation: East US
ManagedImageSharedImageGalleryId: /subscriptions/...../resourceGroups/..../providers/Microsoft.Compute/galleries/PackerTestGallery/images/packer-test/versions/0.0.6
```

</details>

