### PR TITLE
Enable SecurityProfile (TrustedLaunch) for Virtual Machines

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1068,6 +1068,10 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A managed image must be created from a managed image, it cannot be created from a VHD."))
 	}
 
+	if (c.SecureBootEnabled || c.VTpmEnabled) && isCustomManagedImage {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A managed image can not set SecureBoot or VTpm, these features are only supported when directly publishing to a Shared Image Gallery"))
+	}
+
 	if (c.CaptureContainerName != "" || c.CaptureNamePrefix != "" || c.ManagedImageName != "") && c.DiskEncryptionSetId != "" {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("Setting a disk encryption set ID is not allowed when building a VHD or creating a Managed Image, only when publishing directly to Shared Image Gallery"))
 	}

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1068,7 +1068,7 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A managed image must be created from a managed image, it cannot be created from a VHD."))
 	}
 
-	if (c.SecureBootEnabled || c.VTpmEnabled) && (c.ManagedImageName != "" && c.ManagedImageResourceGroupName != "") {
+	if (c.SecureBootEnabled || c.VTpmEnabled) && (c.ManagedImageName != "" || c.ManagedImageResourceGroupName != "") {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A managed image (managed_image_name, managed_image_resource_group_name) can not set SecureBoot or VTpm, these features are only supported when directly publishing to a Shared Image Gallery"))
 	}
 

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1068,8 +1068,8 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A managed image must be created from a managed image, it cannot be created from a VHD."))
 	}
 
