### PR TITLE
Ensure `build.password` parameter gets set to generated password for SSH Communicator when no SSH password is set

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -861,6 +861,9 @@ func setUserNamePassword(c *Config) error {
 	}
 
 	if c.Comm.Type == "ssh" {
+		if c.Comm.SSHPassword == "" {
+			c.Comm.SSHPassword = c.Password
+		}
 		return nil
 	}
 

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -72,8 +72,8 @@ func TestConfigUserNameOverride(t *testing.T) {
 	if c.Password != c.tmpAdminPassword {
 		t.Errorf("Expected 'Password' to be set to generated password, but found %q!", c.Password)
 	}
-	if c.Comm.SSHPassword != "" {
-		t.Errorf("Expected 'c.Comm.SSHPassword' to be empty, but found %q!", c.Comm.SSHPassword)
+	if c.Comm.SSHPassword != c.tmpAdminPassword {
+		t.Errorf("Expected 'c.Comm.SSHPassword' to set to generated password, but found %q!", c.Comm.SSHPassword)
 	}
 	if c.UserName != "override_username" {
 		t.Errorf("Expected 'UserName' to be set to 'override_username', but found %q!", c.UserName)


### PR DESCRIPTION

## The problem

When using the new SSH on Windows functionality in 1.4.0, it doesn't appear to be setting build.Password (that is recommend [here](https://developer.hashicorp.com/packer/docs/provisioners/powershell#elevated_user)).

## The solution

As discussed in https://github.com/hashicorp/packer-plugin-azure/issues/267#issuecomment-1419973955, this change sets the `c.Comm.SSHPassword` to the generated password, which is (magically, somehow) converted to `${build.Password}`.

### Tests

_Please include tests. We recommend looking at existing tests as an example. _

I looked to create a new test, but it appears the main scenario is catered for by changing `TestConfigUserNameOverride`.
The other inverse behaviour is covered by `TestConfigShouldBeAbleToOverrideDefaultedValues`.

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #267

