### PR TITLE
Don't set OSProfile (Username/password) on images that use a Specialized Parent

### DIFF
--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -11,7 +11,7 @@ package arm
 // * ARM_SUBSCRIPTION_ID
 // * ARM_STORAGE_ACCOUNT
 // * AZURE_SSH_PASS - In our Linux SIG test we build two specialized images, this requires setting a shared password for both builds
-// * ARM_SSH_PRIVATE_KEY_LOCATION - the file location of a PEM encoded SSH private key,
+// * ARM_SSH_PRIVATE_KEY_FILE - the file location of a PEM encoded SSH private key,
 //
 // The subscription in question should have a resource group
 // called "packer-acceptance-test" in "South Central US" region. The
@@ -62,8 +62,8 @@ func TestBuilderAcc_SharedImageGallery_ARM64SpecializedLinuxSIG_WithChildImage(t
 		return
 	}
 
-	if os.Getenv("ARM_SSH_PRIVATE_KEY_LOCATION") == "" {
-		t.Fatalf("To run this test set a valid ssh private key location in ARM_SSH_PRIVATE_KEY_LOCATION")
+	if os.Getenv("ARM_SSH_PRIVATE_KEY_FILE") == "" {
+		t.Fatalf("To run this test set a valid ssh private key location in ARM_SSH_PRIVATE_KEY_FILE")
 		return
 	}
 

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -10,7 +10,7 @@ package arm
 // * ARM_CLIENT_SECRET
 // * ARM_SUBSCRIPTION_ID
 // * ARM_STORAGE_ACCOUNT
-// * ARM_SSH_PRIVATE_KEY_FILE - the file location of a PEM encoded SSH private key,
+// * ARM_SSH_PRIVATE_KEY_FILE - the file location of a PEM encoded RSA SSH Private Key (ed25519 is not supported by Azure),
 //
 // The subscription in question should have a resource group
 // called "packer-acceptance-test" in "South Central US" region. The

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -50,6 +50,12 @@ const DeviceLoginAcceptanceTest = "DEVICELOGIN_TEST"
 // Then a second Specialized ARM64 Linux VM that uses the first as its source/parent image
 func TestBuilderAcc_SharedImageGallery_ARM64SpecializedLinuxSIG_WithChildImage(t *testing.T) {
 	t.Parallel()
+
+	if os.Getenv("PACKER_ACC") == "" {
+		t.Skip("Skipping acceptance test as environment variable `PACKER_ACC` is not set")
+		return
+	}
+
 	if os.Getenv("AZURE_CLI_AUTH") == "" {
 		t.Fatalf("Azure CLI Acceptance tests require 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
 		return
@@ -109,6 +115,10 @@ func TestBuilderAcc_SharedImageGallery_ARM64SpecializedLinuxSIG_WithChildImage(t
 
 func TestBuilderAcc_SharedImageGallery_WindowsSIG(t *testing.T) {
 	t.Parallel()
+	if os.Getenv("PACKER_ACC") == "" {
+		t.Skip("Skipping acceptance test as environment variable `PACKER_ACC` is not set")
+		return
+	}
 	if os.Getenv("AZURE_CLI_AUTH") == "" {
 		t.Fatalf("Azure CLI Acceptance tests require 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
 		return
@@ -254,6 +264,10 @@ func TestBuilderAcc_ManagedDisk_Linux_DeviceLogin(t *testing.T) {
 
 func TestBuilderAcc_ManagedDisk_Linux_AzureCLI(t *testing.T) {
 	t.Parallel()
+	if os.Getenv("PACKER_ACC") == "" {
+		t.Skip("Skipping acceptance test as environment variable `PACKER_ACC` is not set")
+		return
+	}
 	if os.Getenv("AZURE_CLI_AUTH") == "" {
 		t.Fatalf("Azure CLI Acceptance tests require 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
 		return

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -44,29 +44,44 @@ import (
 
 const DeviceLoginAcceptanceTest = "DEVICELOGIN_TEST"
 
-func TestBuilderAcc_SharedImageGallery_ARM64SpecializedLinuxSIG(t *testing.T) {
+// This test builds two images,
+// First a parent Specialized ARM 64 Linux VM to a Shared Image Gallery/Compute Gallery
+// Then a second Specialized ARM64 Linux VM that uses the first as its source/parent image
+func TestBuilderAcc_SharedImageGallery_ARM64SpecializedLinuxSIG_WithChildImage(t *testing.T) {
 	t.Parallel()
 	if os.Getenv("AZURE_CLI_AUTH") == "" {
 		t.Skip("Azure CLI Acceptance tests skipped unless env 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
 		return
 	}
+
+	if os.Getenv("ARM_SSH_PASS") == "" {
+		// If no password is set generate a SSH password to be shared between the two builds
+		// Specialized images retain their user setup, so the password needs to be the same across both builds.
+
+		var tempName = NewTempName("packer-acc-test")
+		err := os.Setenv("ARM_SSH_PASS", tempName.AdminPassword)
+		if err != nil {
+			t.Fatalf("Failed to set ARM_SSH_PASS env variables with error %s", err.Error())
+		}
+	}
+
+	createSharedImageGalleryDefinition(t, CreateSharedImageGalleryDefinitionParameters{
+		galleryImageName: "arm-linux-specialized-sig",
+		imageSku:         "22_04-lts-arm64",
+		imageOffer:       "0001-com-ubuntu-server-jammy",
+		imagePublisher:   "canonical",
+		isX64:            false,
+		isWindows:        false,
+		useGenTwoVM:      true,
+		specialized:      true,
+	})
+
+	defer deleteSharedImageGalleryDefinition(t, "arm-linux-specialized-sig", []string{"1.0.0", "1.0.1"})
+	// Create parent specialized shared gallery image
 	acctest.TestPlugin(t, &acctest.PluginTestCase{
 		Name:     "test-specialized-linux-sig",
 		Type:     "azure-arm",
 		Template: string(armLinuxSpecialziedSIGTemplate),
-		Setup: func() error {
-			createSharedImageGalleryDefinition(t, CreateSharedImageGalleryDefinitionParameters{
-				galleryImageName: "arm-linux-specialized-sig",
-				imageSku:         "22_04-lts-arm64",
-				imageOffer:       "0001-com-ubuntu-server-jammy",
-				imagePublisher:   "canonical",
-				isX64:            false,
-				isWindows:        false,
-				useGenTwoVM:      true,
-				specialized:      true,
-			})
-			return nil
-		},
 		Check: func(buildCommand *exec.Cmd, logfile string) error {
 			if buildCommand.ProcessState != nil {
 				if buildCommand.ProcessState.ExitCode() != 0 {
@@ -76,33 +91,54 @@ func TestBuilderAcc_SharedImageGallery_ARM64SpecializedLinuxSIG(t *testing.T) {
 			return nil
 		},
 		Teardown: func() error {
-			deleteSharedImageGalleryDefinition(t, "arm-linux-specialized-sig")
 			return nil
 		},
 	})
+
+	// Create child image from a specialized parent
+	acctest.TestPlugin(t, &acctest.PluginTestCase{
+		Name:     "test-specialized-linux-sig-child",
+		Type:     "azure-arm",
+		Template: string(armLinuxChildFromSpecializedParent),
+		Check: func(buildCommand *exec.Cmd, logfile string) error {
+			if buildCommand.ProcessState != nil {
+				if buildCommand.ProcessState.ExitCode() != 0 {
+					return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
+				}
+			}
+			return nil
+		},
+	})
+
 }
 
+func TestBuilderAcc_SharedImageGallery_ARM64SpecializedLinuxSIG_ChildOfSpecializedParent(t *testing.T) {
+	if os.Getenv("AZURE_CLI_AUTH") == "" {
+		t.Skip("Azure CLI Acceptance tests skipped unless env 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
+		return
+	}
+}
 func TestBuilderAcc_SharedImageGallery_WindowsSIG(t *testing.T) {
 	t.Parallel()
 	if os.Getenv("AZURE_CLI_AUTH") == "" {
 		t.Skip("Azure CLI Acceptance tests skipped unless env 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
 		return
 	}
+
+	createSharedImageGalleryDefinition(t, CreateSharedImageGalleryDefinitionParameters{
+		galleryImageName: "windows-sig",
+		imageSku:         "2012-R2-Datacenter",
+		imageOffer:       "WindowsServer",
+		imagePublisher:   "MicrosoftWindowsServer",
+		isX64:            true,
+		isWindows:        true,
+	})
+	defer deleteSharedImageGalleryDefinition(t, "windows-sig", []string{"1.0.0"})
+
 	acctest.TestPlugin(t, &acctest.PluginTestCase{
 		Name:     "test-windows-sig",
 		Type:     "azure-arm",
 		Template: string(windowsSIGTemplate),
-		Setup: func() error {
-			createSharedImageGalleryDefinition(t, CreateSharedImageGalleryDefinitionParameters{
-				galleryImageName: "windows-sig",
-				imageSku:         "2012-R2-Datacenter",
-				imageOffer:       "WindowsServer",
-				imagePublisher:   "MicrosoftWindowsServer",
-				isX64:            true,
-				isWindows:        true,
-			})
-			return nil
-		},
 		Check: func(buildCommand *exec.Cmd, logfile string) error {
 			if buildCommand.ProcessState != nil {
 				if buildCommand.ProcessState.ExitCode() != 0 {
@@ -112,7 +148,6 @@ func TestBuilderAcc_SharedImageGallery_WindowsSIG(t *testing.T) {
 			return nil
 		},
 		Teardown: func() error {
-			deleteSharedImageGalleryDefinition(t, "windows-sig")
 			return nil
 		},
 	})
@@ -324,6 +359,9 @@ var windowsSIGTemplate []byte
 //go:embed testdata/arm_linux_specialized.pkr.hcl
 var armLinuxSpecialziedSIGTemplate []byte
 
+//go:embed testdata/child_from_specialized_parent.pkr.hcl
+var armLinuxChildFromSpecializedParent []byte
+
 func TestBuilderAcc_rsaSHA2OnlyServer(t *testing.T) {
 	t.Parallel()
 	acctest.TestPlugin(t, &acctest.PluginTestCase{
@@ -422,21 +460,26 @@ func createSharedImageGalleryDefinition(t *testing.T, params CreateSharedImageGa
 	}
 }
 
-func deleteSharedImageGalleryDefinition(t *testing.T, galleryImageName string) {
+func deleteSharedImageGalleryDefinition(t *testing.T, galleryImageName string, imageVersions []string) {
 	azureClient := createTestAzureClient(t)
-	versionFuture, err := azureClient.GalleryImageVersionsClient.Delete(context.TODO(), "packer-acceptance-test", "acctestgallery", galleryImageName, "1.0.0")
-	if err != nil {
-		t.Fatalf("failed to delete Gallery %s: %s", galleryImageName, err)
-	}
-	err = versionFuture.WaitForCompletionRef(context.TODO(), azureClient.GalleryImageVersionsClient.Client)
-	if err != nil {
-		t.Fatalf("failed to delete Gallery %s: %s", galleryImageName, err)
+	for _, imageVersion := range imageVersions {
+		// If we fail to delete a gallery version we should still try to delete other versions and the gallery
+		// Its possible a build was canceled or failed mid test that would leave any of the builds incomplete
+		// We still want to try and delete the Gallery to not leave behind orphaned resources to manually clean up
+		versionFuture, err := azureClient.GalleryImageVersionsClient.Delete(context.TODO(), "packer-acceptance-test", "acctestgallery", galleryImageName, imageVersion)
+		if err != nil {
+			t.Logf("failed to delete Gallery Image Version %s:%s %s", galleryImageName, imageVersion, err)
+		}
+		err = versionFuture.WaitForCompletionRef(context.TODO(), azureClient.GalleryImageVersionsClient.Client)
+		if err != nil {
+			t.Logf("failed to delete Gallery Image Version %s:%s %s", galleryImageName, imageVersion, err)
+		}
 	}
 	retryConfig := retry.Config{
 		Tries:      5,
-		RetryDelay: (&retry.Backoff{InitialBackoff: 10 * time.Second, MaxBackoff: 60 * time.Second, Multiplier: 2}).Linear,
+		RetryDelay: (&retry.Backoff{InitialBackoff: 2 * time.Second, MaxBackoff: 30 * time.Second, Multiplier: 2}).Linear,
 	}
-	err = retryConfig.Run(context.TODO(), func(ctx context.Context) error {
+	err := retryConfig.Run(context.TODO(), func(ctx context.Context) error {
 		galleryFuture, err := azureClient.GalleryImagesClient.Delete(context.TODO(), "packer-acceptance-test", "acctestgallery", galleryImageName)
 		if err != nil {
 			return err
@@ -447,7 +490,6 @@ func deleteSharedImageGalleryDefinition(t *testing.T, galleryImageName string) {
 	if err != nil {
 		t.Fatalf("failed to delete Gallery %s: %s", galleryImageName, err)
 	}
-
 }
 
 func testUi() *packersdk.BasicUi {

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -10,7 +10,6 @@ package arm
 // * ARM_CLIENT_SECRET
 // * ARM_SUBSCRIPTION_ID
 // * ARM_STORAGE_ACCOUNT
-// * AZURE_SSH_PASS - In our Linux SIG test we build two specialized images, this requires setting a shared password for both builds
 // * ARM_SSH_PRIVATE_KEY_FILE - the file location of a PEM encoded SSH private key,
 //
 // The subscription in question should have a resource group
@@ -52,13 +51,7 @@ const DeviceLoginAcceptanceTest = "DEVICELOGIN_TEST"
 func TestBuilderAcc_SharedImageGallery_ARM64SpecializedLinuxSIG_WithChildImage(t *testing.T) {
 	t.Parallel()
 	if os.Getenv("AZURE_CLI_AUTH") == "" {
-		t.Skip("Azure CLI Acceptance tests skipped unless env 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
-		return
-	}
-
-	// A password is required to be shared between builds as Specialized Images do not have their main user profile removed
-	if os.Getenv("ARM_SSH_PASS") == "" {
-		t.Fatalf("To run this test set a valid ssh password in the env variable ARM_SSH_PASS")
+		t.Fatalf("Azure CLI Acceptance tests require 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
 		return
 	}
 
@@ -117,7 +110,7 @@ func TestBuilderAcc_SharedImageGallery_ARM64SpecializedLinuxSIG_WithChildImage(t
 func TestBuilderAcc_SharedImageGallery_WindowsSIG(t *testing.T) {
 	t.Parallel()
 	if os.Getenv("AZURE_CLI_AUTH") == "" {
-		t.Skip("Azure CLI Acceptance tests skipped unless env 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
+		t.Fatalf("Azure CLI Acceptance tests require 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
 		return
 	}
 
@@ -262,7 +255,7 @@ func TestBuilderAcc_ManagedDisk_Linux_DeviceLogin(t *testing.T) {
 func TestBuilderAcc_ManagedDisk_Linux_AzureCLI(t *testing.T) {
 	t.Parallel()
 	if os.Getenv("AZURE_CLI_AUTH") == "" {
-		t.Skip("Azure CLI Acceptance tests skipped unless env 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
+		t.Fatalf("Azure CLI Acceptance tests require 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established")
 		return
 	}
 

--- a/builder/azure/arm/step_get_source_image_name.go
+++ b/builder/azure/arm/step_get_source_image_name.go
@@ -69,6 +69,7 @@ func (s *StepGetSourceImageName) Run(ctx context.Context, state multistep.StateB
 
 			// First check if the parent Gallery Image Version source ID is a managed image, if so we use that as our source image name
 			parentSourceID := *image.GalleryImageVersionProperties.StorageProfile.Source.ID
+
 			isSIGSourcedFromManagedImage, _ := regexp.MatchString("/subscriptions/[^/]*/resourceGroups/[^/]*/providers/Microsoft.Compute/images/[^/]*$", parentSourceID)
 
 			if isSIGSourcedFromManagedImage {

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -78,7 +78,7 @@ func GetSpecializedVirtualMachineDeployment(config *Config) (*resources.Deployme
 		CommandToExecute:           &template.TemplateParameter{Value: config.CustomScript},
 	}
 
-	err = builder.SetSpecializedVM()
+	err = builder.ClearOsProfile()
 	if err != nil {
 		return nil, err
 	}

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment16.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment16.approved.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminPassword": {
+      "type": "securestring"
+    },
+    "adminUsername": {
+      "type": "string"
+    },
+    "commandToExecute": {
+      "type": "string"
+    },
+    "dataDiskName": {
+      "type": "string"
+    },
+    "dnsNameForPublicIP": {
+      "type": "string"
+    },
+    "nicName": {
+      "type": "string"
+    },
+    "nsgName": {
+      "type": "string"
+    },
+    "osDiskName": {
+      "type": "string"
+    },
+    "publicIPAddressName": {
+      "type": "string"
+    },
+    "storageAccountBlobEndpoint": {
+      "type": "string"
+    },
+    "subnetName": {
+      "type": "string"
+    },
+    "virtualNetworkName": {
+      "type": "string"
+    },
+    "vmName": {
+      "type": "string"
+    },
+    "vmSize": {
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "apiVersion": "[variables('publicIPAddressApiVersion')]",
+      "location": "[variables('location')]",
+      "name": "[parameters('publicIPAddressName')]",
+      "properties": {
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+        },
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]"
+      },
+      "type": "Microsoft.Network/publicIPAddresses"
+    },
+    {
+      "apiVersion": "[variables('virtualNetworksApiVersion')]",
+      "location": "[variables('location')]",
+      "name": "[variables('virtualNetworkName')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetAddressPrefix')]"
+            }
+          }
+        ]
+      },
+      "type": "Microsoft.Network/virtualNetworks"
+    },
+    {
+      "apiVersion": "[variables('networkInterfacesApiVersion')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "location": "[variables('location')]",
+      "name": "[parameters('nicName')]",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      },
+      "type": "Microsoft.Network/networkInterfaces"
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
+      ],
+      "location": "[variables('location')]",
+      "name": "[parameters('vmName')]",
+      "properties": {
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": false
+          }
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            }
+          ]
+        },
+        "storageProfile": {
+          "imageReference": {
+            "offer": "ignored00",
+            "publisher": "ignored00",
+            "sku": "ignored00",
+            "version": "latest"
+          },
+          "osDisk": {
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "name": "[parameters('osDiskName')]",
+            "vhd": {
+              "uri": "[concat(parameters('storageAccountBlobEndpoint'),variables('vmStorageAccountContainerName'),'/', parameters('osDiskName'),'.vhd')]"
+            }
+          }
+        }
+      },
+      "type": "Microsoft.Compute/virtualMachines"
+    },
+    {
+      "apiVersion": "2022-08-01",
+      "condition": "[not(empty(parameters('commandToExecute')))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+      ],
+      "location": "[variables('location')]",
+      "name": "[concat(parameters('vmName'), '/extension-customscript')]",
+      "properties": {
+        "autoUpgradeMinorVersion": true,
+        "publisher": "Microsoft.Compute",
+        "settings": {
+          "commandToExecute": "[parameters('commandToExecute')]"
+        },
+        "type": "CustomScriptExtension",
+        "typeHandlerVersion": "1.8"
+      },
+      "type": "Microsoft.Compute/virtualMachines/extensions"
+    }
+  ],
+  "variables": {
+    "addressPrefix": "10.0.0.0/16",
+    "apiVersion": "2021-11-01",
+    "location": "[resourceGroup().location]",
+    "managedDiskApiVersion": "2017-03-30",
+    "networkInterfacesApiVersion": "2017-04-01",
+    "networkSecurityGroupsApiVersion": "2019-04-01",
+    "publicIPAddressApiVersion": "2017-04-01",
+    "publicIPAddressType": "Dynamic",
+    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
+    "subnetAddressPrefix": "10.0.0.0/24",
+    "subnetName": "[parameters('subnetName')]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "virtualNetworkName": "[parameters('virtualNetworkName')]",
+    "virtualNetworkResourceGroup": "[resourceGroup().name]",
+    "virtualNetworksApiVersion": "2017-04-01",
+    "vmStorageAccountContainerName": "images",
+    "vnetID": "[resourceId(variables('virtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+  }
+}

--- a/builder/azure/arm/template_factory_test.go
+++ b/builder/azure/arm/template_factory_test.go
@@ -504,6 +504,22 @@ func TestVirtualMachineDeployment15(t *testing.T) {
 	approvaltests.VerifyJSONStruct(t, deployment.Properties.Template)
 }
 
+// Ensure Specialized VMs don't set OsProfile}
+func TestVirtualMachineDeployment16(t *testing.T) {
+	m := getArmBuilderConfiguration()
+
+	var c Config
+	_, err := c.Prepare(m, getPackerConfiguration(), getPackerSSHPasswordCommunicatorConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
+	deployment, err := GetSpecializedVirtualMachineDeployment(&c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	approvaltests.VerifyJSONStruct(t, deployment.Properties.Template)
+}
 // Ensure the link values are not set, and the concrete values are set.
 func TestKeyVaultDeployment00(t *testing.T) {
 	var c Config

--- a/builder/azure/arm/template_factory_test.go
+++ b/builder/azure/arm/template_factory_test.go
@@ -520,6 +520,7 @@ func TestVirtualMachineDeployment16(t *testing.T) {
 
 	approvaltests.VerifyJSONStruct(t, deployment.Properties.Template)
 }
+
 // Ensure the link values are not set, and the concrete values are set.
 func TestKeyVaultDeployment00(t *testing.T) {
 	var c Config

--- a/builder/azure/arm/testdata/arm_linux_specialized.pkr.hcl
+++ b/builder/azure/arm/testdata/arm_linux_specialized.pkr.hcl
@@ -9,7 +9,7 @@ variable "ssh_password" {
 }
 
 variable "ssh_private_key_location" {
-  default = "${env("ARM_SSH_PRIVATE_KEY_LOCATION")}"
+  default = "${env("ARM_SSH_PRIVATE_KEY_FILE")}"
   type = string
 }
 

--- a/builder/azure/arm/testdata/arm_linux_specialized.pkr.hcl
+++ b/builder/azure/arm/testdata/arm_linux_specialized.pkr.hcl
@@ -2,12 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
-variable "ssh_password" {
-  type = string
-  sensitive = true
-  default = "${env("ARM_SSH_PASS")}"
-}
-
 variable "ssh_private_key_location" {
   default = "${env("ARM_SSH_PRIVATE_KEY_FILE")}"
   type = string
@@ -21,7 +15,6 @@ source "azure-arm" "linux-sig" {
   location           = "South Central US"
   vm_size            = "Standard_D4ps_v5"
   ssh_username       = "packer"
-  ssh_password       = var.ssh_password
   ssh_private_key_file = var.ssh_private_key_location
   communicator       = "ssh"
   shared_image_gallery_destination {

--- a/builder/azure/arm/testdata/arm_linux_specialized.pkr.hcl
+++ b/builder/azure/arm/testdata/arm_linux_specialized.pkr.hcl
@@ -8,6 +8,11 @@ variable "ssh_password" {
   default = "${env("ARM_SSH_PASS")}"
 }
 
+variable "ssh_private_key_location" {
+  default = "${env("ARM_SSH_PRIVATE_KEY_LOCATION")}"
+  type = string
+}
+
 source "azure-arm" "linux-sig" {
   image_offer        = "0001-com-ubuntu-server-jammy"
   image_publisher    = "canonical"
@@ -17,6 +22,8 @@ source "azure-arm" "linux-sig" {
   vm_size            = "Standard_D4ps_v5"
   ssh_username       = "packer"
   ssh_password       = var.ssh_password
+  ssh_private_key_file = var.ssh_private_key_location
+  communicator       = "ssh"
   shared_image_gallery_destination {
     image_name     = "arm-linux-specialized-sig"
     gallery_name   = "acctestgallery"

--- a/builder/azure/arm/testdata/child_from_specialized_parent.pkr.hcl
+++ b/builder/azure/arm/testdata/child_from_specialized_parent.pkr.hcl
@@ -4,23 +4,33 @@ locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 variable "ssh_password" {
   type = string
-  sensitive = true
   default = "${env("ARM_SSH_PASS")}"
+  sensitive = true
+}
+
+variable "subscription" {
+  default = "${env("ARM_SUBSCRIPTION_ID")}"
+  type = string
+  sensitive = true
 }
 
 source "azure-arm" "linux-sig" {
-  image_offer        = "0001-com-ubuntu-server-jammy"
-  image_publisher    = "canonical"
-  image_sku          = "22_04-lts-arm64"
   use_azure_cli_auth = true
   location           = "South Central US"
   vm_size            = "Standard_D4ps_v5"
   ssh_username       = "packer"
   ssh_password       = var.ssh_password
-  shared_image_gallery_destination {
+  shared_image_gallery{
+    subscription   = var.subscription
     image_name     = "arm-linux-specialized-sig"
     gallery_name   = "acctestgallery"
     image_version  = "1.0.0"
+    resource_group = "packer-acceptance-test"
+  }
+  shared_image_gallery_destination {
+    image_name     = "arm-linux-specialized-sig"
+    gallery_name   = "acctestgallery"
+    image_version  = "1.0.1"
     resource_group = "packer-acceptance-test"
     specialized    = true
   }

--- a/builder/azure/arm/testdata/child_from_specialized_parent.pkr.hcl
+++ b/builder/azure/arm/testdata/child_from_specialized_parent.pkr.hcl
@@ -15,7 +15,7 @@ variable "subscription" {
 }
 
 variable "ssh_private_key_location" {
-  default = "${env("ARM_SSH_PRIVATE_KEY_LOCATION")}"
+  default = "${env("ARM_SSH_PRIVATE_KEY_FILE")}"
   type = string
 }
 

--- a/builder/azure/arm/testdata/child_from_specialized_parent.pkr.hcl
+++ b/builder/azure/arm/testdata/child_from_specialized_parent.pkr.hcl
@@ -14,12 +14,19 @@ variable "subscription" {
   sensitive = true
 }
 
+variable "ssh_private_key_location" {
+  default = "${env("ARM_SSH_PRIVATE_KEY_LOCATION")}"
+  type = string
+}
+
 source "azure-arm" "linux-sig" {
   use_azure_cli_auth = true
   location           = "South Central US"
   vm_size            = "Standard_D4ps_v5"
   ssh_username       = "packer"
   ssh_password       = var.ssh_password
+  ssh_private_key_file = var.ssh_private_key_location
+  communicator       = "ssh"
   shared_image_gallery{
     subscription   = var.subscription
     image_name     = "arm-linux-specialized-sig"

--- a/builder/azure/arm/testdata/child_from_specialized_parent.pkr.hcl
+++ b/builder/azure/arm/testdata/child_from_specialized_parent.pkr.hcl
@@ -2,12 +2,6 @@
 # SPDX-License-Identifier: MPL-2.0
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
-variable "ssh_password" {
-  type = string
-  default = "${env("ARM_SSH_PASS")}"
-  sensitive = true
-}
-
 variable "subscription" {
   default = "${env("ARM_SUBSCRIPTION_ID")}"
   type = string
@@ -24,7 +18,6 @@ source "azure-arm" "linux-sig" {
   location           = "South Central US"
   vm_size            = "Standard_D4ps_v5"
   ssh_username       = "packer"
-  ssh_password       = var.ssh_password
   ssh_private_key_file = var.ssh_private_key_location
   communicator       = "ssh"
   shared_image_gallery{

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -519,7 +519,7 @@ func (s *TemplateBuilder) SetSecurityProfile(secureBootEnabled bool, vtpmEnabled
 	return nil
 }
 
-func (s *TemplateBuilder) SetSpecializedVM() error {
+func (s *TemplateBuilder) ClearOsProfile() error {
 	resource, err := s.getResourceByType(resourceVirtualMachine)
 	if err != nil {
 		return err

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -355,7 +355,6 @@ func (s *TemplateBuilder) SetSpot(policy compute.VirtualMachineEvictionPolicyTyp
 
 	resource.Properties.Priority = to.StringPtr("Spot")
 	resource.Properties.EvictionPolicy = &policy
-
 	if price == 0 {
 		price = -1
 	}
@@ -517,6 +516,15 @@ func (s *TemplateBuilder) SetSecurityProfile(secureBootEnabled bool, vtpmEnabled
 	}
 	resource.Properties.SecurityProfile.EncryptionAtHost = to.BoolPtr(encryptionAtHost)
 
+	return nil
+}
+
+func (s *TemplateBuilder) SetSpecializedVM() error {
+	resource, err := s.getResourceByType(resourceVirtualMachine)
+	if err != nil {
+		return err
+	}
+	resource.Properties.OsProfile = nil
 	return nil
 }
 


### PR DESCRIPTION
This PR fixes an issue added with plugin version v1.4.3

### Description 

In that plugin version we added support for creating a specialized ACG image with Packer, however when trying to use that specialized ACG image as a source for another image, we would incorrectly set the username and password, which is already defined in non-generalized VM Images.

### Changes

- Whenever a source SIG image is specialized, we remove the OS Profile field from the VM Deployment Template
- Added an acceptance test which requires an SSH PEM Private key file, the path of which is set under the environment variable `ARM_SSH_PRIVATE_KEY_FILE`
- ARM Acceptance tests no longer skip CLI auth tests, instead they fail the test file if Azure CLI auth is not set up

Closes #307

