### PR TITLE
Fix Shared Image Gallery Sourced builds HCP Packer Ancestry and  add SIG Acceptance Tests

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -217,6 +217,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	if b.config.OSType == constants.Target_Linux {
 		steps = []multistep.Step{
 			&StepGetSourceImageName{
+				client:        azureClient,
 				config:        &b.config,
 				GeneratedData: generatedData,
 				say:           func(message string) { ui.Say(message) },
@@ -244,6 +245,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	} else if b.config.OSType == constants.Target_Windows {
 		steps = []multistep.Step{
 			&StepGetSourceImageName{
+				client:        azureClient,
 				config:        &b.config,
 				GeneratedData: generatedData,
 				say:           func(message string) { ui.Say(message) },

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -217,7 +217,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	if b.config.OSType == constants.Target_Linux {
 		steps = []multistep.Step{
 			&StepGetSourceImageName{
-				client:        azureClient,
 				config:        &b.config,
 				GeneratedData: generatedData,
 				say:           func(message string) { ui.Say(message) },
@@ -245,7 +244,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	} else if b.config.OSType == constants.Target_Windows {
 		steps = []multistep.Step{
 			&StepGetSourceImageName{
-				client:        azureClient,
 				config:        &b.config,
 				GeneratedData: generatedData,
 				say:           func(message string) { ui.Say(message) },

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -45,6 +45,10 @@ import (
 const DeviceLoginAcceptanceTest = "DEVICELOGIN_TEST"
 
 func TestBuilderAcc_ARM64SpecializedLinuxSIG(t *testing.T) {
+	if os.Getenv("AZURE_CLI_AUTH") == "" {
+		t.Skip("Azure CLI Acceptance tests skipped unless env 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
+		return
+	}
 	acctest.TestPlugin(t, &acctest.PluginTestCase{
 		Name:     "test-specialized-linux-sig",
 		Type:     "azure-arm",
@@ -78,6 +82,10 @@ func TestBuilderAcc_ARM64SpecializedLinuxSIG(t *testing.T) {
 }
 
 func TestBuilderAcc_WindowsSIG(t *testing.T) {
+	if os.Getenv("AZURE_CLI_AUTH") == "" {
+		t.Skip("Azure CLI Acceptance tests skipped unless env 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
+		return
+	}
 	acctest.TestPlugin(t, &acctest.PluginTestCase{
 		Name:     "test-windows-sig",
 		Type:     "azure-arm",
@@ -353,7 +361,7 @@ func createTestAzureClient(t *testing.T) AzureClient {
 		spnCloud,
 		spnKeyVault)
 	if err != nil {
-		t.Fatalf("failed to create azure client: %s", err)
+		t.Fatalf("failed to create test azure client: %s", err)
 	}
 	return *azureClient
 }

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -81,7 +81,7 @@ func TestBuilderAcc_SharedImageGallery_ARM64SpecializedLinuxSIG(t *testing.T) {
 	})
 }
 
-func TestBuilderAcc_WindowsSIG(t *testing.T) {
+func TestBuilderAcc_SharedImageGallery_WindowsSIG(t *testing.T) {
 	if os.Getenv("AZURE_CLI_AUTH") == "" {
 		t.Skip("Azure CLI Acceptance tests skipped unless env 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
 		return

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -44,15 +44,12 @@ import (
 const DeviceLoginAcceptanceTest = "DEVICELOGIN_TEST"
 
 func TestBuilderAcc_WindowsSIG(t *testing.T) {
-	b := Builder{}
-	_, _, _ = b.Prepare()
-	azureClient := createTestAzureClient(t)
 	acctest.TestPlugin(t, &acctest.PluginTestCase{
 		Name:     "test-windows-sig",
 		Type:     "azure-arm",
 		Template: testBuilderAccSIGDiskWindows,
 		Setup: func() error {
-			createSharedImageGalleryDefinition(t, azureClient, CreateSharedImageGalleryDefinitionParameters{
+			createSharedImageGalleryDefinition(t, CreateSharedImageGalleryDefinitionParameters{
 				galleryImageName: "windows-sig",
 				imageSku:         "2012-R2-Datacenter",
 				imageOffer:       "WindowsServer",
@@ -71,7 +68,7 @@ func TestBuilderAcc_WindowsSIG(t *testing.T) {
 			return nil
 		},
 		Teardown: func() error {
-			deleteSharedImageGalleryDefinition(t, azureClient, "windows-sig")
+			deleteSharedImageGalleryDefinition(t, "windows-sig")
 			return nil
 		},
 	})
@@ -321,7 +318,8 @@ func createTestAzureClient(t *testing.T) AzureClient {
 	return *azureClient
 }
 
-func createSharedImageGalleryDefinition(t *testing.T, azureClient AzureClient, params CreateSharedImageGalleryDefinitionParameters) {
+func createSharedImageGalleryDefinition(t *testing.T, params CreateSharedImageGalleryDefinitionParameters) {
+	azureClient := createTestAzureClient(t)
 	osType := compute.OperatingSystemTypesLinux
 	if params.isWindows {
 		osType = compute.OperatingSystemTypesWindows
@@ -363,7 +361,8 @@ func createSharedImageGalleryDefinition(t *testing.T, azureClient AzureClient, p
 	}
 }
 
-func deleteSharedImageGalleryDefinition(t *testing.T, azureClient AzureClient, galleryImageName string) {
+func deleteSharedImageGalleryDefinition(t *testing.T, galleryImageName string) {
+	azureClient := createTestAzureClient(t)
 	versionFuture, err := azureClient.GalleryImageVersionsClient.Delete(context.TODO(), "packer-acceptance-test", "acctestgallery", galleryImageName, "1.0.0")
 	if err != nil {
 		t.Fatalf("failed to delete Gallery %s: %s", galleryImageName, err)

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -44,21 +44,21 @@ import (
 
 const DeviceLoginAcceptanceTest = "DEVICELOGIN_TEST"
 
-func TestBuilderAcc_ARM64GeneralizedLinuxSIG(t *testing.T) {
+func TestBuilderAcc_ARM64SpecializedLinuxSIG(t *testing.T) {
 	acctest.TestPlugin(t, &acctest.PluginTestCase{
-		Name:     "test-linux-sig",
+		Name:     "test-specialized-linux-sig",
 		Type:     "azure-arm",
-		Template: string(armLinuxGeneralizedSIGTemplate),
+		Template: string(armLinuxSpecialziedSIGTemplate),
 		Setup: func() error {
 			createSharedImageGalleryDefinition(t, CreateSharedImageGalleryDefinitionParameters{
-				galleryImageName: "arm-linux-generalized-sig",
+				galleryImageName: "arm-linux-specialized-sig",
 				imageSku:         "22_04-lts-arm64",
 				imageOffer:       "0001-com-ubuntu-server-jammy",
 				imagePublisher:   "canonical",
 				isX64:            false,
 				isWindows:        false,
 				useGenTwoVM:      true,
-				specialized:      false,
+				specialized:      true,
 			})
 			return nil
 		},
@@ -71,7 +71,7 @@ func TestBuilderAcc_ARM64GeneralizedLinuxSIG(t *testing.T) {
 			return nil
 		},
 		Teardown: func() error {
-			deleteSharedImageGalleryDefinition(t, "arm-linux-generalized-sig")
+			deleteSharedImageGalleryDefinition(t, "arm-linux-specialized-sig")
 			return nil
 		},
 	})
@@ -301,8 +301,8 @@ var rsaSHA2OnlyTemplate []byte
 //go:embed testdata/windows_sig.pkr.hcl
 var windowsSIGTemplate []byte
 
-//go:embed testdata/arm_linux_generalized.pkr.hcl
-var armLinuxGeneralizedSIGTemplate []byte
+//go:embed testdata/arm_linux_specialized.pkr.hcl
+var armLinuxSpecialziedSIGTemplate []byte
 
 func TestBuilderAcc_rsaSHA2OnlyServer(t *testing.T) {
 	acctest.TestPlugin(t, &acctest.PluginTestCase{

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -44,7 +44,7 @@ import (
 
 const DeviceLoginAcceptanceTest = "DEVICELOGIN_TEST"
 
-func TestBuilderAcc_ARM64SpecializedLinuxSIG(t *testing.T) {
+func TestBuilderAcc_SharedImageGallery_ARM64SpecializedLinuxSIG(t *testing.T) {
 	if os.Getenv("AZURE_CLI_AUTH") == "" {
 		t.Skip("Azure CLI Acceptance tests skipped unless env 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
 		return

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -605,6 +605,19 @@ type keyVaultCertificate struct {
 	Password string `json:"password,omitempty"`
 }
 
+func (c *Config) getSourceSharedImageGalleryID() string {
+	id := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s",
+		c.SharedGallery.Subscription,
+		c.SharedGallery.ResourceGroup,
+		c.SharedGallery.GalleryName,
+		c.SharedGallery.ImageName)
+	if c.SharedGallery.ImageVersion != "" {
+		id += fmt.Sprintf("/versions/%s",
+			c.SharedGallery.ImageVersion)
+	}
+	return id
+}
+
 func (c *Config) toVMID() string {
 	var resourceGroupName string
 	if c.tmpResourceGroupName != "" {

--- a/builder/azure/arm/step_get_source_image_name.go
+++ b/builder/azure/arm/step_get_source_image_name.go
@@ -48,17 +48,9 @@ func (s *StepGetSourceImageName) Run(ctx context.Context, state multistep.StateB
 			return multistep.ActionContinue
 		}
 
-		if image.GalleryImageVersionProperties != nil && image.GalleryImageVersionProperties.StorageProfile != nil &&
-			image.GalleryImageVersionProperties.StorageProfile.Source != nil && image.GalleryImageVersionProperties.StorageProfile.Source.ID != nil {
-
-			imageID := *image.GalleryImageVersionProperties.StorageProfile.Source.ID
-			s.say(fmt.Sprintf(" -> SourceImageName: '%s'", imageID))
-			s.GeneratedData.Put("SourceImageName", imageID)
-			return multistep.ActionContinue
-		}
-
-		log.Println("[TRACE] unable to identify the source image for provided gallery image version")
-		s.GeneratedData.Put("SourceImageName", "ERR_SOURCE_IMAGE_NAME_NOT_FOUND")
+		imageID := *image.ID
+		s.say(fmt.Sprintf(" -> SourceImageName: '%s'", imageID))
+		s.GeneratedData.Put("SourceImageName", imageID)
 		return multistep.ActionContinue
 	}
 

--- a/builder/azure/arm/step_get_source_image_name.go
+++ b/builder/azure/arm/step_get_source_image_name.go
@@ -6,14 +6,12 @@ package arm
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
 )
 
 type StepGetSourceImageName struct {
-	client        *AzureClient
 	config        *Config
 	GeneratedData *packerbuilderdata.GeneratedData
 	say           func(message string)
@@ -36,19 +34,7 @@ func (s *StepGetSourceImageName) Run(ctx context.Context, state multistep.StateB
 	}
 
 	if s.config.SharedGallery.Subscription != "" {
-		client := s.client.GalleryImageVersionsClient
-		client.SubscriptionID = s.config.SharedGallery.Subscription
-
-		image, err := client.Get(ctx, s.config.SharedGallery.ResourceGroup,
-			s.config.SharedGallery.GalleryName, s.config.SharedGallery.ImageName, s.config.SharedGallery.ImageVersion, "")
-
-		if err != nil {
-			log.Println("[TRACE] unable to derive managed image URL for shared gallery version image")
-			s.GeneratedData.Put("SourceImageName", "ERR_SOURCE_IMAGE_NAME_NOT_FOUND")
-			return multistep.ActionContinue
-		}
-
-		imageID := *image.ID
+		imageID := s.config.getSourceSharedImageGalleryID()
 		s.say(fmt.Sprintf(" -> SourceImageName: '%s'", imageID))
 		s.GeneratedData.Put("SourceImageName", imageID)
 		return multistep.ActionContinue

--- a/builder/azure/arm/step_get_source_image_name_test.go
+++ b/builder/azure/arm/step_get_source_image_name_test.go
@@ -54,6 +54,33 @@ func TestStepGetSourceImageName(t *testing.T) {
 			},
 			expected: "/subscriptions/1234/providers/Microsoft.Compute/locations/west/publishers/Microsoft/ArtifactTypes/vmimage/offers/Server/skus/0/versions/2019",
 		},
+		{
+			name: "SharedImageGallery",
+			config: &Config{
+				ClientConfig: client.Config{SubscriptionID: "1234"},
+				SharedGallery: SharedImageGallery{
+					GalleryName:   "test",
+					ImageName:     "image",
+					Subscription:  "1234",
+					ResourceGroup: "group",
+				},
+			},
+			expected: "/subscriptions/1234/resourceGroups/group/providers/Microsoft.Compute/galleries/test/images/image",
+		},
+		{
+			name: "SharedImageGallery with version",
+			config: &Config{
+				ClientConfig: client.Config{SubscriptionID: "1234"},
+				SharedGallery: SharedImageGallery{
+					GalleryName:   "test",
+					ImageVersion:  "2.0.0",
+					ImageName:     "image",
+					Subscription:  "1234",
+					ResourceGroup: "group",
+				},
+			},
+			expected: "/subscriptions/1234/resourceGroups/group/providers/Microsoft.Compute/galleries/test/images/image/versions/2.0.0",
+		},
 	}
 	for _, tt := range tc {
 		tt := tt

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -117,15 +117,7 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 		// TODO : Handle this error
 		_ = builder.SetManagedMarketplaceImage(config.ImagePublisher, config.ImageOffer, config.ImageSku, config.ImageVersion, config.managedImageStorageAccountType, config.diskCachingType)
 	} else if config.SharedGallery.Subscription != "" {
-		imageID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/galleries/%s/images/%s",
-			config.SharedGallery.Subscription,
-			config.SharedGallery.ResourceGroup,
-			config.SharedGallery.GalleryName,
-			config.SharedGallery.ImageName)
-		if config.SharedGallery.ImageVersion != "" {
-			imageID += fmt.Sprintf("/versions/%s",
-				config.SharedGallery.ImageVersion)
-		}
+		imageID := config.getSourceSharedImageGalleryID()
 
 		err = builder.SetSharedGalleryImage(config.Location, imageID, config.diskCachingType)
 		if err != nil {

--- a/builder/azure/arm/testdata/arm_linux_generalized.pkr.hcl
+++ b/builder/azure/arm/testdata/arm_linux_generalized.pkr.hcl
@@ -1,0 +1,39 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+
+variables {
+  subscription_id = env("ARM_SUBSCRIPTION_ID")
+  client_id       = env("ARM_CLIENT_ID")
+  client_secret   = env("ARM_CLIENT_SECRET")
+  resource_group  = env("ARM_RESOURCE_GROUP_NAME")
+}
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "azure-arm" "linux-sig" {
+  subscription_id            = var.subscription_id
+  client_id                  = var.client_id
+  async_resourcegroup_delete = true
+  client_secret              = var.client_secret
+  image_offer                = "0001-com-ubuntu-server-jammy"
+  image_publisher            = "canonical"
+  image_sku                  = "22_04-lts-arm64"
+
+  location = "South Central US"
+  vm_size  = "Standard_D4ps_v5"
+
+  shared_image_gallery_destination {
+    image_name     = "arm-linux-generalized-sig"
+    gallery_name   = "acctestgallery"
+    image_version  = "1.0.0"
+    resource_group = "packer-acceptance-test"
+    specialized    = true
+  }
+
+  os_type = "Linux"
+}
+
+build {
+  sources = ["source.azure-arm.linux-sig"]
+}
+

--- a/builder/azure/arm/testdata/arm_linux_specialized.pkr.hcl
+++ b/builder/azure/arm/testdata/arm_linux_specialized.pkr.hcl
@@ -2,24 +2,15 @@
 # SPDX-License-Identifier: MPL-2.0
 
 
-variables {
-  subscription_id = env("ARM_SUBSCRIPTION_ID")
-  client_id       = env("ARM_CLIENT_ID")
-  client_secret   = env("ARM_CLIENT_SECRET")
-  resource_group  = env("ARM_RESOURCE_GROUP_NAME")
-}
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "azure-arm" "linux-sig" {
-  subscription_id            = var.subscription_id
-  client_id                  = var.client_id
-  client_secret              = var.client_secret
-  image_offer                = "0001-com-ubuntu-server-jammy"
-  image_publisher            = "canonical"
-  image_sku                  = "22_04-lts-arm64"
-
-  location = "South Central US"
-  vm_size  = "Standard_D4ps_v5"
+  image_offer        = "0001-com-ubuntu-server-jammy"
+  image_publisher    = "canonical"
+  image_sku          = "22_04-lts-arm64"
+  use_azure_cli_auth = true
+  location           = "South Central US"
+  vm_size            = "Standard_D4ps_v5"
 
   shared_image_gallery_destination {
     image_name     = "arm-linux-specialized-sig"

--- a/builder/azure/arm/testdata/arm_linux_specialized.pkr.hcl
+++ b/builder/azure/arm/testdata/arm_linux_specialized.pkr.hcl
@@ -13,7 +13,6 @@ locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 source "azure-arm" "linux-sig" {
   subscription_id            = var.subscription_id
   client_id                  = var.client_id
-  async_resourcegroup_delete = true
   client_secret              = var.client_secret
   image_offer                = "0001-com-ubuntu-server-jammy"
   image_publisher            = "canonical"
@@ -23,7 +22,7 @@ source "azure-arm" "linux-sig" {
   vm_size  = "Standard_D4ps_v5"
 
   shared_image_gallery_destination {
-    image_name     = "arm-linux-generalized-sig"
+    image_name     = "arm-linux-specialized-sig"
     gallery_name   = "acctestgallery"
     image_version  = "1.0.0"
     resource_group = "packer-acceptance-test"

--- a/builder/azure/arm/testdata/windows_sig.pkr.hcl
+++ b/builder/azure/arm/testdata/windows_sig.pkr.hcl
@@ -1,25 +1,15 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-
-variables {
-  subscription_id = env("ARM_SUBSCRIPTION_ID")
-  client_id       = env("ARM_CLIENT_ID")
-  client_secret   = env("ARM_CLIENT_SECRET")
-  resource_group  = env("ARM_RESOURCE_GROUP_NAME")
-}
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "azure-arm" "windows-sig" {
-  subscription_id            = var.subscription_id
-  client_id                  = var.client_id
-  communicator               = "winrm"
-  winrm_timeout              = "5m"
-  winrm_use_ssl              = true
-  winrm_insecure             = true
-  winrm_username             = "packer"
-  client_secret              = var.client_secret
-
+  communicator       = "winrm"
+  winrm_timeout      = "5m"
+  winrm_use_ssl      = true
+  winrm_insecure     = true
+  winrm_username     = "packer"
+  use_azure_cli_auth = true
   shared_image_gallery_destination {
     image_name     = "windows-sig"
     gallery_name   = "acctestgallery"

--- a/builder/azure/arm/testdata/windows_sig.pkr.hcl
+++ b/builder/azure/arm/testdata/windows_sig.pkr.hcl
@@ -18,7 +18,6 @@ source "azure-arm" "windows-sig" {
   winrm_use_ssl              = true
   winrm_insecure             = true
   winrm_username             = "packer"
-  async_resourcegroup_delete = true
   client_secret              = var.client_secret
 
   shared_image_gallery_destination {

--- a/builder/azure/arm/testdata/windows_sig.pkr.hcl
+++ b/builder/azure/arm/testdata/windows_sig.pkr.hcl
@@ -1,0 +1,45 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+
+variables {
+  subscription_id = env("ARM_SUBSCRIPTION_ID")
+  client_id       = env("ARM_CLIENT_ID")
+  client_secret   = env("ARM_CLIENT_SECRET")
+  resource_group  = env("ARM_RESOURCE_GROUP_NAME")
+}
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "azure-arm" "windows-sig" {
+  subscription_id            = var.subscription_id
+  client_id                  = var.client_id
+  communicator               = "winrm"
+  winrm_timeout              = "5m"
+  winrm_use_ssl              = true
+  winrm_insecure             = true
+  winrm_username             = "packer"
+  async_resourcegroup_delete = true
+  client_secret              = var.client_secret
+
+  shared_image_gallery_destination {
+    image_name     = "windows-sig"
+    gallery_name   = "acctestgallery"
+    image_version  = "1.0.0"
+    resource_group = "packer-acceptance-test"
+  }
+  managed_image_name                = "packer-test-windows-sig-${local.timestamp}"
+  managed_image_resource_group_name = "packer-acceptance-test"
+
+  os_type         = "Windows"
+  image_publisher = "MicrosoftWindowsServer"
+  image_offer     = "WindowsServer"
+  image_sku       = "2012-R2-Datacenter"
+
+  location = "South Central US"
+  vm_size  = "Standard_DS2_v2"
+}
+
+build {
+  sources = ["source.azure-arm.windows-sig"]
+}
+

--- a/docs-partials/builder/azure/arm/SharedImageGalleryDestination-not-required.mdx
+++ b/docs-partials/builder/azure/arm/SharedImageGalleryDestination-not-required.mdx
@@ -15,6 +15,6 @@
 - `storage_account_type` (string) - Specify a storage account type for the Shared Image Gallery Image Version.
   Defaults to `Standard_LRS`. Accepted values are `Standard_LRS`, `Standard_ZRS` and `Premium_LRS`
 
-- `specialized` (bool) - Set to true if publishing to a Specialized Gallery, this skips a call to set the resulting VM's OS state as Generalized
+- `specialized` (bool) - Set to true if publishing to a Specialized Gallery, this skips a call to set the build VM's OS state as Generalized
 
 <!-- End of code generated from the comments of the SharedImageGalleryDestination struct in builder/azure/arm/config.go; -->


### PR DESCRIPTION
Before this PR the Source Image ID for a SIG sourced build would be the source VM that the Shared Image Gallery image version was built from, rather than the Shared Image Gallery image version itself.

```
SourceImageName: '/subscriptions/1f90521a-24f6-4758-ac3d-88d869fb0bf5/resourceGroups/pkr-Resource-Group-p6ehd2pbol/providers/Microsoft.Compute/virtualMachines/pkrvmp6ehd2pbol
```

After this PR the source image ID for a SIG sourced build is the parent SIG image version
```
-> SourceImageName: '/subscriptions/{subscription}/resourceGroups/jenna/providers/Microsoft.Compute/galleries/hcp_packer_ancestry/images/parent-image/versions/4.0.0'
```

For builds that are directly published to SIG, the plugin sends the SIG ID to HCP Packer as the Image ID which makes sense and works end to end with Terraform currently, thus we should use this ID as our `SourceImageName` the field which Packer uses to determine parent images

This PR also introduces SIG acceptance tests to the ARM builder acceptance tests.
