### PR TITLE
Address linter issues

### DIFF
--- a/builder/azure/arm/azure_error_response.go
+++ b/builder/azure/arm/azure_error_response.go
@@ -30,10 +30,6 @@ func (e *azureErrorDetails) isEmpty() bool {
 	return e.Code == ""
 }
 
-func (e *azureErrorResponse) isEmpty() bool {
-	return e.ErrorDetails.isEmpty()
-}
-
 func (e *azureErrorResponse) Error() string {
 	var buf bytes.Buffer
 	//buf.WriteString("-=-=- ERROR -=-=-")

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -847,7 +847,7 @@ func provideDefaultValues(c *Config) {
 		c.BuildKeyVaultSKU = DefaultKeyVaultSKU
 	}
 
-	c.ClientConfig.SetDefaultValues()
+	_ = c.ClientConfig.SetDefaultValues()
 }
 
 func assertTagProperties(c *Config, errs *packersdk.MultiError) {

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -173,8 +173,10 @@ func TestConfigShouldBeAbleToOverrideDefaultedValues(t *testing.T) {
 
 func TestConfigShouldDefaultVMSizeToStandardA1(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
-
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if c.VMSize != "Standard_A1" {
 		t.Errorf("Expected 'VMSize' to default to 'Standard_A1', but got '%s'.", c.VMSize)
 	}
@@ -182,8 +184,10 @@ func TestConfigShouldDefaultVMSizeToStandardA1(t *testing.T) {
 
 func TestConfigShouldDefaultImageVersionToLatest(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
-
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if c.ImageVersion != "latest" {
 		t.Errorf("Expected 'ImageVersion' to default to 'latest', but got '%s'.", c.ImageVersion)
 	}
@@ -203,7 +207,10 @@ func TestConfigShouldNotDefaultImageVersionIfCustomImage(t *testing.T) {
 	}
 
 	var c Config
-	c.Prepare(config, getPackerConfiguration())
+	_, err := c.Prepare(config, getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if c.ImageVersion != "" {
 		t.Errorf("Expected 'ImageVersion' to empty, but got '%s'.", c.ImageVersion)
 	}
@@ -292,7 +299,10 @@ func TestConfigVirtualNetworkNameIsOptional(t *testing.T) {
 	}
 
 	var c Config
-	c.Prepare(config, getPackerConfiguration())
+	_, err := c.Prepare(config, getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if c.VirtualNetworkName != "MyVirtualNetwork" {
 		t.Errorf("Expected Config to set virtual_network_name to MyVirtualNetwork, but got %q", c.VirtualNetworkName)
 	}
@@ -484,8 +494,10 @@ func TestConfigShouldRejectInboundIpAddressesWithVirtualNetwork(t *testing.T) {
 
 func TestConfigShouldDefaultToPublicCloud(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
-
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if c.ClientConfig.CloudEnvironmentName != "Public" {
 		t.Errorf("Expected 'CloudEnvironmentName' to default to 'Public', but got '%s'.", c.ClientConfig.CloudEnvironmentName)
 	}
@@ -576,8 +588,11 @@ func TestUserShouldProvideRequiredValues(t *testing.T) {
 
 func TestSystemShouldDefineRuntimeValues(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
 
+	if err != nil {
+		t.Fatal(err)
+	}
 	if c.Password == "" {
 		t.Errorf("Expected Password to not be empty, but it was '%s'!", c.Password)
 	}
@@ -609,7 +624,10 @@ func TestSystemShouldDefineRuntimeValues(t *testing.T) {
 
 func TestConfigShouldTransformToVirtualMachineCaptureParameters(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	parameters := c.toVirtualMachineCaptureParameters()
 
 	if *parameters.DestinationContainerName != c.CaptureContainerName {
@@ -1654,7 +1672,10 @@ func TestConfigShouldRejectManagedDiskNames(t *testing.T) {
 
 func TestConfigAdditionalDiskDefaultIsNil(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if c.AdditionalDiskSize != nil {
 		t.Errorf("Expected Config to not have a set of additional disks, but got a non nil value")
 	}
@@ -1678,7 +1699,10 @@ func TestConfigAdditionalDiskOverrideDefault(t *testing.T) {
 	}
 
 	var c Config
-	c.Prepare(config, diskconfig, getPackerConfiguration())
+	_, err := c.Prepare(config, diskconfig, getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if c.AdditionalDiskSize == nil {
 		t.Errorf("Expected Config to have a set of additional disks, but got nil")
 	}

--- a/builder/azure/arm/openssh_key_pair_test.go
+++ b/builder/azure/arm/openssh_key_pair_test.go
@@ -30,7 +30,7 @@ func TestPrivateKeyShouldParse(t *testing.T) {
 		t.Fatalf("Failed to create a new OpenSSH key pair, err=%s.", err)
 	}
 
-	_, err = ssh.ParsePrivateKey([]byte(testSubject.PrivateKey()))
+	_, err = ssh.ParsePrivateKey(testSubject.PrivateKey())
 	if err != nil {
 		t.Fatalf("Failed to parse the private key, err=%s\n", err)
 	}

--- a/builder/azure/arm/resource_resolver_test.go
+++ b/builder/azure/arm/resource_resolver_test.go
@@ -6,14 +6,17 @@ import (
 
 func TestResourceResolverIgnoresEmptyVirtualNetworkName(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	if c.VirtualNetworkName != "" {
 		t.Fatalf("Expected VirtualNetworkName to be empty by default")
 	}
 
 	sut := newTestResourceResolver()
 	sut.findVirtualNetworkResourceGroup = nil // assert that this is not even called
-	sut.Resolve(&c)
+	_ = sut.Resolve(&c)
 
 	if c.VirtualNetworkName != "" {
 		t.Fatalf("Expected VirtualNetworkName to be empty")
@@ -27,7 +30,10 @@ func TestResourceResolverIgnoresEmptyVirtualNetworkName(t *testing.T) {
 // there is no need to do a lookup.
 func TestResourceResolverIgnoresSetVirtualNetwork(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	c.VirtualNetworkName = "--virtual-network-name--"
 	c.VirtualNetworkResourceGroupName = "--virtual-network-resource-group-name--"
 	c.VirtualNetworkSubnetName = "--virtual-network-subnet-name--"
@@ -35,7 +41,7 @@ func TestResourceResolverIgnoresSetVirtualNetwork(t *testing.T) {
 	sut := newTestResourceResolver()
 	sut.findVirtualNetworkResourceGroup = nil // assert that this is not even called
 	sut.findVirtualNetworkSubnet = nil        // assert that this is not even called
-	sut.Resolve(&c)
+	_ = sut.Resolve(&c)
 
 	if c.VirtualNetworkName != "--virtual-network-name--" {
 		t.Fatalf("Expected VirtualNetworkName to be --virtual-network-name--")
@@ -52,11 +58,14 @@ func TestResourceResolverIgnoresSetVirtualNetwork(t *testing.T) {
 // resource group name.
 func TestResourceResolverSetVirtualNetworkResourceGroupName(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	c.VirtualNetworkName = "--virtual-network-name--"
 
 	sut := newTestResourceResolver()
-	sut.Resolve(&c)
+	_ = sut.Resolve(&c)
 
 	if c.VirtualNetworkResourceGroupName != "findVirtualNetworkResourceGroup is mocked" {
 		t.Fatalf("Expected VirtualNetworkResourceGroupName to be 'findVirtualNetworkResourceGroup is mocked'")

--- a/builder/azure/arm/step_create_resource_group.go
+++ b/builder/azure/arm/step_create_resource_group.go
@@ -89,7 +89,7 @@ func (s *StepCreateResourceGroup) Run(ctx context.Context, state multistep.State
 
 		s.say(fmt.Sprintf(" -> ResourceGroupName : '%s'", resourceGroupName))
 		s.say(fmt.Sprintf(" -> Location          : '%s'", location))
-		s.say(fmt.Sprintf(" -> Tags              :"))
+		s.say(" -> Tags              :")
 		for k, v := range tags {
 			s.say(fmt.Sprintf(" ->> %s : %s", k, *v))
 		}

--- a/builder/azure/arm/step_delete_additional_disks.go
+++ b/builder/azure/arm/step_delete_additional_disks.go
@@ -71,12 +71,12 @@ func (s *StepDeleteAdditionalDisk) Run(ctx context.Context, state multistep.Stat
 	var resourceGroupName = state.Get(constants.ArmResourceGroupName).(string)
 
 	if dataDisks == nil {
-		s.say(fmt.Sprintf(" -> No Additional Disks specified"))
+		s.say(" -> No Additional Disks specified")
 		return multistep.ActionContinue
 	}
 
 	if isManagedDisk && !isExistingResourceGroup {
-		s.say(fmt.Sprintf(" -> Additional Disk : skipping, managed disk was used..."))
+		s.say(" -> Additional Disk : skipping, managed disk was used...")
 		return multistep.ActionContinue
 	}
 

--- a/builder/azure/arm/step_get_ip_address.go
+++ b/builder/azure/arm/step_get_ip_address.go
@@ -73,7 +73,8 @@ func (s *StepGetIPAddress) getPublicIP(ctx context.Context, resourceGroupName st
 }
 
 func (s *StepGetIPAddress) getPublicIPInPrivateNetwork(ctx context.Context, resourceGroupName string, ipAddressName string, interfaceName string) (string, error) {
-	s.getPrivateIP(ctx, resourceGroupName, ipAddressName, interfaceName)
+	// TODO: This was being called without capturing any return variables, causing linter issue, as far as I can tell calling getPrivateIP here does nothing, look into removing
+	_, _ = s.getPrivateIP(ctx, resourceGroupName, ipAddressName, interfaceName)
 	return s.getPublicIP(ctx, resourceGroupName, ipAddressName, interfaceName)
 }
 

--- a/builder/azure/arm/step_publish_to_shared_image_gallery.go
+++ b/builder/azure/arm/step_publish_to_shared_image_gallery.go
@@ -88,7 +88,7 @@ func (s *StepPublishToSharedImageGallery) publishToSig(ctx context.Context, mdiI
 		endOfLifeDate = (*date.Time)(nil)
 	}
 
-	storageAccountType, err := getSigDestinationStorageAccountType(string(sharedImageGallery.SigDestinationStorageAccountType))
+	storageAccountType, err := getSigDestinationStorageAccountType(sharedImageGallery.SigDestinationStorageAccountType)
 	if err != nil {
 		s.error(err)
 		return "", err

--- a/builder/azure/arm/step_snapshot_data_disks.go
+++ b/builder/azure/arm/step_snapshot_data_disks.go
@@ -81,11 +81,7 @@ func (s *StepSnapshotDataDisks) Run(ctx context.Context, stateBag multistep.Stat
 	var additionalDisks = stateBag.Get(constants.ArmAdditionalDiskVhds).([]string)
 	var dstSnapshotPrefix = stateBag.Get(constants.ArmManagedImageDataDiskSnapshotPrefix).(string)
 
-	if len(additionalDisks) == 1 {
-		s.say(fmt.Sprintf("Snapshotting data disk ..."))
-	} else {
-		s.say(fmt.Sprintf("Snapshotting data disks ..."))
-	}
+	s.say("Snapshotting data disks ...")
 
 	for i, disk := range additionalDisks {
 		s.say(fmt.Sprintf(" -> Data Disk   : '%s'", disk))

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -24,7 +24,7 @@ func GetKeyVaultDeployment(config *Config) (*resources.Deployment, error) {
 	}
 
 	builder, _ := template.NewTemplateBuilder(template.KeyVault)
-	builder.SetTags(&config.AzureTags)
+	_ = builder.SetTags(&config.AzureTags)
 
 	doc, _ := builder.ToJSON()
 	return createDeploymentParameters(*doc, params)
@@ -92,7 +92,10 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 			config.ImageSku,
 			config.ImageVersion)
 
-		builder.SetManagedMarketplaceImage(config.Location, config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion, imageID, config.managedImageStorageAccountType, config.diskCachingType)
+		err = builder.SetManagedMarketplaceImage(config.Location, config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion, imageID, config.managedImageStorageAccountType, config.diskCachingType)
+		if err != nil {
+			return nil, err
+		}
 	} else if config.SharedGallery.Subscription != "" {
 		imageID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s",
 			config.SharedGallery.Subscription,

--- a/builder/azure/arm/template_factory_test.go
+++ b/builder/azure/arm/template_factory_test.go
@@ -14,7 +14,10 @@ import (
 // Ensure the link values are not set, and the concrete values are set.
 func TestVirtualMachineDeployment00(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	deployment, err := GetVirtualMachineDeployment(&c)
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +47,10 @@ func TestVirtualMachineDeployment00(t *testing.T) {
 // Ensure the Virtual Machine template is a valid JSON document.
 func TestVirtualMachineDeployment01(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	deployment, err := GetVirtualMachineDeployment(&c)
 	if err != nil {
 		t.Fatal(err)
@@ -59,7 +65,10 @@ func TestVirtualMachineDeployment01(t *testing.T) {
 // Ensure the Virtual Machine template parameters are correct.
 func TestVirtualMachineDeployment02(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	deployment, err := GetVirtualMachineDeployment(&c)
 	if err != nil {
 		t.Fatal(err)
@@ -474,7 +483,10 @@ func TestVirtualMachineDeployment14(t *testing.T) {
 // Ensure the link values are not set, and the concrete values are set.
 func TestKeyVaultDeployment00(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	deployment, err := GetKeyVaultDeployment(&c)
 	if err != nil {
 		t.Fatal(err)
@@ -504,7 +516,10 @@ func TestKeyVaultDeployment00(t *testing.T) {
 // Ensure the KeyVault template is a valid JSON document.
 func TestKeyVaultDeployment01(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	deployment, err := GetKeyVaultDeployment(&c)
 	if err != nil {
 		t.Fatal(err)
@@ -519,8 +534,10 @@ func TestKeyVaultDeployment01(t *testing.T) {
 // Ensure the KeyVault template parameters are correct.
 func TestKeyVaultDeployment02(t *testing.T) {
 	var c Config
-	c.Prepare(getArmBuilderConfigurationWithWindows(), getPackerConfiguration())
-
+	_, err := c.Prepare(getArmBuilderConfigurationWithWindows(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	deployment, err := GetKeyVaultDeployment(&c)
 	if err != nil {
 		t.Fatal(err)
@@ -562,7 +579,10 @@ func TestKeyVaultDeployment03(t *testing.T) {
 	}
 
 	var c Config
-	c.Prepare(tags, getArmBuilderConfigurationWithWindows(), getPackerConfiguration())
+	_, err := c.Prepare(tags, getArmBuilderConfigurationWithWindows(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	deployment, err := GetKeyVaultDeployment(&c)
 	if err != nil {
 		t.Fatal(err)
@@ -581,7 +601,10 @@ func TestPlanInfo01(t *testing.T) {
 	}
 
 	var c Config
-	c.Prepare(planInfo, getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(planInfo, getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	deployment, err := GetVirtualMachineDeployment(&c)
 	if err != nil {
 		t.Fatal(err)
@@ -604,7 +627,10 @@ func TestPlanInfo02(t *testing.T) {
 	}
 
 	var c Config
-	c.Prepare(planInfo, getArmBuilderConfiguration(), getPackerConfiguration())
+	_, err := c.Prepare(planInfo, getArmBuilderConfiguration(), getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
 	deployment, err := GetVirtualMachineDeployment(&c)
 	if err != nil {
 		t.Fatal(err)

--- a/builder/azure/chroot/diskattacher.go
+++ b/builder/azure/chroot/diskattacher.go
@@ -123,6 +123,8 @@ func (da *diskAttacher) AttachDisk(ctx context.Context, diskID string) (int32, e
 
 	// disk was not found on VM, go and actually attach it
 
+	// TODO This assignment looks like it would do nothing, consider removing it
+	//nolint
 	var lun int32 = -1
 findFreeLun:
 	for lun = 0; lun < 64; lun++ {

--- a/builder/azure/chroot/step_verify_source_disk_test.go
+++ b/builder/azure/chroot/step_verify_source_disk_test.go
@@ -23,13 +23,9 @@ func Test_StepVerifySourceDisk_Run(t *testing.T) {
 		GetDiskResponseCode int
 		GetDiskResponseBody string
 	}
-	type args struct {
-		state multistep.StateBag
-	}
 	tests := []struct {
 		name       string
 		fields     fields
-		args       args
 		want       multistep.StepAction
 		errormatch string
 	}{

--- a/builder/azure/dtl/step_deploy_template.go
+++ b/builder/azure/dtl/step_deploy_template.go
@@ -126,7 +126,7 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 		for {
 			f, err := s.client.DtlVirtualMachineClient.ApplyArtifacts(ctx, s.config.tmpResourceGroupName, s.config.LabName, s.config.tmpComputeName, dtlArtifactsRequest)
 			if err == nil {
-				s.say(fmt.Sprintf("WinRM artifact deployment started, waiting for completion"))
+				s.say("WinRM artifact deployment started, waiting for completion")
 				err = f.WaitForCompletionRef(ctx, s.client.DtlVirtualMachineClient.Client)
 				if err != nil {
 					s.say(s.client.LastError.Error())
@@ -134,7 +134,7 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 				}
 				break
 			} else {
-				s.say(fmt.Sprintf("WinRM artifact deployment failed, sleeping a minute and retrying"))
+				s.say("WinRM artifact deployment failed, sleeping a minute and retrying")
 				time.Sleep(60 * time.Second)
 			}
 		}


### PR DESCRIPTION
Golang CI has been failing for several months, a lot of the issues I fixed were more than 6-7 years old so I don't believe anything specific changed in the code base to make lint fail, but rather golang-ci lint added new rules at some point.

I tried to keep this relatively simple, any linting changes that seemed like they might have larger code complications I avoided and added a TODO (and in one case a nolint)

