### PR TITLE
Add support for running the chroot builder from a VM scale set

### DIFF
--- a/builder/azure/chroot/diskattacher.go
+++ b/builder/azure/chroot/diskattacher.go
@@ -15,9 +15,9 @@ import (
 )
 
 type DiskAttacher interface {
-	AttachDisk(ctx context.Context, disk string) (lun int32, err error)
+	AttachDisk(ctx context.Context, state multistep.StateBag, disk string) (lun int32, err error)
 	WaitForDevice(ctx context.Context, i int32) (device string, err error)
-	DetachDisk(ctx context.Context, disk string) (err error)
+	DetachDisk(ctx context.Context, state multistep.StateBag, disk string) (err error)
 	WaitForDetach(ctx context.Context, diskID string) error
 }
 

--- a/builder/azure/chroot/diskattacher_test.go
+++ b/builder/azure/chroot/diskattacher_test.go
@@ -30,10 +30,6 @@ func Test_DiskAttacherAttachesDiskToVM(t *testing.T) {
 		ErrorWriter: errorBuffer,
 	}
 
-	state := new(multistep.BasicStateBag)
-	state.Put("azureclient", azcli)
-	state.Put("ui", ui)
-
 	da := NewDiskAttacher(azcli, ui)
 
 	vm, err := azcli.MetadataClient().GetComputeInfo()

