### PR TITLE
Update max SIG replica count from 10 to 100

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -202,7 +202,7 @@ type Config struct {
 	SharedGalleryImageVersionEndOfLifeDate string `mapstructure:"shared_gallery_image_version_end_of_life_date" required:"false"`
 	// The number of replicas of the Image Version to be created per region. This
 	// property would take effect for a region when regionalReplicaCount is not specified.
-	// Replica count must be between 1 and 100, but 50 replicas should be sufficient for most use cases
+	// Replica count must be between 1 and 100, but 50 replicas should be sufficient for most use cases.
 	SharedGalleryImageVersionReplicaCount int32 `mapstructure:"shared_image_gallery_replica_count" required:"false"`
 	// If set to true, Virtual Machines deployed from the latest version of the
 	// Image Definition won't use this Image Version.

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -202,7 +202,7 @@ type Config struct {
 	SharedGalleryImageVersionEndOfLifeDate string `mapstructure:"shared_gallery_image_version_end_of_life_date" required:"false"`
 	// The number of replicas of the Image Version to be created per region. This
 	// property would take effect for a region when regionalReplicaCount is not specified.
-	// Replica count must be between 1 and 10.
+	// Replica count must be between 1 and 100, but 50 replicas should be sufficient for most use cases
 	SharedGalleryImageVersionReplicaCount int32 `mapstructure:"shared_image_gallery_replica_count" required:"false"`
 	// If set to true, Virtual Machines deployed from the latest version of the
 	// Image Definition won't use this Image Version.

--- a/builder/azure/arm/step_publish_to_shared_image_gallery.go
+++ b/builder/azure/arm/step_publish_to_shared_image_gallery.go
@@ -158,10 +158,10 @@ func (s *StepPublishToSharedImageGallery) Run(ctx context.Context, stateBag mult
 	miSGImageVersionEndOfLifeDate, _ := stateBag.Get(constants.ArmManagedImageSharedGalleryImageVersionEndOfLifeDate).(string)
 	miSGImageVersionExcludeFromLatest, _ := stateBag.Get(constants.ArmManagedImageSharedGalleryImageVersionExcludeFromLatest).(bool)
 	miSigReplicaCount, _ := stateBag.Get(constants.ArmManagedImageSharedGalleryImageVersionReplicaCount).(int32)
-	// Replica count must be between 1 and 10 inclusive.
+	// Replica count must be between 1 and 100 inclusive
 	if miSigReplicaCount <= 0 {
 		miSigReplicaCount = constants.SharedImageGalleryImageVersionDefaultMinReplicaCount
-	} else if miSigReplicaCount > 10 {
+	} else if miSigReplicaCount > constants.SharedImageGalleryImageVersionDefaultMaxReplicaCount {
 		miSigReplicaCount = constants.SharedImageGalleryImageVersionDefaultMaxReplicaCount
 	}
 
@@ -174,7 +174,7 @@ func (s *StepPublishToSharedImageGallery) Run(ctx context.Context, stateBag mult
 	s.say(fmt.Sprintf(" -> SIG storage account type              : '%s'", sharedImageGallery.SigDestinationStorageAccountType))
 	s.say(fmt.Sprintf(" -> SIG image version endoflife date      : '%s'", miSGImageVersionEndOfLifeDate))
 	s.say(fmt.Sprintf(" -> SIG image version exclude from latest : '%t'", miSGImageVersionExcludeFromLatest))
-	s.say(fmt.Sprintf(" -> SIG replica count [1, 10]             : '%d'", miSigReplicaCount))
+	s.say(fmt.Sprintf(" -> SIG replica count [1, 100]            : '%d'", miSigReplicaCount))
 
 	createdGalleryImageVersionID, err := s.publish(ctx, mdiID, sharedImageGallery, miSGImageVersionEndOfLifeDate, miSGImageVersionExcludeFromLatest, miSigReplicaCount, location, tags)
 

--- a/builder/azure/common/constants/stateBag.go
+++ b/builder/azure/common/constants/stateBag.go
@@ -13,7 +13,7 @@ const (
 // Default replica count for image versions in shared image gallery
 const (
 	SharedImageGalleryImageVersionDefaultMinReplicaCount int32 = 1
-	SharedImageGalleryImageVersionDefaultMaxReplicaCount int32 = 10
+	SharedImageGalleryImageVersionDefaultMaxReplicaCount int32 = 100
 )
 
 const (

--- a/docs-partials/builder/azure/arm/Config-not-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-not-required.mdx
@@ -88,7 +88,7 @@
 
 - `shared_image_gallery_replica_count` (int32) - The number of replicas of the Image Version to be created per region. This
   property would take effect for a region when regionalReplicaCount is not specified.
-  Replica count must be between 1 and 10.
+  Replica count must be between 1 and 100, but 50 replicas should be sufficient for most use cases.
 
 - `shared_gallery_image_version_exclude_from_latest` (bool) - If set to true, Virtual Machines deployed from the latest version of the
   Image Definition won't use this Image Version.

--- a/docs-partials/builder/azure/arm/Config-not-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-not-required.mdx
@@ -88,7 +88,7 @@
 
 - `shared_image_gallery_replica_count` (int32) - The number of replicas of the Image Version to be created per region. This
   property would take effect for a region when regionalReplicaCount is not specified.
-  Replica count must be between 1 and 100, but 50 replicas should be sufficient for most use cases.
+  Replica count must be between 1 and 10.
 
 - `shared_gallery_image_version_exclude_from_latest` (bool) - If set to true, Virtual Machines deployed from the latest version of the
   Image Definition won't use this Image Version.


### PR DESCRIPTION
Update the maximum image replica from the previous value of 10 to the new value of 100.

Azure Compute Gallery recently updated the limits of image replica counts from 10 to 100, but 50 replicas should be sufficient for most use cases.

https://docs.microsoft.com/en-us/azure/virtual-machines/azure-compute-gallery#limits

![image](https://user-images.githubusercontent.com/1821568/184433570-8a4c7e32-2888-4a4c-ac9a-25a6a1e45f9c.png)