### PR TITLE
Support Trusted Launch VMs

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -490,6 +490,12 @@ type Config struct {
 	// `custom_resource_build_prefix` + resourcetype + 5 character random alphanumeric string
 	CustomResourcePrefix string `mapstructure:"custom_resource_build_prefix" required:"false"`
 
+	// Specifies if Secure Boot and Trusted Launch is enabled for the Virtual Machine.
+	SecureBootEnabled bool `mapstructure:"secure_boot_enabled" required:"false"`
+
+	// Specifies if vTPM (virtual Trusted Platform Module) and Trusted Launch is enabled for the Virtual Machine.
+	VTpmEnabled bool `mapstructure:"vtpm_enabled" required:"false"`
+
 	// Runtime Values
 	UserName               string `mapstructure-to-hcl2:",skip"`
 	Password               string `mapstructure-to-hcl2:",skip"`

--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -85,6 +85,8 @@ type FlatConfig struct {
 	AllowedInboundIpAddresses                  []string                           `mapstructure:"allowed_inbound_ip_addresses" cty:"allowed_inbound_ip_addresses" hcl:"allowed_inbound_ip_addresses"`
 	BootDiagSTGAccount                         *string                            `mapstructure:"boot_diag_storage_account" required:"false" cty:"boot_diag_storage_account" hcl:"boot_diag_storage_account"`
 	CustomResourcePrefix                       *string                            `mapstructure:"custom_resource_build_prefix" required:"false" cty:"custom_resource_build_prefix" hcl:"custom_resource_build_prefix"`
+	SecureBootEnabled                          *bool                              `mapstructure:"secure_boot_enabled" required:"false" cty:"secure_boot_enabled" hcl:"secure_boot_enabled"`
+	VTpmEnabled                                *bool                              `mapstructure:"vtpm_enabled" required:"false" cty:"vtpm_enabled" hcl:"vtpm_enabled"`
 	Type                                       *string                            `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect                         *string                            `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
 	SSHHost                                    *string                            `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
@@ -223,6 +225,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"allowed_inbound_ip_addresses":                     &hcldec.AttrSpec{Name: "allowed_inbound_ip_addresses", Type: cty.List(cty.String), Required: false},
 		"boot_diag_storage_account":                        &hcldec.AttrSpec{Name: "boot_diag_storage_account", Type: cty.String, Required: false},
 		"custom_resource_build_prefix":                     &hcldec.AttrSpec{Name: "custom_resource_build_prefix", Type: cty.String, Required: false},
+		"secure_boot_enabled":                              &hcldec.AttrSpec{Name: "secure_boot_enabled", Type: cty.Bool, Required: false},
+		"vtpm_enabled":                                     &hcldec.AttrSpec{Name: "vtpm_enabled", Type: cty.Bool, Required: false},
 		"communicator":                                     &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":                          &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},
 		"ssh_host":                                         &hcldec.AttrSpec{Name: "ssh_host", Type: cty.String, Required: false},

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -198,6 +198,13 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 		}
 	}
 
+	if config.SecureBootEnabled || config.VTpmEnabled {
+		err = builder.SetSecurityProfile(config.SecureBootEnabled, config.VTpmEnabled)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	err = builder.SetTags(&config.AzureTags)
 	if err != nil {
 		return nil, err

--- a/builder/azure/common/template/template.go
+++ b/builder/azure/common/template/template.go
@@ -94,11 +94,12 @@ type Properties struct {
 	Sku                          *Sku                                `json:"sku,omitempty"`
 	UserData                     *string                             `json:"userData,omitempty"`
 	//StorageProfile3              *compute.StorageProfile             `json:"storageProfile,omitempty"`
-	StorageProfile *StorageProfileUnion    `json:"storageProfile,omitempty"`
-	Subnets        *[]network.Subnet       `json:"subnets,omitempty"`
-	SecurityRules  *[]network.SecurityRule `json:"securityRules,omitempty"`
-	TenantId       *string                 `json:"tenantId,omitempty"`
-	Value          *string                 `json:"value,omitempty"`
+	StorageProfile  *StorageProfileUnion     `json:"storageProfile,omitempty"`
+	SecurityProfile *compute.SecurityProfile `json:"securityProfile,omitempty"`
+	Subnets         *[]network.Subnet        `json:"subnets,omitempty"`
+	SecurityRules   *[]network.SecurityRule  `json:"securityRules,omitempty"`
+	TenantId        *string                  `json:"tenantId,omitempty"`
+	Value           *string                  `json:"value,omitempty"`
 }
 
 // Template > Resource > Identity

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -450,6 +450,38 @@ func (s *TemplateBuilder) SetBootDiagnostics(diagSTG string) error {
 	return nil
 }
 
+func (s *TemplateBuilder) SetSecurityProfile(secureBootEnabled bool, vtpmEnabled bool) error {
+	s.setVariable("apiVersion", "2020-12-01") // Required for Trusted Launch
+	resource, err := s.getResourceByType(resourceVirtualMachine)
+	if err != nil {
+		return err
+	}
+
+	if secureBootEnabled {
+		if resource.Properties.SecurityProfile == nil {
+			resource.Properties.SecurityProfile = &compute.SecurityProfile{}
+		}
+		if resource.Properties.SecurityProfile.UefiSettings == nil {
+			resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+		}
+		resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
+		resource.Properties.SecurityProfile.UefiSettings.SecureBootEnabled = to.BoolPtr(secureBootEnabled)
+	}
+
+	if vtpmEnabled {
+		if resource.Properties.SecurityProfile == nil {
+			resource.Properties.SecurityProfile = &compute.SecurityProfile{}
+		}
+		if resource.Properties.SecurityProfile.UefiSettings == nil {
+			resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+		}
+		resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
+		resource.Properties.SecurityProfile.UefiSettings.VTpmEnabled = to.BoolPtr(vtpmEnabled)
+	}
+
+	return nil
+}
+
 func (s *TemplateBuilder) ToJSON() (*string, error) {
 	bs, err := json.MarshalIndent(s.template, jsonPrefix, jsonIndent)
 

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -457,25 +457,15 @@ func (s *TemplateBuilder) SetSecurityProfile(secureBootEnabled bool, vtpmEnabled
 		return err
 	}
 
+	resource.Properties.SecurityProfile = &compute.SecurityProfile{}
+	resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+	resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
+
 	if secureBootEnabled {
-		if resource.Properties.SecurityProfile == nil {
-			resource.Properties.SecurityProfile = &compute.SecurityProfile{}
-		}
-		if resource.Properties.SecurityProfile.UefiSettings == nil {
-			resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
-		}
-		resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
 		resource.Properties.SecurityProfile.UefiSettings.SecureBootEnabled = to.BoolPtr(secureBootEnabled)
 	}
 
 	if vtpmEnabled {
-		if resource.Properties.SecurityProfile == nil {
-			resource.Properties.SecurityProfile = &compute.SecurityProfile{}
-		}
-		if resource.Properties.SecurityProfile.UefiSettings == nil {
-			resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
-		}
-		resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
 		resource.Properties.SecurityProfile.UefiSettings.VTpmEnabled = to.BoolPtr(vtpmEnabled)
 	}
 

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -460,14 +460,8 @@ func (s *TemplateBuilder) SetSecurityProfile(secureBootEnabled bool, vtpmEnabled
 	resource.Properties.SecurityProfile = &compute.SecurityProfile{}
 	resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
 	resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
-
-	if secureBootEnabled {
-		resource.Properties.SecurityProfile.UefiSettings.SecureBootEnabled = to.BoolPtr(secureBootEnabled)
-	}
-
-	if vtpmEnabled {
-		resource.Properties.SecurityProfile.UefiSettings.VTpmEnabled = to.BoolPtr(vtpmEnabled)
-	}
+	resource.Properties.SecurityProfile.UefiSettings.SecureBootEnabled = to.BoolPtr(secureBootEnabled)
+	resource.Properties.SecurityProfile.UefiSettings.VTpmEnabled = to.BoolPtr(vtpmEnabled)
 
 	return nil
 }

--- a/docs-partials/builder/azure/arm/Config-not-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-not-required.mdx
@@ -325,6 +325,10 @@
   this will set the prefix for the resources. The actuall resource names will be
   `custom_resource_build_prefix` + resourcetype + 5 character random alphanumeric string
 
+- `secure_boot_enabled` (bool) - Specifies if Secure Boot and Trusted Launch is enabled for the Virtual Machine.
+
+- `vtpm_enabled` (bool) - Specifies if vTPM (virtual Trusted Platform Module) and Trusted Launch is enabled for the Virtual Machine.
+
 - `async_resourcegroup_delete` (bool) - If you want packer to delete the
   temporary resource group asynchronously set this value. It's a boolean
   value and defaults to false. Important Setting this true means that


### PR DESCRIPTION
Sets the SecurityProfile if either Secure Boot or the VTPM option has been set in the packer configuration. This allows the deployment of VMs using Trusted Launch either from marketplace or Shared Image Gallery if the image has been enabled for trusted launch.
https://docs.microsoft.com/en-us/azure/virtual-machines/trusted-launch

Introduced two new parameters:
secure_boot_enabled
vtpm_enabled

