### PR TITLE
Use the parent's Subscription when checking for Specialized SIG

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -214,7 +214,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	}
 	sourceImageSpecialized := false
 	if b.config.SharedGallery.GalleryName != "" {
-		galleryImage, err := azureClient.GalleryImagesClient.Get(ctx, b.config.SharedGallery.ResourceGroup, b.config.SharedGallery.GalleryName, b.config.SharedGallery.ImageName)
+		client := azureClient.GalleryImagesClient
+		client.SubscriptionID = b.config.SharedGallery.Subscription
+		galleryImage, err := client.Get(ctx, b.config.SharedGallery.ResourceGroup, b.config.SharedGallery.GalleryName, b.config.SharedGallery.ImageName)
 		if err != nil {
 			return nil, fmt.Errorf("the parent Shared Gallery Image '%s' from which to source the managed image version to does not exist in the resource group '%s' or does not contain managed image '%s'", b.config.SharedGallery.GalleryName, b.config.SharedGallery.ResourceGroup, b.config.SharedGallery.ImageName)
 		}


### PR DESCRIPTION
In v1.4.4 of the plugin a regression was shipped (https://github.com/hashicorp/packer-plugin-azure/issues/321) where when checking if a source SIG image is specialized or not we were passing in the build's subscription, because of this if you built a SIG image based on a SIG image in another subscription in v1.4.4 you receive the following error

```
==> azure-arm.linux-sig: Running builder ...
==> azure-arm.linux-sig: Getting tokens using Azure CLI
==> azure-arm.linux-sig: Getting tokens using Azure CLI
    azure-arm.linux-sig: Creating Azure Resource Manager (ARM) client ...
Build 'azure-arm.linux-sig' errored after 1 second 97 milliseconds: the parent Shared Gallery Image 'acctestgallery' from which to source the managed image version to does not exist in the resource group 'jenna-other-sub' or does not contain managed image 'arm-linux-specialized-sig'

==> Wait completed after 1 second 97 milliseconds

==> Some builds didn't complete successfully and had errors:
--> azure-arm.linux-sig: the parent Shared Gallery Image 'acctestgallery' from which to source the managed image version to does not exist in the resource group 'jenna-other-sub' or does not contain managed image 'arm-linux-specialized-sig'

==> Builds finished but no artifacts were created.
```

After this change trying to build the same image is successful.

Closes #321 