### PR TITLE
Use latest packer version in setup-packer for OIDC Test

### DIFF
--- a/.github/workflows/oidc-test.yaml
+++ b/.github/workflows/oidc-test.yaml
@@ -9,8 +9,6 @@
 name: OIDC Example - Testing OIDC integration in the SDK branch
 on:
   push:
-    branches:
-    - main
 
 permissions:
   contents: read
@@ -52,9 +50,6 @@ jobs:
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main
         id: setup
-        with: 
-          # TODO Update this to latest after v1.9.3 is released
-          version: '1.9.1'
 
       - name: Build the plugin
         run:  make


### PR DESCRIPTION
Packer v1..9.2 had a bug where locally built plugins were not properly used, so I pinned the OIDC test to 1.9.1, now I want it to be on the latest build since v1.9.3 fixes that issue
