### PR TITLE
Update Availability Zones list and fix warning message

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1266,12 +1266,30 @@ func (c *Config) validateLocationZoneResiliency(say func(s string)) {
 
 	var zones = make(map[string]struct{})
 	zones["westeurope"] = struct{}{}
+	zones["australiaeast"] = struct{}{}
+	zones["brazilsouth"] = struct{}{}
+	zones["canadacentral"] = struct{}{}
+	zones["centralindia"] = struct{}{}
 	zones["centralus"] = struct{}{}
+	zones["chinanorth3"] = struct{}{}
+	zones["eastasia"] = struct{}{}
+	zones["eastus"] = struct{}{}
 	zones["eastus2"] = struct{}{}
 	zones["francecentral"] = struct{}{}
+	zones["germanywestcentral"] = struct{}{}
+	zones["japaneast"] = struct{}{}
+	zones["koreacentral"] = struct{}{}
 	zones["northeurope"] = struct{}{}
+	zones["norwayeast"] = struct{}{}
+	zones["southafricanorth"] = struct{}{}
+	zones["southcentralus"] = struct{}{}
 	zones["southeastasia"] = struct{}{}
+	zones["swedencentral"] = struct{}{}
+	zones["uksouth"] = struct{}{}
+	zones["usgovvirginia"] = struct{}{}
+	zones["westeurope"] = struct{}{}
 	zones["westus2"] = struct{}{}
+	zones["westus3"] = struct{}{}
 
 	if _, ok := zones[c.Location]; !ok {
 		say(fmt.Sprintf("WARNING: Zone resiliency may not be supported in %s, checkout the docs at https://docs.microsoft.com/en-us/azure/availability-zones/", c.Location))

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1285,6 +1285,7 @@ func (c *Config) validateLocationZoneResiliency(say func(s string)) {
 	zones["southcentralus"] = struct{}{}
 	zones["southeastasia"] = struct{}{}
 	zones["swedencentral"] = struct{}{}
+	zones["switzerlandnorth"] = struct{}{}
 	zones["uksouth"] = struct{}{}
 	zones["usgovvirginia"] = struct{}{}
 	zones["westeurope"] = struct{}{}

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1291,7 +1291,7 @@ func (c *Config) validateLocationZoneResiliency(say func(s string)) {
 	zones["westus2"] = struct{}{}
 	zones["westus3"] = struct{}{}
 
-	if _, ok := zones[c.Location]; !ok {
+	if _, ok := zones[normalizeAzureRegion(c.Location)]; !ok {
 		say(fmt.Sprintf("WARNING: Zone resiliency may not be supported in %s, checkout the docs at https://docs.microsoft.com/en-us/azure/availability-zones/", c.Location))
 	}
 }


### PR DESCRIPTION
This PR fixes the following:

- Update the list of supported Availability zones based on https://docs.microsoft.com/en-us/azure/availability-zones/

- Fix the warning message to work properly in cases where a user did specify the location in the exact notation in the template