-	if (c.SecureBootEnabled || c.VTpmEnabled) && isCustomManagedImage {
-		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A managed image can not set SecureBoot or VTpm, these features are only supported when directly publishing to a Shared Image Gallery"))
+	if (c.SecureBootEnabled || c.VTpmEnabled) && (c.ManagedImageName != "" && c.ManagedImageResourceGroupName != "") {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("A managed image (managed_image_name, managed_image_resource_group_name) can not set SecureBoot or VTpm, these features are only supported when directly publishing to a Shared Image Gallery"))
 	}
 
 	if (c.CaptureContainerName != "" || c.CaptureNamePrefix != "" || c.ManagedImageName != "") && c.DiskEncryptionSetId != "" {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -535,6 +535,11 @@ type Config struct {
 	// or
 	// [Linux](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/azure-hybrid-benefit-linux)
 	LicenseType string `mapstructure:"license_type" required:"false"`
+	// Specifies if Secure Boot and Trusted Launch is enabled for the Virtual Machine.
+	SecureBootEnabled bool `mapstructure:"secure_boot_enabled" required:"false"`
+
+	// Specifies if vTPM (virtual Trusted Platform Module) and Trusted Launch is enabled for the Virtual Machine.
+	VTpmEnabled bool `mapstructure:"vtpm_enabled" required:"false"`
 
 	// Runtime Values
 	UserName               string `mapstructure-to-hcl2:",skip"`

--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -90,6 +90,8 @@ type FlatConfig struct {
 	BootDiagSTGAccount                         *string                            `mapstructure:"boot_diag_storage_account" required:"false" cty:"boot_diag_storage_account" hcl:"boot_diag_storage_account"`
 	CustomResourcePrefix                       *string                            `mapstructure:"custom_resource_build_prefix" required:"false" cty:"custom_resource_build_prefix" hcl:"custom_resource_build_prefix"`
 	LicenseType                                *string                            `mapstructure:"license_type" required:"false" cty:"license_type" hcl:"license_type"`
+	SecureBootEnabled                          *bool                              `mapstructure:"secure_boot_enabled" required:"false" cty:"secure_boot_enabled" hcl:"secure_boot_enabled"`
+	VTpmEnabled                                *bool                              `mapstructure:"vtpm_enabled" required:"false" cty:"vtpm_enabled" hcl:"vtpm_enabled"`
 	Type                                       *string                            `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect                         *string                            `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
 	SSHHost                                    *string                            `mapstructure:"ssh_host" cty:"ssh_host" hcl:"ssh_host"`
@@ -232,6 +234,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"boot_diag_storage_account":                        &hcldec.AttrSpec{Name: "boot_diag_storage_account", Type: cty.String, Required: false},
 		"custom_resource_build_prefix":                     &hcldec.AttrSpec{Name: "custom_resource_build_prefix", Type: cty.String, Required: false},
 		"license_type":                                     &hcldec.AttrSpec{Name: "license_type", Type: cty.String, Required: false},
+		"secure_boot_enabled":                              &hcldec.AttrSpec{Name: "secure_boot_enabled", Type: cty.Bool, Required: false},
+		"vtpm_enabled":                                     &hcldec.AttrSpec{Name: "vtpm_enabled", Type: cty.Bool, Required: false},
 		"communicator":                                     &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":                          &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},
 		"ssh_host":                                         &hcldec.AttrSpec{Name: "ssh_host", Type: cty.String, Required: false},

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -1321,6 +1322,58 @@ func TestConfigShouldRejectManagedImageOSDiskSnapshotNameAndManagedImageDataDisk
 	_, err := c.Prepare(config, getPackerConfiguration())
 	if err == nil {
 		t.Fatal("expected config to reject Managed Image build with data disk snapshot prefix and OS disk snapshot name with capture name prefix")
+	}
+}
+
+func TestConfigShouldRejectSecureBootWhenPublishingToAManagedImage(t *testing.T) {
+	expectedErrorMessage := "A managed image (managed_image_name, managed_image_resource_group_name) can not set SecureBoot or VTpm, these features are only supported when directly publishing to a Shared Image Gallery"
+	config := map[string]interface{}{
+		"image_offer":                       "ignore",
+		"image_publisher":                   "ignore",
+		"image_sku":                         "ignore",
+		"location":                          "ignore",
+		"subscription_id":                   "ignore",
+		"communicator":                      "none",
+		"managed_image_resource_group_name": "ignore",
+		"managed_image_name":                "ignore",
+		"secure_boot_enabled":               "true",
+
+		// Does not matter for this test case, just pick one.
+		"os_type": constants.Target_Linux,
+	}
+
+	var c Config
+	_, err := c.Prepare(config, getPackerConfiguration())
+	if err == nil {
+		t.Fatal("expected config to reject managed image with secure boot, secure boot is only allowed when direct publishing to SIG")
+	} else if !strings.Contains(err.Error(), expectedErrorMessage) {
+		t.Fatalf("unexpected rejection reason, expected %s to contain %s", err.Error(), expectedErrorMessage)
+	}
+}
+
+func TestConfigShouldRejectVTPMWhenPublishingToAManagedImage(t *testing.T) {
+	expectedErrorMessage := "A managed image (managed_image_name, managed_image_resource_group_name) can not set SecureBoot or VTpm, these features are only supported when directly publishing to a Shared Image Gallery"
+	config := map[string]interface{}{
+		"image_offer":                       "ignore",
+		"image_publisher":                   "ignore",
+		"image_sku":                         "ignore",
+		"location":                          "ignore",
+		"subscription_id":                   "ignore",
+		"communicator":                      "none",
+		"managed_image_resource_group_name": "ignore",
+		"managed_image_name":                "ignore",
+		"vtpm_enabled":                      "true",
+
+		// Does not matter for this test case, just pick one.
+		"os_type": constants.Target_Linux,
+	}
+
+	var c Config
+	_, err := c.Prepare(config, getPackerConfiguration())
+	if err == nil {
+		t.Fatal("expected config to reject managed image with secure boot, secure boot is only allowed when direct publishing to SIG")
+	} else if !strings.Contains(err.Error(), expectedErrorMessage) {
+		t.Fatalf("unexpected rejection reason, expected %s to contain %s", err.Error(), expectedErrorMessage)
 	}
 }
 

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -238,6 +238,13 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 		}
 	}
 
