### PR TITLE
Add encryption at host flag to the arm template

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -562,6 +562,9 @@ type Config struct {
 	LicenseType string `mapstructure:"license_type" required:"false"`
 	// Specifies if Secure Boot and Trusted Launch is enabled for the Virtual Machine.
 	SecureBootEnabled bool `mapstructure:"secure_boot_enabled" required:"false"`
+	// Specifies if Encryption at host is enabled for the Virtual Machine.
+	// Requires enabling encryption at host in the Subscription read more [here](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell)
+	EncryptionAtHost bool `mapstructure:"encryption_at_host" required:"false"`
 
 	// Specifies if vTPM (virtual Trusted Platform Module) and Trusted Launch is enabled for the Virtual Machine.
 	VTpmEnabled bool `mapstructure:"vtpm_enabled" required:"false"`

--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -91,6 +91,7 @@ type FlatConfig struct {
 	CustomResourcePrefix                       *string                            `mapstructure:"custom_resource_build_prefix" required:"false" cty:"custom_resource_build_prefix" hcl:"custom_resource_build_prefix"`
 	LicenseType                                *string                            `mapstructure:"license_type" required:"false" cty:"license_type" hcl:"license_type"`
 	SecureBootEnabled                          *bool                              `mapstructure:"secure_boot_enabled" required:"false" cty:"secure_boot_enabled" hcl:"secure_boot_enabled"`
+	EncryptionAtHost                           *bool                              `mapstructure:"encryption_at_host" required:"false" cty:"encryption_at_host" hcl:"encryption_at_host"`
 	VTpmEnabled                                *bool                              `mapstructure:"vtpm_enabled" required:"false" cty:"vtpm_enabled" hcl:"vtpm_enabled"`
 	Type                                       *string                            `mapstructure:"communicator" cty:"communicator" hcl:"communicator"`
 	PauseBeforeConnect                         *string                            `mapstructure:"pause_before_connecting" cty:"pause_before_connecting" hcl:"pause_before_connecting"`
@@ -235,6 +236,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"custom_resource_build_prefix":                     &hcldec.AttrSpec{Name: "custom_resource_build_prefix", Type: cty.String, Required: false},
 		"license_type":                                     &hcldec.AttrSpec{Name: "license_type", Type: cty.String, Required: false},
 		"secure_boot_enabled":                              &hcldec.AttrSpec{Name: "secure_boot_enabled", Type: cty.Bool, Required: false},
+		"encryption_at_host":                               &hcldec.AttrSpec{Name: "encryption_at_host", Type: cty.Bool, Required: false},
 		"vtpm_enabled":                                     &hcldec.AttrSpec{Name: "vtpm_enabled", Type: cty.Bool, Required: false},
 		"communicator":                                     &hcldec.AttrSpec{Name: "communicator", Type: cty.String, Required: false},
 		"pause_before_connecting":                          &hcldec.AttrSpec{Name: "pause_before_connecting", Type: cty.String, Required: false},

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -233,8 +233,8 @@ func GetVirtualMachineDeployment(config *Config) (*resources.Deployment, error) 
 		}
 	}
 
