### PR TITLE
docs(spot) ensure a block is used by adding example and including missing attributes partial

### DIFF
--- a/docs-partials/builder/azure/arm/Config-not-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-not-required.mdx
@@ -108,10 +108,27 @@
   VM from your VHD. See
   [pricing](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/)
   information. Defaults to `Standard_A1`.
-  
+
   CLI example `az vm list-sizes --location westus`
 
 - `spot` (Spot) - If set use a spot instance during build; spot configuration settings only apply to the virtual machine launched by Packer and will not be persisted on the resulting image artifact.
+
+Following is an example:
+
+  In JSON
+  ```json
+  "spot": {
+      "eviction_policy": "Delete",
+      "max_price": "0.4",
+  }
+  ```
+  In HCL2
+  ```hcl
+  spot {
+      eviction_policy = "Delete"
+      max_price = "0.4"
+  }
+  ```
 
 - `managed_image_resource_group_name` (string) - Specify the managed image resource group name where the result of the
   Packer build will be saved. The resource group must already exist. If

--- a/docs/builders/arm.mdx
+++ b/docs/builders/arm.mdx
@@ -173,10 +173,16 @@ The shared_image_gallery block is available for building a new image from a priv
 
 ### Shared Image Gallery Destination
 
-The shared_image_gallery_destination block is available for publishing a new image version to an existing shared image gallery. 
+The shared_image_gallery_destination block is available for publishing a new image version to an existing shared image gallery.
 
 @include 'builder/azure/arm/SharedImageGalleryDestination-not-required.mdx'
 
+
+### Spot
+
+The `spot` block is available to use a spot instance during build.
+
+@include 'builder/azure/arm/Spot-not-required.mdx'
 
 
 ## Build Shared Information Variables


### PR DESCRIPTION
Hello there 👋 

While trying to enable the `spot` mode introduced in https://github.com/hashicorp/packer-plugin-azure/pull/223, 
we struggle to get that the `spot` atrribute is in fact a block (ref.  https://github.com/jenkins-infra/packer-images/pull/598).

This PR proposes an update of the documentation with the following enhancements:

- Add an example for JSON and HCL for the `spot` block
- Add a "Spot" section which include the autogenerated partial block to ensure all attributes of the `spot`  block are defined