### PR TITLE
Fix err check to show error correctly

### DIFF
--- a/builder/azure/arm/step_deploy_template.go
+++ b/builder/azure/arm/step_deploy_template.go
@@ -116,7 +116,7 @@ func (s *StepDeployTemplate) deployTemplate(ctx context.Context, resourceGroupNa
 	}
 
 	err = f.WaitForCompletionRef(ctx, s.client.DeploymentsClient.Client)
-	if err == nil {
+	if err != nil {
 		s.say(s.client.LastError.Error())
 	}
 


### PR DESCRIPTION
While working on some other changes, I found that the error checking for "did the deployment succeed" was incorrect - it was showing the error message if there was no error, rather than if there was an error.

(I think I can get away with not including tests for this, given it's just a UI change?)