### PR TITLE
Fix ARM builder docs and examples

### DIFF
--- a/docs/builders/arm.mdx
+++ b/docs/builders/arm.mdx
@@ -351,10 +351,8 @@ here](https://technet.microsoft.com/en-us/library/hh824815.aspx)
     {
       "type": "powershell",
       "inline": [
-        " # NOTE: the following *3* lines are only needed if the you have installed the Guest Agent.",
-        "  while ((Get-Service RdAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
-        "  while ((Get-Service WindowsAzureTelemetryService).Status -ne 'Running') { Start-Sleep -s 5 }",
-        "  while ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
+        "# If Guest Agent services are installed, make sure that they have started.",
+        "foreach ($service in Get-Service -Name RdAgent, WindowsAzureTelemetryService, WindowsAzureGuestAgent -ErrorAction SilentlyContinue) { while ((Get-Service $service.Name).Status -ne 'Running') { Start-Sleep -s 5 } }",
 
         "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit /mode:vm",
         "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }"
@@ -370,10 +368,8 @@ here](https://technet.microsoft.com/en-us/library/hh824815.aspx)
 ```hcl
 provisioner "powershell" {
    inline = [
-        " # NOTE: the following *3* lines are only needed if the you have installed the Guest Agent.",
-        "  while ((Get-Service RdAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
-        "  while ((Get-Service WindowsAzureTelemetryService).Status -ne 'Running') { Start-Sleep -s 5 }",
-        "  while ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
+        "# If Guest Agent services are installed, make sure that they have started.",
+        "foreach ($service in Get-Service -Name RdAgent, WindowsAzureTelemetryService, WindowsAzureGuestAgent -ErrorAction SilentlyContinue) { while ((Get-Service $service.Name).Status -ne 'Running') { Start-Sleep -s 5 } }",
 
         "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit /mode:vm",
         "while($true) { $imageState = Get-ItemProperty HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Setup\\State | Select ImageState; if($imageState.ImageState -ne 'IMAGE_STATE_GENERALIZE_RESEAL_TO_OOBE') { Write-Output $imageState.ImageState; Start-Sleep -s 10  } else { break } }"

--- a/example/windows.json
+++ b/example/windows.json
@@ -31,10 +31,8 @@
   "provisioners": [{
     "type": "powershell",
       "inline": [
-        " # NOTE: the following *3* lines are only needed if the you have installed the Guest Agent.",
-        "  while ((Get-Service RdAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
-        "  while ((Get-Service WindowsAzureTelemetryService).Status -ne 'Running') { Start-Sleep -s 5 }",
-        "  while ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
+        "# If Guest Agent services are installed, make sure that they have started.",
+        "foreach ($service in Get-Service -Name RdAgent, WindowsAzureTelemetryService, WindowsAzureGuestAgent -ErrorAction SilentlyContinue) { while ((Get-Service $service.Name).Status -ne 'Running') { Start-Sleep -s 5 } }",
 
         "if( Test-Path $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml ){ rm $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml -Force}",
         "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit /mode:vm",

--- a/example/windows_custom_image.json
+++ b/example/windows_custom_image.json
@@ -36,10 +36,8 @@
   "provisioners": [{
     "type": "powershell",
       "inline": [
-        " # NOTE: the following *3* lines are only needed if the you have installed the Guest Agent.",
-        "  while ((Get-Service RdAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
-        "  while ((Get-Service WindowsAzureTelemetryService).Status -ne 'Running') { Start-Sleep -s 5 }",
-        "  while ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
+        "# If Guest Agent services are installed, make sure that they have started.",
+        "foreach ($service in Get-Service -Name RdAgent, WindowsAzureTelemetryService, WindowsAzureGuestAgent -ErrorAction SilentlyContinue) { while ((Get-Service $service.Name).Status -ne 'Running') { Start-Sleep -s 5 } }",
 
         "if( Test-Path $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml ){ rm $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml -Force}",
         "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit /mode:vm",

--- a/example/windows_quickstart.json
+++ b/example/windows_quickstart.json
@@ -27,10 +27,8 @@
   "provisioners": [{
     "type": "powershell",
       "inline": [
-        " # NOTE: the following *3* lines are only needed if the you have installed the Guest Agent.",
-        "  while ((Get-Service RdAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
-        "  while ((Get-Service WindowsAzureTelemetryService).Status -ne 'Running') { Start-Sleep -s 5 }",
-        "  while ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
+        "# If Guest Agent services are installed, make sure that they have started.",
+        "foreach ($service in Get-Service -Name RdAgent, WindowsAzureTelemetryService, WindowsAzureGuestAgent -ErrorAction SilentlyContinue) { while ((Get-Service $service.Name).Status -ne 'Running') { Start-Sleep -s 5 } }",
 
         "if( Test-Path $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml ){ rm $Env:SystemRoot\\windows\\system32\\Sysprep\\unattend.xml -Force}",
         "& $env:SystemRoot\\System32\\Sysprep\\Sysprep.exe /oobe /generalize /quiet /quit /mode:vm",


### PR DESCRIPTION
### Description

This PR fixes the problem with building Windows VM images using Azure ARM builder scripts referenced in the docs and example JSON templates.

There is a problem with provisioner Powershell snippet referenced in ARM builder docs and examples:
```
        " # NOTE: the following *3* lines are only needed if the you have installed the Guest Agent.",
        "  while ((Get-Service RdAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
        "  while ((Get-Service WindowsAzureTelemetryService).Status -ne 'Running') { Start-Sleep -s 5 }",
        "  while ((Get-Service WindowsAzureGuestAgent).Status -ne 'Running') { Start-Sleep -s 5 }",
```

The problem is caused by WindowsAzureTelemetryService service missing in Windows VM after Microsoft updated the way Guest Agent is installed in Azure Windows VMs [https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/windows-azure-guest-agent](https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/windows-azure-guest-agent):

> Note
> 
> Starting in version 2.7.41491.971 of the VM Guest Agent, the Telemetry component is included in the Windows Azure Guest Agent service. Therefore, you might not see this Telemetry service listed in newly created VMs.

Errors produced by packer because of missing WindowsAzureTelemetryService:

```
==> azure-arm: Get-Service : Cannot find any service with service name 'WindowsAzureTelemetryService'.
==> azure-arm: At C:\Windows\Temp\script-64a6808c-1b35-a7f0-bf07-4b5cef408548.ps1:7 char:11
==> azure-arm: +   while ((Get-Service WindowsAzureTelemetryService).Status -ne 'Runni ...
==> azure-arm: +           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
==> azure-arm:     + CategoryInfo          : ObjectNotFound: (WindowsAzureTelemetryService:String) [Get-Service], ServiceCommandExcep
==> azure-arm:    tion
==> azure-arm:     + FullyQualifiedErrorId : NoServiceFoundForGivenName,Microsoft.PowerShell.Commands.GetServiceCommand
``` 

Related issues:
[#9261](https://github.com/hashicorp/packer/issues/9261)
[#26](https://github.com/hashicorp/packer-plugin-azure/issues/26)
[Discussion](https://discuss.hashicorp.com/t/cannot-find-any-service-with-service-name-windowsazuretelemetryservice/8902/3)

### Proposed Fix
The proposed fix checks that the service exists before checking that it's in the Running status.
Also removed some duplication of code and used _foreach_ to iterate through the list of services to be checked.