-	if config.SecureBootEnabled || config.VTpmEnabled {
-		err = builder.SetSecurityProfile(config.SecureBootEnabled, config.VTpmEnabled)
+	if config.SecureBootEnabled || config.VTpmEnabled || config.EncryptionAtHost {
+		err = builder.SetSecurityProfile(config.SecureBootEnabled, config.VTpmEnabled, config.EncryptionAtHost)
 		if err != nil {
 			return nil, err
 		}

--- a/builder/azure/arm/template_factory_test.TestTrustedLaunch01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestTrustedLaunch01.approved.json
@@ -144,6 +144,7 @@
           }
         },
         "securityProfile": {
+          "encryptionAtHost": false,
           "securityType": "TrustedLaunch",
           "uefiSettings": {
             "secureBootEnabled": true,

--- a/builder/azure/chroot/shared_image_gallery_destination_test.go
+++ b/builder/azure/chroot/shared_image_gallery_destination_test.go
@@ -46,12 +46,12 @@ func TestSharedImageGalleryDestination_Validate(t *testing.T) {
 				ImageName:     "ImageName",
 				ImageVersion:  "0.1.2",
 				TargetRegions: []TargetRegion{
-					TargetRegion{
+					{
 						Name:               "region1",
 						ReplicaCount:       5,
 						StorageAccountType: "Standard_ZRS",
 					},
-					TargetRegion{
+					{
 						Name:               "region2",
 						ReplicaCount:       3,
 						StorageAccountType: "Standard_LRS",
@@ -78,12 +78,12 @@ func TestSharedImageGalleryDestination_Validate(t *testing.T) {
 				ImageName:     "ImageName",
 				ImageVersion:  "0.1.2",
 				TargetRegions: []TargetRegion{
-					TargetRegion{
+					{
 						Name:               "region1",
 						ReplicaCount:       5,
 						StorageAccountType: "Standard_ZRS",
 					},
-					TargetRegion{
+					{
 						Name:               "region2",
 						ReplicaCount:       3,
 						StorageAccountType: "Standard_LRS",
@@ -104,12 +104,12 @@ func TestSharedImageGalleryDestination_Validate(t *testing.T) {
 				ImageName:     "ImageName",
 				ImageVersion:  "0.1.2alpha",
 				TargetRegions: []TargetRegion{
-					TargetRegion{
+					{
 						Name:               "region1",
 						ReplicaCount:       5,
 						StorageAccountType: "Standard_ZRS",
 					},
-					TargetRegion{
+					{
 						Name:               "region2",
 						ReplicaCount:       3,
 						StorageAccountType: "Standard_LRS",

--- a/builder/azure/common/template/template_builder.go
+++ b/builder/azure/common/template/template_builder.go
@@ -501,7 +501,7 @@ func (s *TemplateBuilder) SetLicenseType(licenseType string) error {
 	return nil
 }
 
-func (s *TemplateBuilder) SetSecurityProfile(secureBootEnabled bool, vtpmEnabled bool) error {
+func (s *TemplateBuilder) SetSecurityProfile(secureBootEnabled bool, vtpmEnabled bool, encryptionAtHost bool) error {
 	s.setVariable("apiVersion", "2020-12-01") // Required for Trusted Launch
 	resource, err := s.getResourceByType(resourceVirtualMachine)
 	if err != nil {
@@ -509,10 +509,13 @@ func (s *TemplateBuilder) SetSecurityProfile(secureBootEnabled bool, vtpmEnabled
 	}
 
 	resource.Properties.SecurityProfile = &compute.SecurityProfile{}
-	resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
-	resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
-	resource.Properties.SecurityProfile.UefiSettings.SecureBootEnabled = to.BoolPtr(secureBootEnabled)
-	resource.Properties.SecurityProfile.UefiSettings.VTpmEnabled = to.BoolPtr(vtpmEnabled)
+	if secureBootEnabled || vtpmEnabled {
+		resource.Properties.SecurityProfile.UefiSettings = &compute.UefiSettings{}
+		resource.Properties.SecurityProfile.SecurityType = compute.SecurityTypesTrustedLaunch
+		resource.Properties.SecurityProfile.UefiSettings.SecureBootEnabled = to.BoolPtr(secureBootEnabled)
+		resource.Properties.SecurityProfile.UefiSettings.VTpmEnabled = to.BoolPtr(vtpmEnabled)
+	}
+	resource.Properties.SecurityProfile.EncryptionAtHost = to.BoolPtr(encryptionAtHost)
 
 	return nil
 }

--- a/docs-partials/builder/azure/arm/Config-not-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-not-required.mdx
@@ -381,6 +381,9 @@
 
 - `secure_boot_enabled` (bool) - Specifies if Secure Boot and Trusted Launch is enabled for the Virtual Machine.
 
+- `encryption_at_host` (bool) - Specifies if Encryption at host is enabled for the Virtual Machine.
+  Requires enabling encryption at host in the Subscription read more [here](https://learn.microsoft.com/en-us/azure/virtual-machines/disks-enable-host-based-encryption-portal?tabs=azure-powershell)
+
 - `vtpm_enabled` (bool) - Specifies if vTPM (virtual Trusted Platform Module) and Trusted Launch is enabled for the Virtual Machine.
 
 - `async_resourcegroup_delete` (bool) - If you want packer to delete the


### PR DESCRIPTION
This is an additional parameter already existing in the arm template. We have restricted policies on our infrastructure where we are not able to create the virtual machine without Encryption at host enabled.

I know that it could be a dedicated subscription for the build process but this is the organization and certification requirement.