+	if config.SecureBootEnabled || config.VTpmEnabled {
+		err = builder.SetSecurityProfile(config.SecureBootEnabled, config.VTpmEnabled)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	err = builder.SetTags(&config.AzureTags)
 	if err != nil {
 		return nil, err

--- a/builder/azure/arm/template_factory_test.TestTrustedLaunch01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestTrustedLaunch01.approved.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminPassword": {
+      "type": "securestring"
+    },
+    "adminUsername": {
+      "type": "string"
+    },
+    "dataDiskName": {
+      "type": "string"
+    },
+    "dnsNameForPublicIP": {
+      "type": "string"
+    },
+    "nicName": {
+      "type": "string"
+    },
+    "nsgName": {
+      "type": "string"
+    },
+    "osDiskName": {
+      "type": "string"
+    },
+    "publicIPAddressName": {
+      "type": "string"
+    },
+    "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
+      "type": "string"
+    },
+    "vmName": {
+      "type": "string"
+    },
+    "vmSize": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "apiVersion": "[variables('publicIPAddressApiVersion')]",
+      "location": "[variables('location')]",
+      "name": "[parameters('publicIPAddressName')]",
+      "properties": {
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+        },
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]"
+      },
+      "type": "Microsoft.Network/publicIPAddresses"
+    },
+    {
+      "apiVersion": "[variables('virtualNetworksApiVersion')]",
+      "location": "[variables('location')]",
+      "name": "[variables('virtualNetworkName')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetAddressPrefix')]"
+            }
+          }
+        ]
+      },
+      "type": "Microsoft.Network/virtualNetworks"
+    },
+    {
+      "apiVersion": "[variables('networkInterfacesApiVersion')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "location": "[variables('location')]",
+      "name": "[parameters('nicName')]",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      },
+      "type": "Microsoft.Network/networkInterfaces"
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
+      ],
+      "location": "[variables('location')]",
+      "name": "[parameters('vmName')]",
+      "properties": {
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": false
+          }
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            }
+          ]
+        },
+        "osProfile": {
+          "adminPassword": "[parameters('adminPassword')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "computerName": "[parameters('vmName')]",
+          "linuxConfiguration": {
+            "ssh": {
+              "publicKeys": [
+                {
+                  "keyData": "",
+                  "path": "[variables('sshKeyPath')]"
+                }
+              ]
+            }
+          }
+        },
+        "securityProfile": {
+          "securityType": "TrustedLaunch",
+          "uefiSettings": {
+            "secureBootEnabled": true,
+            "vTpmEnabled": true
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "offer": "ignored00",
+            "publisher": "ignored00",
+            "sku": "ignored00",
+            "version": "latest"
+          },
+          "osDisk": {
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "name": "[parameters('osDiskName')]",
+            "vhd": {
+              "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"
+            }
+          }
+        }
+      },
+      "type": "Microsoft.Compute/virtualMachines"
+    }
+  ],
+  "variables": {
+    "addressPrefix": "10.0.0.0/16",
+    "apiVersion": "2020-12-01",
+    "location": "[resourceGroup().location]",
+    "managedDiskApiVersion": "2017-03-30",
+    "networkInterfacesApiVersion": "2017-04-01",
+    "networkSecurityGroupsApiVersion": "2019-04-01",
+    "publicIPAddressApiVersion": "2017-04-01",
+    "publicIPAddressType": "Dynamic",
+    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
+    "subnetAddressPrefix": "10.0.0.0/24",
+    "subnetName": "[parameters('subnetName')]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
+    "virtualNetworkResourceGroup": "[resourceGroup().name]",
+    "virtualNetworksApiVersion": "2017-04-01",
+    "vmStorageAccountContainerName": "images",
+    "vnetID": "[resourceId(variables('virtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+  }
+}

