### PR TITLE
fix(builder): return early on skip capture

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -320,6 +320,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		return nil, errors.New("Build was halted.")
 	}
 
+	if b.config.SkipCreateImage {
+		// NOTE(jkoelker) if the capture was skipped, then just return
+		return nil, nil
+	}
+
 	getSasUrlFunc := func(name string) string {
 		blob := azureClient.BlobStorageClient.GetContainerReference(DefaultSasBlobContainer).GetBlobReference(name)
 		options := storage.BlobSASOptions{}

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -25,6 +25,8 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
 )
 
+var ErrNoImage = errors.New("failed to find shared image gallery id in state")
+
 type Builder struct {
 	config   Config
 	stateBag multistep.StateBag
@@ -531,6 +533,13 @@ func (b *Builder) managedImageArtifactWithSIGAsDestination(managedImageID string
 		stateData[key] = v
 	}
 
+	destinationSharedImageGalleryId := ""
+	if galleryID, ok := b.stateBag.GetOk(constants.ArmManagedImageSharedGalleryId); ok {
+		destinationSharedImageGalleryId = galleryID.(string)
+	} else {
+		return nil, ErrNoImage
+	}
+
 	return NewManagedImageArtifactWithSIGAsDestination(b.config.OSType,
 		b.config.ManagedImageResourceGroupName,
 		b.config.ManagedImageName,
@@ -538,6 +547,6 @@ func (b *Builder) managedImageArtifactWithSIGAsDestination(managedImageID string
 		managedImageID,
 		b.config.ManagedImageOSDiskSnapshotName,
 		b.config.ManagedImageDataDiskSnapshotPrefix,
-		b.stateBag.Get(constants.ArmManagedImageSharedGalleryId).(string),
+		destinationSharedImageGalleryId,
 		stateData)
 }

--- a/builder/azure/arm/builder_test.go
+++ b/builder/azure/arm/builder_test.go
@@ -3,6 +3,8 @@ package arm
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/constants"
 )
 
@@ -64,6 +66,16 @@ func TestStateBagShouldPoluateExpectedTags(t *testing.T) {
 		}
 	}
 
+}
+
+func TestManagedImageArtifactWithSIGAsDestinationNoImage(t *testing.T) {
+	var testSubject Builder
+
+	_, _, err := testSubject.Prepare(getArmBuilderConfiguration(), getPackerConfiguration())
+	assert.NoErrorf(t, err, "failed to prepare: %s", err)
+
+	_, err = testSubject.managedImageArtifactWithSIGAsDestination("fakeID", generatedData())
+	assert.ErrorIs(t, err, ErrNoImage)
 }
 
 func TestBuildSharedImageGalleryArtifact_withState(t *testing.T) {

--- a/builder/azure/common/config_test.go
+++ b/builder/azure/common/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common"
 )
 
