### PR TITLE
Support building Shared Image Gallery Image without intermediate Managed Image

### DIFF
--- a/builder/azure/arm/artifact.go
+++ b/builder/azure/arm/artifact.go
@@ -100,6 +100,14 @@ func NewManagedImageArtifactWithSIGAsDestination(osType, resourceGroup, name, lo
 	}, nil
 }
 
+func NewSharedImageArtifact(osType, destinationSharedImageGalleryId string, generatedData map[string]interface{}) (*Artifact, error) {
+	return &Artifact{
+		OSType:                           osType,
+		ManagedImageSharedImageGalleryId: destinationSharedImageGalleryId,
+		StateData:                        generatedData,
+	}, nil
+}
+
 func NewArtifact(template *CaptureTemplate, getSasUrl func(name string) string, osType string, generatedData map[string]interface{}) (*Artifact, error) {
 	if template == nil {
 		return nil, fmt.Errorf("nil capture template")

--- a/builder/azure/arm/artifact_test.go
+++ b/builder/azure/arm/artifact_test.go
@@ -272,6 +272,11 @@ ManagedImageLocation: fakeLocation
 ManagedImageOSDiskSnapshotName: fakeOsDiskSnapshotName
 ManagedImageDataDiskSnapshotPrefix: fakeDataDiskSnapshotPrefix
 ManagedImageSharedImageGalleryId: fakeSharedImageGallery
+SharedImageGalleryResourceGroup: fakeResourceGroup
+SharedImageGalleryName: fakeName
+SharedImageGalleryImageName: fakeGalleryImageName
+SharedImageGalleryImageVersion: fakeGalleryImageVersion
+SharedImageGalleryReplicatedRegions: fake-region-1, fake-region-2
 `
 
 	result := artifact.String()

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -618,5 +618,5 @@ func (b *Builder) sharedImageArtifact(stateData map[string]interface{}) (*Artifa
 		return nil, ErrNoImage
 	}
 
-	return NewSharedImageArtifact(b.config.OSType, destinationSharedImageGalleryId, stateData)
+	return NewSharedImageArtifact(b.config.OSType, destinationSharedImageGalleryId, b.config.Location, stateData)
 }

--- a/builder/azure/arm/builder_test.go
+++ b/builder/azure/arm/builder_test.go
@@ -89,7 +89,7 @@ func TestBuildSharedImageGalleryArtifact_withState(t *testing.T) {
 	// During the publishing state to a shared image gallery this information is added to the builder StateBag.
 	// Adding it to the test to mimic a successful SIG publishing step.
 	testSubject.stateBag.Put(constants.ArmManagedImageSigPublishResourceGroup, "fakeGalleryResourceGroup")
-	testSubject.stateBag.Put(constants.ArmManagedImageSharedGalleryName, "faleGalleryName")
+	testSubject.stateBag.Put(constants.ArmManagedImageSharedGalleryName, "fakeGalleryName")
 	testSubject.stateBag.Put(constants.ArmManagedImageSharedGalleryImageName, "fakeGalleryImageName")
 	testSubject.stateBag.Put(constants.ArmManagedImageSharedGalleryImageVersion, "fakeGalleryImageVersion")
 	testSubject.stateBag.Put(constants.ArmManagedImageSharedGalleryReplicationRegions, []string{"fake-region-1", "fake-region-2"})
@@ -116,6 +116,11 @@ ManagedImageLocation: fakeLocation
 ManagedImageOSDiskSnapshotName: fakeOsDiskSnapshotName
 ManagedImageDataDiskSnapshotPrefix: fakeDataDiskSnapshotPrefix
 ManagedImageSharedImageGalleryId: fakeSharedImageGallery
+SharedImageGalleryResourceGroup: fakeGalleryResourceGroup
+SharedImageGalleryName: fakeGalleryName
+SharedImageGalleryImageName: fakeGalleryImageName
+SharedImageGalleryImageVersion: fakeGalleryImageVersion
+SharedImageGalleryReplicatedRegions: fake-region-1, fake-region-2
 `
 
 	result := artifact.String()

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -577,6 +577,10 @@ func (c *Config) isManagedImage() bool {
 	return c.ManagedImageName != ""
 }
 
+func (c *Config) isPublishToSIG() bool {
+	return c.SharedGalleryDestination.SigDestinationGalleryName != ""
+}
+
 func (c *Config) toVirtualMachineCaptureParameters() *compute.VirtualMachineCaptureParameters {
 	return &compute.VirtualMachineCaptureParameters{
 		DestinationContainerName: &c.CaptureContainerName,
@@ -980,12 +984,12 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 
 	/////////////////////////////////////////////
 	// Capture
-	if c.CaptureContainerName == "" && c.ManagedImageName == "" {
-		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A capture_container_name or managed_image_name must be specified"))
+	if c.CaptureContainerName == "" && c.ManagedImageName == "" && c.SharedGalleryDestination.SigDestinationGalleryName == "" {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A capture_container_name, managed_image_name or shared_image_gallery_destination must be specified"))
 	}
 
-	if c.CaptureNamePrefix == "" && c.ManagedImageResourceGroupName == "" {
-		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A capture_name_prefix or managed_image_resource_group_name must be specified"))
+	if c.CaptureNamePrefix == "" && c.ManagedImageResourceGroupName == "" && c.SharedGalleryDestination.SigDestinationGalleryName == "" {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A capture_name_prefix, managed_image_resource_group_name or shared_image_gallery_destination must be specified"))
 	}
 
 	if (c.CaptureNamePrefix != "" || c.CaptureContainerName != "") && (c.ManagedImageResourceGroupName != "" || c.ManagedImageName != "") {
@@ -1111,15 +1115,15 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 		return (a || b) && !(a && b)
 	}
 
-	if !xor((c.StorageAccount != "" || c.ResourceGroupName != ""), (c.ManagedImageName != "" || c.ManagedImageResourceGroupName != "")) {
-		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("Specify either a VHD (storage_account and resource_group_name) or Managed Image (managed_image_resource_group_name and managed_image_name) output"))
+	if !xor(c.StorageAccount != "" || c.ResourceGroupName != "", c.ManagedImageName != "" || c.ManagedImageResourceGroupName != "" || c.SharedGalleryDestination.SigDestinationGalleryName != "") {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("Specify either only a VHD (storage_account and resource_group_name), or either a Managed Image (managed_image_resource_group_name and managed_image_name) or a Shared Image Gallery (shared_image_gallery_destination) output"))
 	}
 
 	if !xor(c.Location != "", c.BuildResourceGroupName != "") {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("Specify either a location to create the resource group in or an existing build_resource_group_name, but not both."))
 	}
 
-	if c.ManagedImageName == "" && c.ManagedImageResourceGroupName == "" {
+	if c.ManagedImageName == "" && c.ManagedImageResourceGroupName == "" && c.SharedGalleryDestination.SigDestinationGalleryName == "" {
 		if c.StorageAccount == "" {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A storage_account must be specified"))
 		}
@@ -1152,7 +1156,7 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 		}
 	}
 
-	if c.ManagedImageName != "" && c.ManagedImageResourceGroupName != "" && c.SharedGalleryDestination.SigDestinationGalleryName != "" {
+	if c.SharedGalleryDestination.SigDestinationGalleryName != "" {
 		if c.SharedGalleryDestination.SigDestinationResourceGroup == "" {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A resource_group must be specified for shared_image_gallery_destination"))
 		}

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1166,9 +1166,6 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 		if c.SharedGalleryDestination.SigDestinationImageVersion == "" {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("An image_version must be specified for shared_image_gallery_destination"))
 		}
-		if len(c.SharedGalleryDestination.SigDestinationReplicationRegions) == 0 {
-			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A list of replication_regions must be specified for shared_image_gallery_destination"))
-		}
 		if c.SharedGalleryDestination.SigDestinationSubscription == "" {
 			c.SharedGalleryDestination.SigDestinationSubscription = c.ClientConfig.SubscriptionID
 		}

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1116,7 +1116,7 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 	}
 
 	if !xor(c.StorageAccount != "" || c.ResourceGroupName != "", c.ManagedImageName != "" || c.ManagedImageResourceGroupName != "" || c.SharedGalleryDestination.SigDestinationGalleryName != "") {
-		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("Specify either only a VHD (storage_account and resource_group_name), or either a Managed Image (managed_image_resource_group_name and managed_image_name) or a Shared Image Gallery (shared_image_gallery_destination) output"))
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("Specify either a VHD (storage_account and resource_group_name), a Managed Image (managed_image_resource_group_name and managed_image_name) or a Shared Image Gallery (shared_image_gallery_destination) output (Managed Images can also be published to Shared Image Galleries)"))
 	}
 
 	if !xor(c.Location != "", c.BuildResourceGroupName != "") {

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -1253,6 +1253,33 @@ func TestConfigShouldAcceptManagedImageOSDiskSnapshotNameAndManagedImageDataDisk
 	}
 }
 
+func TestConfigShouldAcceptAbsentManagedImageButPresentSharedImageGalleryDestination(t *testing.T) {
+	config := map[string]interface{}{
+		"image_offer":     "ignore",
+		"image_publisher": "ignore",
+		"image_sku":       "ignore",
+		"location":        "ignore",
+		"subscription_id": "ignore",
+		"communicator":    "none",
+		// Does not matter for this test case, just pick one.
+		"os_type": constants.Target_Linux,
+
+		"shared_image_gallery_destination": map[string]string{
+			"resource_group":      "ignore",
+			"gallery_name":        "ignore",
+			"image_name":          "ignore",
+			"image_version":       "ignore",
+			"replication_regions": "ignore",
+		},
+	}
+
+	var c Config
+	_, err := c.Prepare(config, getPackerConfiguration())
+	if err != nil {
+		t.Fatalf("expected config to accept platform managed image build: %v", err)
+	}
+}
+
 func TestConfigShouldRejectManagedImageOSDiskSnapshotNameAndManagedImageDataDiskSnapshotPrefixWithCaptureContainerName(t *testing.T) {
 	config := map[string]interface{}{
 		"image_offer":                         "ignore",

--- a/builder/azure/arm/step_capture_image_test.go
+++ b/builder/azure/arm/step_capture_image_test.go
@@ -132,6 +132,7 @@ func createTestStateBagStepCaptureImage() multistep.StateBag {
 	stateBag.Put(constants.ArmManagedImageResourceGroupName, "")
 	stateBag.Put(constants.ArmManagedImageName, "")
 	stateBag.Put(constants.ArmImageParameters, &compute.Image{})
+	stateBag.Put(constants.ArmIsSIGImage, false)
 
 	return stateBag
 }

--- a/builder/azure/arm/step_delete_additional_disks.go
+++ b/builder/azure/arm/step_delete_additional_disks.go
@@ -67,6 +67,7 @@ func (s *StepDeleteAdditionalDisk) Run(ctx context.Context, state multistep.Stat
 		dataDisks = disks.([]string)
 	}
 	var isManagedDisk = state.Get(constants.ArmIsManagedImage).(bool)
+	var isSIGImage = state.Get(constants.ArmIsSIGImage).(bool)
 	var isExistingResourceGroup = state.Get(constants.ArmIsExistingResourceGroup).(bool)
 	var resourceGroupName = state.Get(constants.ArmResourceGroupName).(string)
 
@@ -75,7 +76,7 @@ func (s *StepDeleteAdditionalDisk) Run(ctx context.Context, state multistep.Stat
 		return multistep.ActionContinue
 	}
 
-	if isManagedDisk && !isExistingResourceGroup {
+	if (isManagedDisk || isSIGImage) && !isExistingResourceGroup {
 		s.say(" -> Additional Disk : skipping, managed disk was used...")
 		return multistep.ActionContinue
 	}
@@ -83,7 +84,7 @@ func (s *StepDeleteAdditionalDisk) Run(ctx context.Context, state multistep.Stat
 	for i, additionaldisk := range dataDisks {
 		s.say(fmt.Sprintf(" -> Additional Disk %d: '%s'", i+1, additionaldisk))
 		var err error
-		if isManagedDisk {
+		if isManagedDisk || isSIGImage {
 			err = s.deleteManaged(ctx, resourceGroupName, additionaldisk)
 			if err != nil {
 				s.say("Failed to delete the managed Additional Disk!")

--- a/builder/azure/arm/step_delete_additional_disks_test.go
+++ b/builder/azure/arm/step_delete_additional_disks_test.go
@@ -155,6 +155,7 @@ func TestStepDeleteAdditionalDiskShouldPassIfManagedDiskInTempResourceGroup(t *t
 	stateBag := new(multistep.BasicStateBag)
 	stateBag.Put(constants.ArmAdditionalDiskVhds, []string{"subscriptions/123-456-789/resourceGroups/existingresourcegroup/providers/Microsoft.Compute/disks/osdisk"})
 	stateBag.Put(constants.ArmIsManagedImage, true)
+	stateBag.Put(constants.ArmIsSIGImage, false)
 	stateBag.Put(constants.ArmIsExistingResourceGroup, false)
 	stateBag.Put(constants.ArmResourceGroupName, "testgroup")
 
@@ -179,6 +180,7 @@ func TestStepDeleteAdditionalDiskShouldFailIfManagedDiskInExistingResourceGroupF
 	stateBag := new(multistep.BasicStateBag)
 	stateBag.Put(constants.ArmAdditionalDiskVhds, []string{"subscriptions/123-456-789/resourceGroups/existingresourcegroup/providers/Microsoft.Compute/disks/osdisk"})
 	stateBag.Put(constants.ArmIsManagedImage, true)
+	stateBag.Put(constants.ArmIsSIGImage, false)
 	stateBag.Put(constants.ArmIsExistingResourceGroup, true)
 	stateBag.Put(constants.ArmResourceGroupName, "testgroup")
 
@@ -203,6 +205,7 @@ func TestStepDeleteAdditionalDiskShouldFailIfManagedDiskInExistingResourceGroupI
 	stateBag := new(multistep.BasicStateBag)
 	stateBag.Put(constants.ArmAdditionalDiskVhds, []string{"subscriptions/123-456-789/resourceGroups/existingresourcegroup/providers/Microsoft.Compute/disks/osdisk"})
 	stateBag.Put(constants.ArmIsManagedImage, true)
+	stateBag.Put(constants.ArmIsSIGImage, false)
 	stateBag.Put(constants.ArmIsExistingResourceGroup, true)
 	stateBag.Put(constants.ArmResourceGroupName, "testgroup")
 
@@ -220,6 +223,7 @@ func DeleteTestStateBagStepDeleteAdditionalDisk(osDiskVhds []string) multistep.S
 	stateBag := new(multistep.BasicStateBag)
 	stateBag.Put(constants.ArmAdditionalDiskVhds, osDiskVhds)
 	stateBag.Put(constants.ArmIsManagedImage, false)
+	stateBag.Put(constants.ArmIsSIGImage, false)
 	stateBag.Put(constants.ArmIsExistingResourceGroup, false)
 	stateBag.Put(constants.ArmResourceGroupName, "testgroup")
 

--- a/builder/azure/arm/step_deploy_template_test.go
+++ b/builder/azure/arm/step_deploy_template_test.go
@@ -115,6 +115,7 @@ func TestStepDeployTemplateCleanupShouldDeleteManagedOSImageInExistingResourceGr
 
 	stateBag := createTestStateBagStepDeployTemplate()
 	stateBag.Put(constants.ArmIsManagedImage, true)
+	stateBag.Put(constants.ArmIsSIGImage, false)
 	stateBag.Put(constants.ArmIsExistingResourceGroup, true)
 	stateBag.Put(constants.ArmIsResourceGroupCreated, true)
 	stateBag.Put(constants.ArmKeepOSDisk, false)
@@ -132,6 +133,7 @@ func TestStepDeployTemplateCleanupShouldDeleteManagedOSImageInTemporaryResourceG
 
 	stateBag := createTestStateBagStepDeployTemplate()
 	stateBag.Put(constants.ArmIsManagedImage, true)
+	stateBag.Put(constants.ArmIsSIGImage, false)
 	stateBag.Put(constants.ArmIsExistingResourceGroup, false)
 	stateBag.Put(constants.ArmIsResourceGroupCreated, true)
 	stateBag.Put(constants.ArmKeepOSDisk, false)
@@ -149,6 +151,7 @@ func TestStepDeployTemplateCleanupShouldDeleteVHDOSImageInExistingResourceGroup(
 
 	stateBag := createTestStateBagStepDeployTemplate()
 	stateBag.Put(constants.ArmIsManagedImage, false)
+	stateBag.Put(constants.ArmIsSIGImage, false)
 	stateBag.Put(constants.ArmIsExistingResourceGroup, true)
 	stateBag.Put(constants.ArmIsResourceGroupCreated, true)
 	stateBag.Put(constants.ArmKeepOSDisk, false)
@@ -166,6 +169,7 @@ func TestStepDeployTemplateCleanupShouldVHDOSImageInTemporaryResourceGroup(t *te
 
 	stateBag := createTestStateBagStepDeployTemplate()
 	stateBag.Put(constants.ArmIsManagedImage, false)
+	stateBag.Put(constants.ArmIsSIGImage, false)
 	stateBag.Put(constants.ArmIsExistingResourceGroup, false)
 	stateBag.Put(constants.ArmIsResourceGroupCreated, true)
 	stateBag.Put(constants.ArmKeepOSDisk, false)

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -110,17 +110,9 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 		if err != nil {
 			return nil, err
 		}
-	} else if config.ManagedImageName != "" && config.ImagePublisher != "" {
-		imageID := fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Compute/locations/%s/publishers/%s/ArtifactTypes/vmimage/offers/%s/skus/%s/versions/%s",
-			config.ClientConfig.SubscriptionID,
-			config.Location,
-			config.ImagePublisher,
-			config.ImageOffer,
-			config.ImageSku,
-			config.ImageVersion)
-
+	} else if (config.isManagedImage() || config.isPublishToSIG()) && config.ImagePublisher != "" {
 		// TODO : Handle this error
-		_ = builder.SetManagedMarketplaceImage(config.Location, config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion, imageID, config.managedImageStorageAccountType, config.diskCachingType)
+		_ = builder.SetManagedMarketplaceImage(config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion, config.managedImageStorageAccountType, config.diskCachingType)
 	} else if config.SharedGallery.Subscription != "" {
 		imageID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s",
 			config.SharedGallery.Subscription,

--- a/builder/azure/common/constants/stateBag.go
+++ b/builder/azure/common/constants/stateBag.go
@@ -38,6 +38,7 @@ const (
 	ArmIsExistingResourceGroup                                 string = "arm.IsExistingResourceGroup"
 	ArmIsExistingKeyVault                                      string = "arm.IsExistingKeyVault"
 	ArmIsManagedImage                                          string = "arm.IsManagedImage"
+	ArmIsSIGImage                                              string = "arm.IsSIGImage"
 	ArmManagedImageResourceGroupName                           string = "arm.ManagedImageResourceGroupName"
 	ArmManagedImageName                                        string = "arm.ManagedImageName"
 	ArmManagedImageSigPublishResourceGroup                     string = "arm.ManagedImageSigPublishResourceGroup"

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -161,7 +161,7 @@ func (s *TemplateBuilder) SetManagedDiskUrl(managedImageId string, storageAccoun
 	return nil
 }
 
-func (s *TemplateBuilder) SetManagedMarketplaceImage(location, publisher, offer, sku, version, imageID string, storageAccountType compute.StorageAccountTypes, cachingType compute.CachingTypes) error {
+func (s *TemplateBuilder) SetManagedMarketplaceImage(publisher, offer, sku, version string, storageAccountType compute.StorageAccountTypes, cachingType compute.CachingTypes) error {
 	resource, err := s.getResourceByType(resourceVirtualMachine)
 	if err != nil {
 		return err

--- a/builder/azure/common/template/template_builder_test.go
+++ b/builder/azure/common/template/template_builder_test.go
@@ -131,7 +131,7 @@ func TestBuildWindows01(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = testSubject.SetManagedMarketplaceImage("MicrosoftWindowsServer", "WindowsServer", "2012-R2-Datacenter", "latest", "2015-1", "1", "Premium_LRS", compute.CachingTypesReadWrite)
+	err = testSubject.SetManagedMarketplaceImage("WindowsServer", "2012-R2-Datacenter", "latest", "2015-1", "Premium_LRS", compute.CachingTypesReadWrite)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/docs/builders/arm.mdx
+++ b/docs/builders/arm.mdx
@@ -80,9 +80,11 @@ you should specify `subscription_id`, `client_id` and one of `client_secret`,
 
 ### Azure ARM builder specific options
 
-The Azure builder can create either a VHD or a managed image. If you are
-creating a VHD, you **must** start with a VHD. Likewise, if you want to create
+The Azure builder can create either a VHD, managed image or create a Shared Image Gallery.
+If you are creating a VHD, you **must** start with a VHD. Likewise, if you want to create
 a managed image you **must** start with a managed image.
+Managed images can also be published to shared image galleries,
+but a managed image definition is not required to publish to a gallery.
 
 ### Required:
 


### PR DESCRIPTION
As result it fixes #210 
ARM64 Managed Images are not supported, only ones in Shared Image Gallery.

I've tested it on Windows 11 ARM64 in West Europe, works!
Input from contributors/mainteners is welcome.

Closes #210

