### PR TITLE
[CR254] Set "image_version" to "default" in all sample config files

### DIFF
--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -380,6 +380,7 @@ func testBuilderUserDataLinux(userdata string) string {
 	  "image_publisher": "Canonical",
 	  "image_offer": "UbuntuServer",
 	  "image_sku": "16.04-LTS",
+	  "image_version": "latest",
 	  "user_data_file": "%s",
 
 	  "location": "South Central US",
@@ -415,6 +416,7 @@ const testBuilderAccManagedDiskWindows = `
 	  "image_publisher": "MicrosoftWindowsServer",
 	  "image_offer": "WindowsServer",
 	  "image_sku": "2012-R2-Datacenter",
+	  "image_version": "latest",
 
 	  "communicator": "winrm",
 	  "winrm_use_ssl": "true",
@@ -451,6 +453,7 @@ const testBuilderAccManagedDiskWindowsBuildResourceGroup = `
 	  "image_publisher": "MicrosoftWindowsServer",
 	  "image_offer": "WindowsServer",
 	  "image_sku": "2012-R2-Datacenter",
+	  "image_version": "latest",
 
 	  "communicator": "winrm",
 	  "winrm_use_ssl": "true",
@@ -486,6 +489,7 @@ const testBuilderAccManagedDiskWindowsBuildResourceGroupAdditionalDisk = `
 	  "image_publisher": "MicrosoftWindowsServer",
 	  "image_offer": "WindowsServer",
 	  "image_sku": "2012-R2-Datacenter",
+	  "image_version": "latest",
 
 	  "communicator": "winrm",
 	  "winrm_use_ssl": "true",
@@ -551,6 +555,7 @@ const testBuilderAccManagedDiskLinux = `
 	  "image_publisher": "Canonical",
 	  "image_offer": "UbuntuServer",
 	  "image_sku": "16.04-LTS",
+	  "image_version": "latest",
 
 	  "location": "South Central US",
 	  "vm_size": "Standard_DS2_v2",
@@ -579,6 +584,7 @@ const testBuilderAccManagedDiskLinuxDeviceLogin = `
 	  "image_publisher": "Canonical",
 	  "image_offer": "UbuntuServer",
 	  "image_sku": "16.04-LTS",
+	  "image_version": "latest",
 	  "async_resourcegroup_delete": "true",
 
 	  "location": "South Central US",
@@ -611,6 +617,7 @@ const testBuilderAccBlobWindows = `
 	  "image_publisher": "MicrosoftWindowsServer",
 	  "image_offer": "WindowsServer",
 	  "image_sku": "2012-R2-Datacenter",
+	  "image_version": "latest",
 
 	  "communicator": "winrm",
 	  "winrm_use_ssl": "true",
@@ -648,6 +655,7 @@ const testBuilderAccBlobLinux = `
 	  "image_publisher": "Canonical",
 	  "image_offer": "UbuntuServer",
 	  "image_sku": "16.04-LTS",
+	  "image_version": "latest",
 
 	  "location": "South Central US",
 	  "vm_size": "Standard_DS2_v2"
@@ -670,6 +678,7 @@ const testBuilderAccManagedDiskLinuxAzureCLI = `
 	  "image_publisher": "Canonical",
 	  "image_offer": "UbuntuServer",
 	  "image_sku": "16.04-LTS",
+	  "image_version": "latest",
 
 	  "location": "South Central US",
 	  "vm_size": "Standard_DS2_v2",

--- a/builder/azure/arm/testdata/rsa_sha2_only_server.pkr.hcl
+++ b/builder/azure/arm/testdata/rsa_sha2_only_server.pkr.hcl
@@ -26,6 +26,8 @@ source "azure-arm" "ubuntu2204" {
   image_publisher = "canonical"
   image_offer     = "0001-com-ubuntu-server-jammy-daily"
   image_sku       = "22_04-daily-lts"
+  image_versio    = "latest"
+  image_version   = "latest"
 
   location = "West US2"
   vm_size  = "Standard_DS2_v2"

--- a/builder/azure/arm/testdata/rsa_sha2_only_server.pkr.hcl
+++ b/builder/azure/arm/testdata/rsa_sha2_only_server.pkr.hcl
@@ -26,7 +26,6 @@ source "azure-arm" "ubuntu2204" {
   image_publisher = "canonical"
   image_offer     = "0001-com-ubuntu-server-jammy-daily"
   image_sku       = "22_04-daily-lts"
-  image_versio    = "latest"
   image_version   = "latest"
 
   location = "West US2"

--- a/builder/azure/dtl/WindowsMixAndMatch.json
+++ b/builder/azure/dtl/WindowsMixAndMatch.json
@@ -21,6 +21,7 @@
       "image_publisher": "MicrosoftWindowsDesktop",
       "image_offer": "Windows-10",
       "image_sku": "19h1-ent",
+      "image_version": "latest",
       "azure_tags": {
         "dept": "Engineering",
         "task": "Image deployment"

--- a/builder/azure/dtl/WindowsSimple.json
+++ b/builder/azure/dtl/WindowsSimple.json
@@ -21,6 +21,7 @@
       "image_publisher": "MicrosoftWindowsDesktop",
       "image_offer": "Windows-10",
       "image_sku": "19h1-ent",
+      "image_version": "latest",
       "azure_tags": {
         "dept": "Engineering",
         "task": "Image deployment"

--- a/builder/azure/dtl/builder_acc_test.go
+++ b/builder/azure/dtl/builder_acc_test.go
@@ -91,6 +91,7 @@ const testBuilderAccManagedDiskWindows = `
 	  "image_publisher": "MicrosoftWindowsServer",
 	  "image_offer": "WindowsServer",
 	  "image_sku": "2012-R2-Datacenter",
+	  "image_version": "latest",
 
 	  "communicator": "winrm",
 	  "winrm_use_ssl": "true",
@@ -130,6 +131,7 @@ const testBuilderAccManagedDiskLinux = `
 	  "image_publisher": "Canonical",
 	  "image_offer": "UbuntuServer",
 	  "image_sku": "16.04-LTS",
+	  "image_version": "latest",
 
 	  "location": "South Central US",
 	  "vm_size": "Standard_DS2_v2",

--- a/docs/builders/dtl.mdx
+++ b/docs/builders/dtl.mdx
@@ -122,6 +122,7 @@ source "azure-dtl" "example" {
   image_offer                       = "UbuntuServer"
   image_publisher                   = "Canonical"
   image_sku                         = "16.04-LTS"
+  image_version                     = "latest"
   lab_name                          = "packer-test"
   lab_resource_group_name           = "packer-test"
   lab_virtual_network_name          = "dtlpacker-test"

--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -90,6 +90,7 @@ source "azure-arm" "basic-example" {
   image_publisher = "Canonical"
   image_offer = "UbuntuServer"
   image_sku = "14.04.4-LTS"
+  image_version = "latest"
 
   location = "West US"
   vm_size = "Standard_A2"

--- a/example/centos.json
+++ b/example/centos.json
@@ -2,11 +2,11 @@
   "variables": {
     "client_id": "{{env `ARM_CLIENT_ID`}}",
     "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
-    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
-    "tenant_id": "{{env `ARM_TENANT_ID`}}",
+    "resource_group": "{{env `ARM_RESOURCE_GROUP_NAME`}}",
     "ssh_user": "centos",
     "ssh_pass": "{{env `ARM_SSH_PASS`}}",
-    "resource_group": "{{env `ARM_RESOURCE_GROUP_NAME`}}"
+    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
+    "tenant_id": "{{env `ARM_TENANT_ID`}}"
   },
   "builders": [{
     "type": "azure-arm",

--- a/example/debian.json
+++ b/example/debian.json
@@ -2,9 +2,9 @@
   "variables": {
     "client_id": "{{env `ARM_CLIENT_ID`}}",
     "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
-    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
     "ssh_user": "packer",
-    "ssh_pass": "{{env `ARM_SSH_PASS`}}"
+    "ssh_pass": "{{env `ARM_SSH_PASS`}}",
+    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}"
   },
   "builders": [{
     "type": "azure-arm",
@@ -25,6 +25,7 @@
     "image_publisher": "credativ",
     "image_offer": "Debian",
     "image_sku": "9",
+    "image_version": "latest",
     "ssh_pty": "true",
 
     "location": "South Central US",

--- a/example/freebsd.json
+++ b/example/freebsd.json
@@ -2,9 +2,9 @@
   "variables": {
     "client_id": "{{env `ARM_CLIENT_ID`}}",
     "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
-    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
     "ssh_user": "packer",
-    "ssh_pass": "{{env `ARM_SSH_PASS`}}"
+    "ssh_pass": "{{env `ARM_SSH_PASS`}}",
+    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}"
   },
   "builders": [{
     "type": "azure-arm",

--- a/example/marketplace_plan_info.json
+++ b/example/marketplace_plan_info.json
@@ -18,6 +18,7 @@
     "image_publisher": "bitnami",
     "image_offer": "rabbitmq",
     "image_sku": "rabbitmq",
+    "image_version": "latest",
 
     "azure_tags": {
         "dept": "engineering",

--- a/example/rhel.json
+++ b/example/rhel.json
@@ -2,10 +2,10 @@
   "variables": {
     "client_id": "{{env `ARM_CLIENT_ID`}}",
     "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
-    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
-    "tenant_id": "{{env `ARM_TENANT_ID`}}",
     "ssh_user": "centos",
-    "ssh_pass": "{{env `ARM_SSH_PASS`}}"
+    "ssh_pass": "{{env `ARM_SSH_PASS`}}",
+    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
+    "tenant_id": "{{env `ARM_TENANT_ID`}}"
   },
   "builders": [{
     "type": "azure-arm",
@@ -17,7 +17,6 @@
 
     "managed_image_resource_group_name": "packertest",
     "managed_image_name": "MyRedHatOSImage",
-
 
     "ssh_username": "{{user `ssh_user`}}",
     "ssh_password": "{{user `ssh_pass`}}",

--- a/example/suse.json
+++ b/example/suse.json
@@ -2,9 +2,9 @@
   "variables": {
     "client_id": "{{env `ARM_CLIENT_ID`}}",
     "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
-    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
     "ssh_user": "packer",
-    "ssh_pass": "{{env `ARM_SSH_PASS`}}"
+    "ssh_pass": "{{env `ARM_SSH_PASS`}}",
+    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}"
   },
   "builders": [{
     "type": "azure-arm",
@@ -23,6 +23,7 @@
     "image_publisher": "SUSE",
     "image_offer": "SLES",
     "image_sku": "12-SP3",
+    "image_version": "latest",
     "ssh_pty": "true",
 
     "location": "South Central US",

--- a/example/ubuntu-chroot.json
+++ b/example/ubuntu-chroot.json
@@ -2,9 +2,9 @@
   "variables": {
     "client_id": "{{env `ARM_CLIENT_ID`}}",
     "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
-    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
+    "gallery_name": "{{env `ARM_GALLERY_NAME`}}",
     "resource_group": "{{env `ARM_IMAGE_RESOURCEGROUP_ID`}}",
-    "gallery_name": "{{env `ARM_GALLERY_NAME`}}"
+    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}"
   },
   "builders": [{
     "type": "azure-chroot",

--- a/example/ubuntu.json
+++ b/example/ubuntu.json
@@ -15,6 +15,7 @@
     "image_publisher": "Canonical",
     "image_offer": "UbuntuServer",
     "image_sku": "16.04-LTS",
+    "image_version": "latest",
 
     "managed_image_resource_group_name": "packertest",
     "managed_image_name": "MyUbuntuImage",

--- a/example/ubuntu_quickstart.json
+++ b/example/ubuntu_quickstart.json
@@ -18,6 +18,7 @@
     "image_publisher": "Canonical",
     "image_offer": "UbuntuServer",
     "image_sku": "16.04-LTS",
+    "image_version": "latest",
 
     "location": "West US",
     "vm_size": "Standard_DS2_v2"

--- a/example/windows.json
+++ b/example/windows.json
@@ -18,6 +18,7 @@
     "image_publisher": "MicrosoftWindowsServer",
     "image_offer": "WindowsServer",
     "image_sku": "2012-R2-Datacenter",
+    "image_version": "latest",
 
     "communicator": "winrm",
     "winrm_use_ssl": "true",

--- a/example/windows_custom_image.json
+++ b/example/windows_custom_image.json
@@ -2,10 +2,10 @@
   "variables": {
     "client_id": "{{env `ARM_CLIENT_ID`}}",
     "client_secret": "{{env `ARM_CLIENT_SECRET`}}",
+    "object_id": "{{env `ARM_OBJECT_ID`}}",
     "resource_group": "{{env `ARM_RESOURCE_GROUP`}}",
     "storage_account": "{{env `ARM_STORAGE_ACCOUNT`}}",
-    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}",
-    "object_id": "{{env `ARM_OBJECT_ID`}}"
+    "subscription_id": "{{env `ARM_SUBSCRIPTION_ID`}}"
   },
   "builders": [
     {

--- a/example/windows_quickstart.json
+++ b/example/windows_quickstart.json
@@ -14,6 +14,7 @@
     "image_publisher": "MicrosoftWindowsServer",
     "image_offer": "WindowsServer",
     "image_sku": "2012-R2-Datacenter",
+    "image_version": "latest",
 
     "communicator": "winrm",
     "winrm_use_ssl": "true",


### PR DESCRIPTION
Feature request 254 requests adding the "image_version" set to the default "latest" value consistently in every sample file. Some have it, some don't, let's be consistent if we can.