### PR TITLE
feat: support skipping image creation

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -231,8 +231,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			NewStepPowerOffCompute(azureClient, ui),
 			NewStepSnapshotOSDisk(azureClient, ui, &b.config),
 			NewStepSnapshotDataDisks(azureClient, ui, &b.config),
-			NewStepCaptureImage(azureClient, ui),
-			NewStepPublishToSharedImageGallery(azureClient, ui, &b.config),
 		}
 	} else if b.config.OSType == constants.Target_Windows {
 		steps = []multistep.Step{
@@ -278,12 +276,18 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			NewStepPowerOffCompute(azureClient, ui),
 			NewStepSnapshotOSDisk(azureClient, ui, &b.config),
 			NewStepSnapshotDataDisks(azureClient, ui, &b.config),
-			NewStepCaptureImage(azureClient, ui),
-			NewStepPublishToSharedImageGallery(azureClient, ui, &b.config),
 		)
 	} else {
 		return nil, fmt.Errorf("Builder does not support the os_type '%s'", b.config.OSType)
 	}
+
+	captureSteps := b.config.CaptureSteps(
+		ui.Say,
+		NewStepCaptureImage(azureClient, ui),
+		NewStepPublishToSharedImageGallery(azureClient, ui, &b.config),
+	)
+
+	steps = append(steps, captureSteps...)
 
 	if b.config.PackerDebug {
 		ui.Message(fmt.Sprintf("temp admin user: '%s'", b.config.UserName))

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -103,6 +103,8 @@ type SharedImageGalleryDestination struct {
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
+	azcommon.Config `mapstructure:",squash"`
+
 	// Authentication via OAUTH
 	ClientConfig client.Config `mapstructure:",squash"`
 

--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -19,6 +19,7 @@ type FlatConfig struct {
 	PackerOnError                              *string                            `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars                             map[string]string                  `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars                        []string                           `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
+	SkipCreateImage                            *bool                              `mapstructure:"skip_create_image" required:"false" cty:"skip_create_image" hcl:"skip_create_image"`
 	CloudEnvironmentName                       *string                            `mapstructure:"cloud_environment_name" required:"false" cty:"cloud_environment_name" hcl:"cloud_environment_name"`
 	MetadataHost                               *string                            `mapstructure:"metadata_host" required:"false" cty:"metadata_host" hcl:"metadata_host"`
 	ClientID                                   *string                            `mapstructure:"client_id" cty:"client_id" hcl:"client_id"`
@@ -153,6 +154,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_on_error":                                  &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},
 		"packer_user_variables":                            &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables":                       &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
+		"skip_create_image":                                &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},
 		"cloud_environment_name":                           &hcldec.AttrSpec{Name: "cloud_environment_name", Type: cty.String, Required: false},
 		"metadata_host":                                    &hcldec.AttrSpec{Name: "metadata_host", Type: cty.String, Required: false},
 		"client_id":                                        &hcldec.AttrSpec{Name: "client_id", Type: cty.String, Required: false},

--- a/builder/azure/chroot/builder.hcl2spec.go
+++ b/builder/azure/chroot/builder.hcl2spec.go
@@ -18,6 +18,7 @@ type FlatConfig struct {
 	PackerOnError                     *string                            `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars                    map[string]string                  `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars               []string                           `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
+	SkipCreateImage                   *bool                              `mapstructure:"skip_create_image" required:"false" cty:"skip_create_image" hcl:"skip_create_image"`
 	CloudEnvironmentName              *string                            `mapstructure:"cloud_environment_name" required:"false" cty:"cloud_environment_name" hcl:"cloud_environment_name"`
 	MetadataHost                      *string                            `mapstructure:"metadata_host" required:"false" cty:"metadata_host" hcl:"metadata_host"`
 	ClientID                          *string                            `mapstructure:"client_id" cty:"client_id" hcl:"client_id"`
@@ -74,6 +75,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_on_error":                 &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},
 		"packer_user_variables":           &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables":      &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
+		"skip_create_image":               &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},
 		"cloud_environment_name":          &hcldec.AttrSpec{Name: "cloud_environment_name", Type: cty.String, Required: false},
 		"metadata_host":                   &hcldec.AttrSpec{Name: "metadata_host", Type: cty.String, Required: false},
 		"client_id":                       &hcldec.AttrSpec{Name: "client_id", Type: cty.String, Required: false},

--- a/builder/azure/chroot/builder_test.go
+++ b/builder/azure/chroot/builder_test.go
@@ -226,7 +226,7 @@ func Test_buildsteps(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			withMetadataStub(func() { // ensure that values are taken from info, instead of retrieved again
-				got := buildsteps(tt.config, info, &packerbuilderdata.GeneratedData{})
+				got := buildsteps(tt.config, info, &packerbuilderdata.GeneratedData{}, func(string) {})
 				tt.verify(got, t)
 			})
 		})

--- a/builder/azure/common/config.go
+++ b/builder/azure/common/config.go
@@ -1,0 +1,33 @@
+//go:generate packer-sdc struct-markdown
+
+package common
+
+import (
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+)
+
+const (
+	SkippingImageCreation = "Skipping image creation..."
+)
+
+type Config struct {
+	// Skip creating the image.
+	// Useful for setting to `true` during a build test stage.
+	// Defaults to `false`.
+	SkipCreateImage bool `mapstructure:"skip_create_image" required:"false"`
+}
+
+// CaptureSteps returns the steps unless `SkipCreateImage` is `true`. In that case it returns
+// a step that to inform the user that image capture is being skipped.
+func (config Config) CaptureSteps(say func(string), steps ...multistep.Step) []multistep.Step {
+	if !config.SkipCreateImage {
+		return steps
+	}
+
+	return []multistep.Step{
+		&StepNotify{
+			message: SkippingImageCreation,
+			say:     say,
+		},
+	}
+}

--- a/builder/azure/common/config_test.go
+++ b/builder/azure/common/config_test.go
@@ -1,0 +1,44 @@
+package common_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/packer-plugin-azure/builder/azure/common"
+)
+
+func TestSkipCreateImage(t *testing.T) {
+	var said []string
+
+	say := func(what string) {
+		said = append(said, what)
+	}
+
+	config := common.Config{}
+	message := "Capture Image"
+
+	steps := config.CaptureSteps(say, common.NewStepNotify(message, say))
+	state := &multistep.BasicStateBag{}
+
+	ctx := context.Background()
+
+	for _, step := range steps {
+		step.Run(ctx, state)
+	}
+
+	assert.Equal(t, said, []string{message})
+
+	said = nil
+	config.SkipCreateImage = true
+
+	steps = config.CaptureSteps(say, common.NewStepNotify(message, say))
+
+	for _, step := range steps {
+		step.Run(ctx, state)
+	}
+
+	assert.Equal(t, said, []string{common.SkippingImageCreation})
+}

