### PR TITLE
Add acceptance test to validate fix for rsa-sha2 only servers

### DIFF
--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -22,6 +22,7 @@ package arm
 import (
 	"bytes"
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -231,6 +232,28 @@ func TestBuilderUserData_Linux(t *testing.T) {
 		Name:     "test-azure-userdata-linux",
 		Type:     "azure-arm",
 		Template: testBuilderUserDataLinux(tmpfile.Name()),
+		Check: func(buildCommand *exec.Cmd, logfile string) error {
+			if buildCommand.ProcessState != nil {
+				if buildCommand.ProcessState.ExitCode() != 0 {
+					return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
+				}
+			}
+			return nil
+		},
+	})
+}
+
+//go:embed testdata/rsa_sha2_only_server.pkr.hcl
+var rsaSHA2OnlyTemplate []byte
+
+func TestBuilderAcc_rsaSHA2OnlyServer(t *testing.T) {
+	b := Builder{}
+	b.Prepare()
+
+	acctest.TestPlugin(t, &acctest.PluginTestCase{
+		Name:     "test-azure-ubuntu-jammy-linux",
+		Type:     "azure-arm",
+		Template: string(rsaSHA2OnlyTemplate),
 		Check: func(buildCommand *exec.Cmd, logfile string) error {
 			if buildCommand.ProcessState != nil {
 				if buildCommand.ProcessState.ExitCode() != 0 {

--- a/builder/azure/arm/testdata/rsa_sha2_only_server.pkr.hcl
+++ b/builder/azure/arm/testdata/rsa_sha2_only_server.pkr.hcl
@@ -1,0 +1,40 @@
+/*
+OpenSSH migrated the ssh-rsa key type, which historically used the ssh-rsa
+signature algorithm based on SHA-1, to the new rsa-sha2-256 and rsa-sha2-512 signature algorithms.
+Golang issues: https://github.com/golang/go/issues/49952
+See plugin issue: https://github.com/hashicorp/packer-plugin-azure/issues/191
+*/
+
+variables {
+  subscription_id = env("ARM_SUBSCRIPTION_ID")
+  client_id       = env("ARM_CLIENT_ID")
+  client_secret   = env("ARM_CLIENT_SECRET")
+  resource_group  = env("ARM_RESOURCE_GROUP_NAME")
+}
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "azure-arm" "ubuntu2204" {
+  subscription_id = var.subscription_id
+  client_id       = var.client_id
+
+  client_secret   = var.client_secret
+
+  managed_image_resource_group_name = var.resource_group
+  managed_image_name                = "ubuntu-jammay-server-test-${local.timestamp}"
+
+  os_type         = "Linux"
+  image_publisher = "canonical"
+  image_offer     = "0001-com-ubuntu-server-jammy-daily"
+  image_sku       = "22_04-daily-lts"
+
+  location = "West US2"
+  vm_size  = "Standard_DS2_v2"
+}
+
+build {
+  sources = ["source.azure-arm.ubuntu2204"]
+  provisioner "shell" {
+    inline          = ["uname -a"]
+  }
+}
+


### PR DESCRIPTION
- Bump github.com/hashicorp/packer-plugin-sdk with latest x/crypto/ssh fix
- Add acceptance test case for rsa-sha2 bug

Related to# https://github.com/hashicorp/packer-plugin-azure/issues/191

Acceptance test before patched SDK
```
> PACKER_ACC=1 go test -count=1 ./... -run=TestBuilderAcc_rsaSHA2OnlyServer
--- FAIL: TestBuilderAcc_rsaSHA2OnlyServer (317.97s)

2022/05/04 12:42:56 [INFO] (telemetry) ending azure-arm.ubuntu2204
2022/05/04 12:42:56 ui error: Build 'azure-arm.ubuntu2204' errored after 4 minutes 4 seconds: Packer experienced an authentication error when trying to connect via SSH. This can happen if your username/password are wrong. You may want to double-check your credentials as part of your debugging process. original error: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain
```

Acceptance test after patched SDK
```
~>  PACKER_ACC=1 go test -count=1 ./... -run=TestBuilderAcc_rsaSHA2OnlyServer
?       github.com/hashicorp/packer-plugin-azure        [no test files]
ok      github.com/hashicorp/packer-plugin-azure/builder/azure/arm      343.369s
ok      github.com/hashicorp/packer-plugin-azure/builder/azure/chroot   0.551s [no tests to run]
ok      github.com/hashicorp/packer-plugin-azure/builder/azure/common   1.376s [no tests to run]
ok      github.com/hashicorp/packer-plugin-azure/builder/azure/common/client    1.836s [no tests to run]
?       github.com/hashicorp/packer-plugin-azure/builder/azure/common/constants [no test files]
?       github.com/hashicorp/packer-plugin-azure/builder/azure/common/lin       [no test files]
?       github.com/hashicorp/packer-plugin-azure/builder/azure/common/logutil   [no test files]
ok      github.com/hashicorp/packer-plugin-azure/builder/azure/common/template  1.226s [no tests to run]
ok      github.com/hashicorp/packer-plugin-azure/builder/azure/dtl      0.619s [no tests to run]
ok      github.com/hashicorp/packer-plugin-azure/builder/azure/pkcs12   0.686s [no tests to run]
ok      github.com/hashicorp/packer-plugin-azure/builder/azure/pkcs12/rc2       0.204s [no tests to run]
?       github.com/hashicorp/packer-plugin-azure/provisioner/azure-dtlartifact  [no test files]
ok      github.com/hashicorp/packer-plugin-azure/version        0.779s [no tests to run]
 

OSType: Linux
ManagedImageResourceGroupName: packer-acceptance-test
ManagedImageName: ubuntu-jammay-server-test-20220504170249
```