--- a/builder/azure/chroot/diskattacher_test.go
+++ b/builder/azure/chroot/diskattacher_test.go
@@ -21,7 +21,6 @@ import (
 func Test_DiskAttacherAttachesDiskToVM(t *testing.T) {
 	azcli, err := client.GetTestClientSet(t) // integration test
 	require.Nil(t, err)
-	da := NewDiskAttacher(azcli)
 	testDiskName := t.Name()
 
 	errorBuffer := &strings.Builder{}
@@ -35,6 +34,8 @@ func Test_DiskAttacherAttachesDiskToVM(t *testing.T) {
 	state.Put("azureclient", azcli)
 	state.Put("ui", ui)
 
+	da := NewDiskAttacher(azcli, ui)
+
 	vm, err := azcli.MetadataClient().GetComputeInfo()
 	require.Nil(t, err, "Test needs to run on an Azure VM, unable to retrieve VM information")
 	t.Log("Creating new disk '", testDiskName, "' in ", vm.ResourceGroupName)
@@ -44,7 +45,7 @@ func Test_DiskAttacherAttachesDiskToVM(t *testing.T) {
 		t.Log("Disk already exists")
 		if disk.DiskState == compute.Attached {
 			t.Log("Disk is attached, assuming to this machine, trying to detach")
-			err = da.DetachDisk(context.TODO(), state, to.String(disk.ID))
+			err = da.DetachDisk(context.TODO(), to.String(disk.ID))
 			require.Nil(t, err)
 		}
 		t.Log("Deleting disk")
@@ -75,7 +76,7 @@ func Test_DiskAttacherAttachesDiskToVM(t *testing.T) {
 	assert.NotNil(t, d)
 
 	t.Log("Attaching disk")
-	lun, err := da.AttachDisk(context.TODO(), state, to.String(d.ID))
+	lun, err := da.AttachDisk(context.TODO(), to.String(d.ID))
 	assert.Nil(t, err)
 
 	t.Log("Waiting for device")
@@ -85,7 +86,7 @@ func Test_DiskAttacherAttachesDiskToVM(t *testing.T) {
 	t.Log("Device path:", dev)
 
 	t.Log("Detaching disk")
-	err = da.DetachDisk(context.TODO(), state, to.String(d.ID))
+	err = da.DetachDisk(context.TODO(), to.String(d.ID))
 	require.Nil(t, err)
 
 	t.Log("Deleting disk")

--- a/builder/azure/chroot/diskattacher_test.go
+++ b/builder/azure/chroot/diskattacher_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-12-01/compute"
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/client"
-	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/builder/azure/chroot/step_attach_disk.go
+++ b/builder/azure/chroot/step_attach_disk.go
@@ -25,8 +25,8 @@ func (s *StepAttachDisk) Run(ctx context.Context, state multistep.StateBag) mult
 
 	ui.Say(fmt.Sprintf("Attaching disk '%s'", diskResourceID))
 
-	da := NewDiskAttacher(azcli)
-	lun, err := da.AttachDisk(ctx, state, diskResourceID)
+	da := NewDiskAttacher(azcli, ui)
+	lun, err := da.AttachDisk(ctx, diskResourceID)
 	if err != nil {
 		log.Printf("StepAttachDisk.Run: error: %+v", err)
 		err := fmt.Errorf(
@@ -73,8 +73,8 @@ func (s *StepAttachDisk) CleanupFunc(state multistep.StateBag) error {
 
 		ui.Say(fmt.Sprintf("Detaching disk '%s'", diskResourceID))
 
-		da := NewDiskAttacher(azcli)
-		err := da.DetachDisk(context.Background(), state, diskResourceID)
+		da := NewDiskAttacher(azcli, ui)
+		err := da.DetachDisk(context.Background(), diskResourceID)
 		if err != nil {
 			return fmt.Errorf("error detaching %q: %v", diskResourceID, err)
 		}

--- a/builder/azure/chroot/step_attach_disk.go
+++ b/builder/azure/chroot/step_attach_disk.go
@@ -26,7 +26,7 @@ func (s *StepAttachDisk) Run(ctx context.Context, state multistep.StateBag) mult
 	ui.Say(fmt.Sprintf("Attaching disk '%s'", diskResourceID))
 
 	da := NewDiskAttacher(azcli)
-	lun, err := da.AttachDisk(ctx, diskResourceID)
+	lun, err := da.AttachDisk(ctx, state, diskResourceID)
 	if err != nil {
 		log.Printf("StepAttachDisk.Run: error: %+v", err)
 		err := fmt.Errorf(
@@ -74,7 +74,7 @@ func (s *StepAttachDisk) CleanupFunc(state multistep.StateBag) error {
 		ui.Say(fmt.Sprintf("Detaching disk '%s'", diskResourceID))
 
 		da := NewDiskAttacher(azcli)
-		err := da.DetachDisk(context.Background(), diskResourceID)
+		err := da.DetachDisk(context.Background(), state, diskResourceID)
 		if err != nil {
 			return fmt.Errorf("error detaching %q: %v", diskResourceID, err)
 		}

--- a/builder/azure/chroot/step_attach_disk_test.go
+++ b/builder/azure/chroot/step_attach_disk_test.go
@@ -101,7 +101,7 @@ type fakeDiskAttacher struct {
 
 var _ DiskAttacher = &fakeDiskAttacher{}
 
-func (da *fakeDiskAttacher) AttachDisk(ctx context.Context, disk string) (lun int32, err error) {
+func (da *fakeDiskAttacher) AttachDisk(ctx context.Context, state multistep.StateBag, disk string) (lun int32, err error) {
 	if da.attachError != nil {
 		return 0, da.attachError
 	}
@@ -122,7 +122,7 @@ func (da *fakeDiskAttacher) WaitForDevice(ctx context.Context, lun int32) (devic
 	panic("expected lun==3")
 }
 
-func (da *fakeDiskAttacher) DetachDisk(ctx context.Context, disk string) (err error) {
+func (da *fakeDiskAttacher) DetachDisk(ctx context.Context, state multistep.StateBag, disk string) (err error) {
 	panic("not implemented")
 }
 

--- a/builder/azure/chroot/step_create_new_diskset.go
+++ b/builder/azure/chroot/step_create_new_diskset.go
@@ -221,7 +221,7 @@ func (s *StepCreateNewDiskset) Cleanup(state multistep.StateBag) {
 		for _, d := range s.disks {
 
 			ui.Say(fmt.Sprintf("Waiting for disk %q detach to complete", d))
-			err := NewDiskAttacher(azcli).WaitForDetach(context.Background(), d.String())
+			err := NewDiskAttacher(azcli, ui).WaitForDetach(context.Background(), d.String())
 			if err != nil {
 				ui.Error(fmt.Sprintf("error detaching disk %q: %s", d, err))
 			}

--- a/builder/azure/chroot/step_mount_device.go
+++ b/builder/azure/chroot/step_mount_device.go
@@ -125,7 +125,7 @@ func (s *StepMountDevice) CleanupFunc(state multistep.StateBag) error {
 	wrappedCommand := state.Get("wrappedCommand").(common.CommandWrapper)
 
 	ui.Say("Unmounting the root device...")
-	unmountCommand, err := wrappedCommand(fmt.Sprintf("umount %s", s.mountPath))
+	unmountCommand, err := wrappedCommand(fmt.Sprintf("umount -R %s", s.mountPath))
 	if err != nil {
 		return fmt.Errorf("error creating unmount command: %s", err)
 	}

--- a/builder/azure/chroot/template_funcs.go
+++ b/builder/azure/chroot/template_funcs.go
@@ -29,7 +29,7 @@ func CreateVMMetadataTemplateFunc() func(string) (string, error) {
 		case "location":
 			return data.Location, nil
 		case "resource_id":
-			return data.ResourceID(), nil
+			return data.GetResourceID(), nil
 		default:
 			return "", fmt.Errorf("unknown metadata key: %s (supported: name, subscription_id, resource_group, location, resource_id)", key)
 		}

--- a/builder/azure/common/client/azure_client_set.go
+++ b/builder/azure/common/client/azure_client_set.go
@@ -25,6 +25,7 @@ type AzureClientSet interface {
 
 	VirtualMachinesClient() computeapi.VirtualMachinesClientAPI
 	VirtualMachineImagesClient() VirtualMachineImagesClientAPI
+	VirtualMachineScaleSetVMsClient() computeapi.VirtualMachineScaleSetVMsClientAPI
 
 	PollClient() autorest.Client
 
@@ -101,6 +102,13 @@ func (s azureClientSet) ImagesClient() computeapi.ImagesClientAPI {
 
 func (s azureClientSet) VirtualMachinesClient() computeapi.VirtualMachinesClientAPI {
 	c := compute.NewVirtualMachinesClient(s.subscriptionID)
+	s.configureAutorestClient(&c.Client)
+	c.PollingDelay = s.PollingDelay
+	return c
+}
+
+func (s azureClientSet) VirtualMachineScaleSetVMsClient() computeapi.VirtualMachineScaleSetVMsClientAPI {
+	c := compute.NewVirtualMachineScaleSetVMsClient(s.subscriptionID)
 	s.configureAutorestClient(&c.Client)
 	c.PollingDelay = s.PollingDelay
 	return c

--- a/builder/azure/common/client/azure_client_set_mock.go
+++ b/builder/azure/common/client/azure_client_set_mock.go
@@ -9,16 +9,17 @@ var _ AzureClientSet = &AzureClientSetMock{}
 
 // AzureClientSetMock provides a generic mock for AzureClientSet
 type AzureClientSetMock struct {
-	DisksClientMock                computeapi.DisksClientAPI
-	SnapshotsClientMock            computeapi.SnapshotsClientAPI
-	ImagesClientMock               computeapi.ImagesClientAPI
-	VirtualMachineImagesClientMock VirtualMachineImagesClientAPI
-	VirtualMachinesClientMock      computeapi.VirtualMachinesClientAPI
-	GalleryImagesClientMock        computeapi.GalleryImagesClientAPI
-	GalleryImageVersionsClientMock computeapi.GalleryImageVersionsClientAPI
-	PollClientMock                 autorest.Client
-	MetadataClientMock             MetadataClientAPI
-	SubscriptionIDMock             string
+	DisksClientMock                     computeapi.DisksClientAPI
+	SnapshotsClientMock                 computeapi.SnapshotsClientAPI
+	ImagesClientMock                    computeapi.ImagesClientAPI
+	VirtualMachineImagesClientMock      VirtualMachineImagesClientAPI
+	VirtualMachinesClientMock           computeapi.VirtualMachinesClientAPI
+	VirtualMachineScaleSetVMsClientMock computeapi.VirtualMachineScaleSetVMsClientAPI
+	GalleryImagesClientMock             computeapi.GalleryImagesClientAPI
+	GalleryImageVersionsClientMock      computeapi.GalleryImageVersionsClientAPI
+	PollClientMock                      autorest.Client
+	MetadataClientMock                  MetadataClientAPI
+	SubscriptionIDMock                  string
 }
 
 // DisksClient returns a DisksClientAPI
@@ -44,6 +45,11 @@ func (m *AzureClientSetMock) VirtualMachineImagesClient() VirtualMachineImagesCl
 // VirtualMachinesClient returns a VirtualMachinesClientAPI
 func (m *AzureClientSetMock) VirtualMachinesClient() computeapi.VirtualMachinesClientAPI {
 	return m.VirtualMachinesClientMock
+}
+
+// VirtualMachineScaleSetVMsClient returns a VirtualMachineScaleSetVMsClientAPI
+func (m *AzureClientSetMock) VirtualMachineScaleSetVMsClient() computeapi.VirtualMachineScaleSetVMsClientAPI {
+	return m.VirtualMachineScaleSetVMsClientMock
 }
 
 // GalleryImagesClient returns a GalleryImagesClientAPI

--- a/builder/azure/common/client/metadata.go
+++ b/builder/azure/common/client/metadata.go
@@ -30,9 +30,11 @@ func (s MetadataClientStub) GetComputeInfo() (*ComputeInfo, error) {
 // ComputeInfo defines the Azure VM metadata that is used in Packer
 type ComputeInfo struct {
 	Name              string
+	ResourceID        string
 	ResourceGroupName string
 	SubscriptionID    string
 	Location          string
+	VmScaleSetName    string
 }
 
 // metadataClient implements MetadataClient
@@ -43,7 +45,7 @@ type metadataClient struct {
 
 var _ MetadataClientAPI = metadataClient{}
 
-const imdsURL = "http://169.254.169.254/metadata/instance?api-version=2017-08-01"
+const imdsURL = "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
 
 // VMResourceID returns the resource ID of the current VM
 func (client metadataClient) GetComputeInfo() (*ComputeInfo, error) {
@@ -78,12 +80,8 @@ func (client metadataClient) GetComputeInfo() (*ComputeInfo, error) {
 	return &vminfo.ComputeInfo, nil
 }
 
-func (ci ComputeInfo) ResourceID() string {
-	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/%s",
-		ci.SubscriptionID,
-		ci.ResourceGroupName,
-		ci.Name,
-	)
+func (ci ComputeInfo) GetResourceID() string {
+	return fmt.Sprintf("/%s", ci.ResourceID)
 }
 
 // NewMetadataClient creates a new instance metadata client


### PR DESCRIPTION
### Description

With the current implementation it is impossible to build VM images from a VM scale set machine using the chroot builder. The following PR adds support for VM scale set virtual machines by making use of the `VirtualMachineScaleSetVMsClient`. The original request for this functionality can be found here: https://github.com/hashicorp/packer/issues/9348, which is identical to our own use case.

### Changes in detail

The following changes have been made:
* Adding the `VirtualMachineScaleSetVMsClient`
* Adding helper functions to: get VM details, get VM disks, set VM disks using the new client
* The existing logic will fall back to the new implementation in case of errors - it will first try to get details as if running from a standalone VM and if any of these calls fail, it will use the `VirtualMachineScaleSetVMsClient` to retry and continue with the rest of the logic.
* Fix unmounting of filesystem on success - multiple filesystem mountpoints are initially mounted under the same location which was causing issues with the final cleanup step. The unmount is now done recursively which solves this issue (see [-R, --recursive](https://man7.org/linux/man-pages/man8/umount.8.html) from the official manual pages). Recursion for each directory will stop if any unmount operation in the chain fails for any reason (and thus preserving the same behavior).

### Risks associated with the changes

**No risks** - there is no negative effect on the existing implementation. We are already using the changes in anger and we haven't discovered any issues.

### Related open issue(s):

Closes [#9348](https://github.com/hashicorp/packer/issues/9348)