--- a/builder/azure/common/step_notify.go
+++ b/builder/azure/common/step_notify.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"context"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+)
+
+type StepNotify struct {
+	message string
+	say     func(string)
+}
+
+func NewStepNotify(message string, say func(string)) *StepNotify {
+	return &StepNotify{
+		message: message,
+		say:     say,
+	}
+}
+
+func (step *StepNotify) Run(
+	ctx context.Context,
+	state multistep.StateBag,
+) multistep.StepAction {
+	step.say(step.message)
+	return multistep.ActionContinue
+}
+
+func (step *StepNotify) Cleanup(state multistep.StateBag) {}
+
+var _ multistep.Step = (*StepNotify)(nil)

--- a/builder/azure/common/step_notify_test.go
+++ b/builder/azure/common/step_notify_test.go
@@ -1,0 +1,30 @@
+package common_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/hashicorp/packer-plugin-azure/builder/azure/common"
+)
+
+func TestStepNotify(t *testing.T) {
+	var said []string
+
+	say := func(what string) {
+		said = append(said, what)
+	}
+
+	message := "Notify Step"
+
+	step := common.NewStepNotify(message, say)
+	state := &multistep.BasicStateBag{}
+
+	ctx := context.Background()
+
+	step.Run(ctx, state)
+
+	assert.Equal(t, said, []string{message})
+}

