### PR TITLE
Fix custom resource build prefix

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1264,7 +1264,7 @@ func assertManagedImageDataDiskSnapshotName(name, setting string) (bool, error) 
 }
 
 func assertResourceNamePrefix(name, setting string) (bool, error) {
-	if !reResourceNamePrefix.Match([]byte(name)) {
+	if !reResourceNamePrefix.MatchString(name) {
 		return false, fmt.Errorf("The setting %s must only contain characters from a-z, A-Z, 0-9 and - and the maximum length is 10 characters", setting)
 	}
 	return true, nil

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -64,7 +64,7 @@ var (
 	reResourceGroupName    = regexp.MustCompile(validResourceGroupNameRe)
 	reSnapshotName         = regexp.MustCompile(`^[A-Za-z0-9_]{1,79}$`)
 	reSnapshotPrefix       = regexp.MustCompile(`^[A-Za-z0-9_]{1,59}$`)
-	reResourceNamePrefix   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]{1,9}$`)
+	reResourceNamePrefix   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]{0,9}$`)
 )
 
 type PlanInformation struct {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -55,7 +55,6 @@ const (
 	// This is not an exhaustive match, but it should be extremely close.
 	validResourceGroupNameRe = "^[^_\\W][\\w-._\\(\\)]{0,89}$"
 	validManagedDiskName     = "^[^_\\W][\\w-._)]{0,79}$"
-	validResourceNamePrefix  = "^[^_\\W][\\w-._)]{0,10}$"
 )
 
 var (
@@ -65,7 +64,7 @@ var (
 	reResourceGroupName    = regexp.MustCompile(validResourceGroupNameRe)
 	reSnapshotName         = regexp.MustCompile(`^[A-Za-z0-9_]{1,79}$`)
 	reSnapshotPrefix       = regexp.MustCompile(`^[A-Za-z0-9_]{1,59}$`)
-	reResourceNamePrefix   = regexp.MustCompile(validResourceNamePrefix)
+	reResourceNamePrefix   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]{1,9}$`)
 )
 
 type PlanInformation struct {
@@ -1265,8 +1264,8 @@ func assertManagedImageDataDiskSnapshotName(name, setting string) (bool, error) 
 }
 
 func assertResourceNamePrefix(name, setting string) (bool, error) {
-	if !isValidAzureName(reResourceNamePrefix, name) {
-		return false, fmt.Errorf("The setting %s must only contain characters from a-z, A-Z, 0-9 and _ and the maximum length is 10 characters", setting)
+	if !reResourceNamePrefix.Match([]byte(name)) {
+		return false, fmt.Errorf("The setting %s must only contain characters from a-z, A-Z, 0-9 and - and the maximum length is 10 characters", setting)
 	}
 	return true, nil
 }

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -2389,3 +2389,53 @@ func TestConfigShouldRejectCustomDataAndCustomDataFile(t *testing.T) {
 		t.Fatal("expected config to reject the use of both custom_data and custom_data_file")
 	}
 }
+
+func TestConfigShouldRejectInvalidCustomResourceBuildPrefix(t *testing.T) {
+	config := map[string]interface{}{
+		"location":               "ignore",
+		"subscription_id":        "ignore",
+		"image_offer":            "ignore",
+		"image_publisher":        "ignore",
+		"image_sku":              "ignore",
+		"os_type":                "linux",
+		"resource_group_name":    "ignore",
+		"storage_account":        "ignore",
+		"capture_container_name": "ignore",
+		"capture_name_prefix":    "ignore",
+	}
+
+	badResourcePrefixes := []string{"pkr_123456", "pkr-1234567", "-pkr123", "pkr.123"}
+	for _, resourcePrefix := range badResourcePrefixes {
+		config["custom_resource_build_prefix"] = resourcePrefix
+		var c Config
+		_, err := c.Prepare(config, getPackerConfiguration())
+		if err == nil {
+			t.Fatalf("expected config to reject %s as custom_resource_build_prefix", resourcePrefix)
+		}
+	}
+}
+
+func TestConfigShouldAcceptValidCustomResourceBuildPrefix(t *testing.T) {
+	config := map[string]interface{}{
+		"location":               "ignore",
+		"subscription_id":        "ignore",
+		"image_offer":            "ignore",
+		"image_publisher":        "ignore",
+		"image_sku":              "ignore",
+		"os_type":                "linux",
+		"resource_group_name":    "ignore",
+		"storage_account":        "ignore",
+		"capture_container_name": "ignore",
+		"capture_name_prefix":    "ignore",
+	}
+
+	goodResourcePrefixes := []string{"pkr-123456", "pkr-12345-", "pkr123"}
+	for _, resourcePrefix := range goodResourcePrefixes {
+		config["custom_resource_build_prefix"] = resourcePrefix
+		var c Config
+		_, err := c.Prepare(config, getPackerConfiguration())
+		if err != nil {
+			t.Fatalf("expected config to accept %s as custom_resource_build_prefix but got error: %s", resourcePrefix, err)
+		}
+	}
+}


### PR DESCRIPTION
## Background
I discovered a few issues in the validation of the `custom_resource_build_prefix` parameter. 
1. Validation of the length allowed 11 characters, and not the documented `10`
2. Validation allowed non-valid characters like `_`, `.` and `)`  for Azure resources
   * `pkr_123456` is not a valid prefix name for a VM (because of the underscore) as stated by Microsoft's [documentation](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcompute):
   > Can't use spaces, control characters, or these characters:
~ ! @ # $ % ^ & * ( ) = + _ [ ] { } \ | ; : . ' " , < > / ?
Windows VMs can't include period or end with hyphen.
Linux VMs can't end with period or hyphen.
3. Calling `isValidAzureName` would not allow the prefix to end with a `-` witch should be allowed according to the [documentation](https://www.packer.io/plugins/builders/azure/arm#custom_resource_build_prefix)
   * `custom_resource_build_prefix` + resourcetype + 5 character random alphanumeric string


This PR address the issues I described above as well as adding tests for `custom_resource_build_prefix`