--- a/builder/azure/arm/template_factory_test.TestTrustedLaunch01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestTrustedLaunch01.approved.json
@@ -8,6 +8,9 @@
     "adminUsername": {
       "type": "string"
     },
+    "commandToExecute": {
+      "type": "string"
+    },
     "dataDiskName": {
       "type": "string"
     },
@@ -165,6 +168,25 @@
         }
       },
       "type": "Microsoft.Compute/virtualMachines"
+    },
+    {
+      "apiVersion": "2022-08-01",
+      "condition": "[not(empty(parameters('commandToExecute')))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+      ],
+      "location": "[variables('location')]",
+      "name": "[concat(parameters('vmName'), '/extension-customscript')]",
+      "properties": {
+        "autoUpgradeMinorVersion": true,
+        "publisher": "Microsoft.Compute",
+        "settings": {
+          "commandToExecute": "[parameters('commandToExecute')]"
+        },
+        "type": "CustomScriptExtension",
+        "typeHandlerVersion": "1.8"
+      },
+      "type": "Microsoft.Compute/virtualMachines/extensions"
     }
   ],
   "variables": {

--- a/builder/azure/arm/template_factory_test.go
+++ b/builder/azure/arm/template_factory_test.go
@@ -690,3 +690,21 @@ func TestPlanInfo02(t *testing.T) {
 
 	approvaltests.VerifyJSONStruct(t, deployment.Properties.Template)
 }
+
+func TestTrustedLaunch01(t *testing.T) {
+	m := getArmBuilderConfiguration()
+	m["secure_boot_enabled"] = "true"
+	m["vtpm_enabled"] = "true"
+
+	var c Config
+	_, err := c.Prepare(m, getPackerConfiguration(), getPackerSSHPasswordCommunicatorConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment, err := GetVirtualMachineDeployment(&c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	approvaltests.VerifyJSONStruct(t, deployment.Properties.Template)
+}

--- a/builder/azure/common/template/template.go
+++ b/builder/azure/common/template/template.go
@@ -104,6 +104,7 @@ type Properties struct {
 	Sku                          *Sku                                       `json:"sku,omitempty"`
 	UserData                     *string                                    `json:"userData,omitempty"`
 	StorageProfile               *StorageProfileUnion                       `json:"storageProfile,omitempty"`
+	SecurityProfile              *compute.SecurityProfile                   `json:"securityProfile,omitempty"`
 	Subnets                      *[]network.Subnet                          `json:"subnets,omitempty"`
 	SecurityRules                *[]network.SecurityRule                    `json:"securityRules,omitempty"`
 	TenantId                     *string                                    `json:"tenantId,omitempty"`

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -508,14 +508,8 @@ func (s *TemplateBuilder) SetSecurityProfile(secureBootEnabled bool, vtpmEnabled
 	resource.Properties.SecurityProfile = &compute.SecurityProfile{}
 	resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
 	resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
-
-	if secureBootEnabled {
-		resource.Properties.SecurityProfile.UefiSettings.SecureBootEnabled = to.BoolPtr(secureBootEnabled)
-	}
-
-	if vtpmEnabled {
-		resource.Properties.SecurityProfile.UefiSettings.VTpmEnabled = to.BoolPtr(vtpmEnabled)
-	}
+	resource.Properties.SecurityProfile.UefiSettings.SecureBootEnabled = to.BoolPtr(secureBootEnabled)
+	resource.Properties.SecurityProfile.UefiSettings.VTpmEnabled = to.BoolPtr(vtpmEnabled)
 
 	return nil
 }

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -498,6 +498,38 @@ func (s *TemplateBuilder) SetLicenseType(licenseType string) error {
 	return nil
 }
 
+func (s *TemplateBuilder) SetSecurityProfile(secureBootEnabled bool, vtpmEnabled bool) error {
+	s.setVariable("apiVersion", "2020-12-01") // Required for Trusted Launch
+	resource, err := s.getResourceByType(resourceVirtualMachine)
+	if err != nil {
+		return err
+	}
+
+	if secureBootEnabled {
+		if resource.Properties.SecurityProfile == nil {
+			resource.Properties.SecurityProfile = &compute.SecurityProfile{}
+		}
+		if resource.Properties.SecurityProfile.UefiSettings == nil {
+			resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+		}
+		resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
+		resource.Properties.SecurityProfile.UefiSettings.SecureBootEnabled = to.BoolPtr(secureBootEnabled)
+	}
+
+	if vtpmEnabled {
+		if resource.Properties.SecurityProfile == nil {
+			resource.Properties.SecurityProfile = &compute.SecurityProfile{}
+		}
+		if resource.Properties.SecurityProfile.UefiSettings == nil {
+			resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+		}
+		resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
+		resource.Properties.SecurityProfile.UefiSettings.VTpmEnabled = to.BoolPtr(vtpmEnabled)
+	}
+
+	return nil
+}
+
 func (s *TemplateBuilder) ToJSON() (*string, error) {
 	bs, err := json.MarshalIndent(s.template, jsonPrefix, jsonIndent)
 

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -505,25 +505,15 @@ func (s *TemplateBuilder) SetSecurityProfile(secureBootEnabled bool, vtpmEnabled
 		return err
 	}
 
+	resource.Properties.SecurityProfile = &compute.SecurityProfile{}
+	resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+	resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
+
 	if secureBootEnabled {
-		if resource.Properties.SecurityProfile == nil {
-			resource.Properties.SecurityProfile = &compute.SecurityProfile{}
-		}
-		if resource.Properties.SecurityProfile.UefiSettings == nil {
-			resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
-		}
-		resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
 		resource.Properties.SecurityProfile.UefiSettings.SecureBootEnabled = to.BoolPtr(secureBootEnabled)
 	}
 
 	if vtpmEnabled {
-		if resource.Properties.SecurityProfile == nil {
-			resource.Properties.SecurityProfile = &compute.SecurityProfile{}
-		}
-		if resource.Properties.SecurityProfile.UefiSettings == nil {
-			resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
-		}
-		resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
 		resource.Properties.SecurityProfile.UefiSettings.VTpmEnabled = to.BoolPtr(vtpmEnabled)
 	}
 

--- a/docs-partials/builder/azure/arm/Config-not-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-not-required.mdx
@@ -358,6 +358,10 @@
   [Windows](https://learn.microsoft.com/en-us/azure/virtual-machines/windows/hybrid-use-benefit-licensing)
   or
   [Linux](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/azure-hybrid-benefit-linux)
+  
+- `secure_boot_enabled` (bool) - Specifies if Secure Boot and Trusted Launch is enabled for the Virtual Machine.
+
+- `vtpm_enabled` (bool) - Specifies if vTPM (virtual Trusted Platform Module) and Trusted Launch is enabled for the Virtual Machine.
 
 - `async_resourcegroup_delete` (bool) - If you want packer to delete the
   temporary resource group asynchronously set this value. It's a boolean


### PR DESCRIPTION
This PR extends the existing PR https://github.com/hashicorp/packer-plugin-azure/pull/220 but adds the requested change from @JenGoldstrich to add tests for the new parameters.

The previous PR has been idle for several months and as this is a popular request I'm hoping this can be progressed.

As per the previous discussion - TrustedLaunch only applies to Virtual Machines, not images, however an image to be used with for a Trusted Launch enabled VM must be created using a builder VM with trusted launch enabled. It cannot be enabled after initial deployment.

Description of change from existing PR (220):

Sets the SecurityProfile if either Secure Boot or the VTPM option has been set in the packer configuration. This allows the deployment of VMs using Trusted Launch either from marketplace or Shared Image Gallery if the image has been enabled for trusted launch.

Introduced two new parameters:
secure_boot_enabled
vtpm_enabled

Closes https://github.com/hashicorp/packer-plugin-azure/issues/221