--- a/builder/azure/dtl/config.go
+++ b/builder/azure/dtl/config.go
@@ -98,6 +98,8 @@ type ArtifactParameter struct {
 type Config struct {
 	common.PackerConfig `mapstructure:",squash"`
 
+	azcommon.Config `mapstructure:",squash"`
+
 	// Authentication via OAUTH
 	ClientConfig client.Config `mapstructure:",squash"`
 

--- a/builder/azure/dtl/config.hcl2spec.go
+++ b/builder/azure/dtl/config.hcl2spec.go
@@ -45,6 +45,7 @@ type FlatConfig struct {
 	PackerOnError                       *string                            `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars                      map[string]string                  `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars                 []string                           `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
+	SkipCreateImage                     *bool                              `mapstructure:"skip_create_image" required:"false" cty:"skip_create_image" hcl:"skip_create_image"`
 	CloudEnvironmentName                *string                            `mapstructure:"cloud_environment_name" required:"false" cty:"cloud_environment_name" hcl:"cloud_environment_name"`
 	MetadataHost                        *string                            `mapstructure:"metadata_host" required:"false" cty:"metadata_host" hcl:"metadata_host"`
 	ClientID                            *string                            `mapstructure:"client_id" cty:"client_id" hcl:"client_id"`
@@ -162,6 +163,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_on_error":                          &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},
 		"packer_user_variables":                    &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables":               &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
+		"skip_create_image":                        &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},
 		"cloud_environment_name":                   &hcldec.AttrSpec{Name: "cloud_environment_name", Type: cty.String, Required: false},
 		"metadata_host":                            &hcldec.AttrSpec{Name: "metadata_host", Type: cty.String, Required: false},
 		"client_id":                                &hcldec.AttrSpec{Name: "client_id", Type: cty.String, Required: false},

--- a/docs-partials/builder/azure/common/Config-not-required.mdx
+++ b/docs-partials/builder/azure/common/Config-not-required.mdx
@@ -1,0 +1,7 @@
+<!-- Code generated from the comments of the Config struct in builder/azure/common/config.go; DO NOT EDIT MANUALLY -->
+
+- `skip_create_image` (bool) - Skip creating the image.
+  Useful for setting to `true` during a build test stage.
+  Defaults to `false`.
+
+<!-- End of code generated from the comments of the Config struct in builder/azure/common/config.go; -->

--- a/docs/builders/arm.mdx
+++ b/docs/builders/arm.mdx
@@ -150,6 +150,8 @@ Providing `temp_resource_group_name` or `location` in combination with
 
 @include 'builder/azure/common/client/Config-not-required.mdx'
 
+@include 'builder/azure/common/Config-not-required.mdx'
+
 ## Build Shared Information Variables
 
 This builder generates data that are shared with provisioner and post-processor via build function of [template engine](https://packer.io/docs/templates/legacy_json_templates/engine) for JSON and [contextual variables](https://packer.io/docs/templates/hcl_templates/contextual-variables) for HCL2.

--- a/docs/builders/chroot.mdx
+++ b/docs/builders/chroot.mdx
@@ -70,6 +70,8 @@ information.
 
 @include 'builder/azure/chroot/Config-not-required.mdx'
 
+@include 'builder/azure/common/Config-not-required.mdx'
+
 #### Output options:
 
 At least one of these options needs to be specified:

--- a/docs/builders/dtl.mdx
+++ b/docs/builders/dtl.mdx
@@ -69,6 +69,8 @@ you should specify `subscription_id`, `client_id` and one of `client_secret`,
 
 @include 'builder/azure/dtl/Config-not-required.mdx'
 
+@include 'builder/azure/common/Config-not-required.mdx'
+
 #### DtlArtifact
 @include 'provisioner/azure-dtlartifact/DtlArtifact-not-required.mdx'
 


### PR DESCRIPTION
Adds the config option `skip_create_image` to the builders to support
skipping image creation.

Fixes: #180