-func TestSkipCreateImage(t *testing.T) {
+func TestSkipCreateImageFalse(t *testing.T) {
 	var said []string
 
 	say := func(what string) {
@@ -30,11 +30,25 @@ func TestSkipCreateImage(t *testing.T) {
 	}
 
 	assert.Equal(t, said, []string{message})
+}
 
-	said = nil
-	config.SkipCreateImage = true
+func TestSkipCreateImageTrue(t *testing.T) {
+	var said []string
 
-	steps = config.CaptureSteps(say, common.NewStepNotify(message, say))
+	say := func(what string) {
+		said = append(said, what)
+	}
+
+	config := common.Config{
+		SkipCreateImage: true,
+	}
+
+	message := "Capture Image"
+
+	steps := config.CaptureSteps(say, common.NewStepNotify(message, say))
+	state := &multistep.BasicStateBag{}
+
+	ctx := context.Background()
 
 	for _, step := range steps {
 		step.Run(ctx, state)


### PR DESCRIPTION
It appears my previous skip patch, while it does indeed skip the capture, later on there was an unchecked type assertion to string that would panic and fail (see log below).

Guard the type assertion and return an error if it is not found, and also return early if the capture was skipped. This appears to be the way the [amazon](https://github.com/hashicorp/packer-plugin-amazon/blob/main/builder/instance/builder.go#L456-L459) and [googlecompute](https://github.com/hashicorp/packer-plugin-googlecompute/blob/main/builder/googlecompute/builder.go#L127-L130) handle skipping, and was an oversight in my original pr.



```
==> Builds finished but no artifacts were created.
panic: interface conversion: interface {} is nil, not string
2022/08/07 21:37:56 packer-builder-azure-arm plugin: 
2022/08/07 21:37:56 packer-builder-azure-arm plugin: goroutine 52 [running]:
2022/08/07 21:37:56 packer-builder-azure-arm plugin: github.com/hashicorp/packer-plugin-azure/builder/azure/arm.(*Builder).managedImageArtifactWithSIGAsDestination(0xc000a8ca80, {0xc0007bc120, 0x81}, 0xc000dbd6e0)
2022/08/07 21:37:56 packer-builder-azure-arm plugin: 	/home/runner/go/pkg/mod/github.com/hashicorp/packer-plugin-azure@v1.1.0/builder/azure/arm/builder.go:541 +0x4c8
2022/08/07 21:37:56 packer-builder-azure-arm plugin: github.com/hashicorp/packer-plugin-azure/builder/azure/arm.(*Builder).Run(0xc000a8ca80, {0x5e76860, 0xc000c871c0}, {0x5e82dc8, 0xc0013bd0b0}, {0x5de3800, 0xc000521820})
2022/08/07 21:37:56 packer-builder-azure-arm plugin: 	/home/runner/go/pkg/mod/github.com/hashicorp/packer-plugin-azure@v1.1.0/builder/azure/arm/builder.go:336 +0x31b1
2022/08/07 21:37:56 packer-builder-azure-arm plugin: github.com/hashicorp/packer-plugin-sdk/rpc.(*BuilderServer).Run(0xc000523a40, 0x61a050, 0xc00061a030)
2022/08/07 21:37:56 packer-builder-azure-arm plugin: 	/home/runner/go/pkg/mod/github.com/hashicorp/packer-plugin-sdk@v0.3.0/rpc/builder.go:117 +0x1e3
2022/08/07 21:37:56 packer-builder-azure-arm plugin: reflect.Value.call({0xc000597200, 0xc00000ea20, 0x13}, {0x5629869, 0x4}, {0xc000573ef8, 0x3, 0x3})
2022/08/07 21:37:56 packer-builder-azure-arm plugin: 	/opt/hostedtoolcache/go/1.17.11/x64/src/reflect/value.go:556 +0x845
2022/08/07 21:37:56 packer-builder-azure-arm plugin: reflect.Value.Call({0xc000597200, 0xc00000ea20, 0xc000f00000}, {0xc000d2def8, 0x3, 0x3})
2022/08/07 21:37:56 packer-builder-azure-arm plugin: 	/opt/hostedtoolcache/go/1.17.11/x64/src/reflect/value.go:339 +0xc5
2022/08/07 21:37:56 packer-builder-azure-arm plugin: net/rpc.(*service).call(0xc000523a80, 0xc0007e18c0, 0x0, 0xc000540020, 0xc00015aa80, 0x842885, {0x450fa60, 0xc00061a02c, 0x842806}, {0x43da080, ...}, ...)
2022/08/07 21:37:56 packer-builder-azure-arm plugin: 	/opt/hostedtoolcache/go/1.17.11/x64/src/net/rpc/server.go:377 +0x239
2022/08/07 21:37:56 packer-builder-azure-arm plugin: created by net/rpc.(*Server).ServeCodec
2022/08/07 21:37:56 packer-builder-azure-arm plugin: 	/opt/hostedtoolcache/go/1.17.11/x64/src/net/rpc/server.go:474 +0x405
2022/08/07 21:37:56 /usr/local/bin/packer: plugin process exited
2022/08/07 21:37:56 [INFO] (telemetry) ending centos-7_9-gen2
2022/08/07 21:37:56 ui error:  [1;31mBuild 'centos-7_9-gen2' errored after 10 minutes 21 seconds: unexpected EOF [0m
2022/08/07 21:37:56 ui: 
==> Wait completed after 10 minutes 21 seconds
2022/08/07 21:37:56 machine readable: error-count []string{"1"}
2022/08/07 21:37:56 ui error: 
==> Some builds didn't complete successfully and had errors:
2022/08/07 21:37:56 machine readable: centos-7_9-gen2,error []string{"unexpected EOF"}
2022/08/07 21:37:56 ui error: --> centos-7_9-gen2: unexpected EOF
2022/08/07 21:37:56 ui: 
==> Builds finished but no artifacts were created.
2022/08/07 21:37:56 [INFO] (telemetry) Finalizing.
2022/08/07 21:37:56 waiting for all plugin processes to complete...
2022/08/07 21:37:56 /usr/local/bin/packer: plugin process exited
2022/08/07 21:37:56 /usr/local/bin/packer: plugin process exited
2022/08/07 21:37:56 /usr/local/bin/packer: plugin process exited
2022/08/07 21:37:56 /usr/local/bin/packer: plugin process exited
2022/08/07 21:37:56 /usr/local/bin/packer: plugin process exited
2022/08/07 21:37:56 /usr/local/bin/packer-provisioner-goss: plugin process exited
2022/08/07 21:37:56 /usr/local/bin/packer: plugin process exited
2022/08/07 21:37:56 /usr/local/bin/packer: plugin process exited
2022/08/07 21:37:56 /usr/local/bin/packer: plugin process exited
2022/08/07 21:37:56 /usr/local/bin/packer: plugin process exited
2022/08/07 21:37:56 /usr/local/bin/packer: plugin process exited
2022/08/07 21:37:56 /usr/local/bin/packer: plugin process exited



!!!!!!!!!!!!!!!!!!!!!!!!!!! PACKER CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!

Packer crashed! This is always indicative of a bug within Packer.
A crash log has been placed at "crash.log" relative to your current
working directory. It would be immensely helpful if you could please
report the crash with Packer[1] so that we can fix this.

[1]: https://github.com/hashicorp/packer/issues

!!!!!!!!!!!!!!!!!!!!!!!!!!! PACKER CRASH !!!!!!!!!!!!!!!!!!!!!!!!!!!!
```
