### PR TITLE
fix: Capture Container Name/Prefix not used in Artifact

### DIFF
--- a/builder/azure/arm/artifact.go
+++ b/builder/azure/arm/artifact.go
@@ -92,16 +92,16 @@ func NewSharedImageArtifact(osType, destinationSharedImageGalleryId string, loca
 	}, nil
 }
 
-func NewArtifact(vmInternalID string, storageAccountUrl string, storageAccountLocation string, osType string, additionalDiskCount int, generatedData map[string]interface{}) (*Artifact, error) {
-	vhdUri := fmt.Sprintf("%ssystem/Microsoft.Compute/Images/images/packer-osDisk.%s.vhd", storageAccountUrl, vmInternalID)
+func NewArtifact(vmInternalID string, captureContainerPrefix string, captureContainerName string, storageAccountUrl string, storageAccountLocation string, osType string, additionalDiskCount int, generatedData map[string]interface{}) (*Artifact, error) {
+	vhdUri := fmt.Sprintf("%ssystem/Microsoft.Compute/Images/%s/%s-osDisk.%s.vhd", storageAccountUrl, captureContainerName, captureContainerPrefix, vmInternalID)
 
-	templateUri := fmt.Sprintf("%ssystem/Microsoft.Compute/Images/images/packer-vmTemplate.%s.json", storageAccountUrl, vmInternalID)
+	templateUri := fmt.Sprintf("%ssystem/Microsoft.Compute/Images/%s/%s-vmTemplate.%s.json", storageAccountUrl, captureContainerName, captureContainerPrefix, vmInternalID)
 
 	var additional_disks *[]AdditionalDiskArtifact
 	if additionalDiskCount > 0 {
 		data_disks := make([]AdditionalDiskArtifact, additionalDiskCount)
 		for i := 0; i < additionalDiskCount; i++ {
-			data_disks[i].AdditionalDiskUri = fmt.Sprintf("%ssystem/Microsoft.Compute/Images/images/packer-datadisk-%d.%s.vhd", storageAccountUrl, i+1, vmInternalID)
+			data_disks[i].AdditionalDiskUri = fmt.Sprintf("%ssystem/Microsoft.Compute/Images/%s/%s-datadisk-%d.%s.vhd", storageAccountUrl, captureContainerName, captureContainerPrefix, i+1, vmInternalID)
 		}
 		additional_disks = &data_disks
 	}

--- a/builder/azure/arm/artifact.go
+++ b/builder/azure/arm/artifact.go
@@ -101,7 +101,7 @@ func NewArtifact(vmInternalID string, captureContainerPrefix string, captureCont
 	if additionalDiskCount > 0 {
 		data_disks := make([]AdditionalDiskArtifact, additionalDiskCount)
 		for i := 0; i < additionalDiskCount; i++ {
-			data_disks[i].AdditionalDiskUri = fmt.Sprintf("%ssystem/Microsoft.Compute/Images/%s/%s-datadisk-%d.%s.vhd", storageAccountUrl, captureContainerName, captureContainerPrefix, i+1, vmInternalID)
+			data_disks[i].AdditionalDiskUri = fmt.Sprintf("%ssystem/Microsoft.Compute/Images/%s/%s-datadisk-%d.%s.vhd", storageAccountUrl, captureContainerName, captureContainerPrefix, i, vmInternalID)
 		}
 		additional_disks = &data_disks
 	}

--- a/builder/azure/arm/artifact_test.go
+++ b/builder/azure/arm/artifact_test.go
@@ -345,7 +345,7 @@ func TestAdditionalDiskArtifactString(t *testing.T) {
 	if !strings.Contains(testSubject, "OSType: Linux") {
 		t.Errorf("Expected String() output to contain OSType")
 	}
-	if !strings.Contains(testSubject, "AdditionalDiskUri (datadisk-1): https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/anothercontainername/anotherprefix-datadisk-1.4085bb15-3644-4641-b9cd-f575918640b4.vhd") {
+	if !strings.Contains(testSubject, "AdditionalDiskUri (datadisk-1): https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/anothercontainername/anotherprefix-datadisk-0.4085bb15-3644-4641-b9cd-f575918640b4.vhd") {
 		t.Errorf("Expected String() output to contain AdditionalDiskUri")
 	}
 }
@@ -394,8 +394,8 @@ func TestAdditionalDiskArtifactProperties(t *testing.T) {
 	if len(*testSubject.AdditionalDisks) != 1 {
 		t.Errorf("Expected AdditionalDisks to have one additional disk, but got %d", len(*testSubject.AdditionalDisks))
 	}
-	if (*testSubject.AdditionalDisks)[0].AdditionalDiskUri != "https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-datadisk-1.4085bb15-3644-4641-b9cd-f575918640b4.vhd" {
-		t.Errorf("Expected additional disk uri to be 'https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-datadisk-1.4085bb15-3644-4641-b9cd-f575918640b4.vhd', but got %s", (*testSubject.AdditionalDisks)[0].AdditionalDiskUri)
+	if (*testSubject.AdditionalDisks)[0].AdditionalDiskUri != "https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-datadisk-0.4085bb15-3644-4641-b9cd-f575918640b4.vhd" {
+		t.Errorf("Expected additional disk uri to be 'https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-datadisk-0.4085bb15-3644-4641-b9cd-f575918640b4.vhd', but got %s", (*testSubject.AdditionalDisks)[0].AdditionalDiskUri)
 	}
 }
 

--- a/builder/azure/arm/artifact_test.go
+++ b/builder/azure/arm/artifact_test.go
@@ -17,7 +17,7 @@ func generatedData() map[string]interface{} {
 }
 
 func TestArtifactIdVHD(t *testing.T) {
-	artifact, err := NewArtifact("4085bb15-3644-4641-b9cd-f575918640b4", "https://storage.blob.core.windows.net/", "southcentralus", "Linux", 0, generatedData())
+	artifact, err := NewArtifact("4085bb15-3644-4641-b9cd-f575918640b4", "packer", "images", "https://storage.blob.core.windows.net/", "southcentralus", "Linux", 0, generatedData())
 	if err != nil {
 		t.Fatalf("err=%s", err)
 	}
@@ -306,7 +306,7 @@ SharedImageGalleryReplicatedRegions: fake-region-1, fake-region-2
 }
 
 func TestArtifactString(t *testing.T) {
-	artifact, err := NewArtifact("4085bb15-3644-4641-b9cd-f575918640b4", "https://storage.blob.core.windows.net/", "southcentralus", "Linux", 0, generatedData())
+	artifact, err := NewArtifact("4085bb15-3644-4641-b9cd-f575918640b4", "packer", "images", "https://storage.blob.core.windows.net/", "southcentralus", "Linux", 0, generatedData())
 	if err != nil {
 		t.Fatalf("err=%s", err)
 	}
@@ -327,7 +327,7 @@ func TestArtifactString(t *testing.T) {
 }
 
 func TestAdditionalDiskArtifactString(t *testing.T) {
-	artifact, err := NewArtifact("4085bb15-3644-4641-b9cd-f575918640b4", "https://storage.blob.core.windows.net/", "southcentralus", "Linux", 1, generatedData())
+	artifact, err := NewArtifact("4085bb15-3644-4641-b9cd-f575918640b4", "packer", "images", "https://storage.blob.core.windows.net/", "southcentralus", "Linux", 1, generatedData())
 	if err != nil {
 		t.Fatalf("err=%s", err)
 	}
@@ -351,7 +351,7 @@ func TestAdditionalDiskArtifactString(t *testing.T) {
 }
 
 func TestArtifactProperties(t *testing.T) {
-	testSubject, err := NewArtifact("4085bb15-3644-4641-b9cd-f575918640b4", "https://storage.blob.core.windows.net/", "southcentralus", "Linux", 0, generatedData())
+	testSubject, err := NewArtifact("4085bb15-3644-4641-b9cd-f575918640b4", "packer", "images", "https://storage.blob.core.windows.net/", "southcentralus", "Linux", 0, generatedData())
 	if err != nil {
 		t.Fatalf("err=%s", err)
 	}
@@ -371,7 +371,7 @@ func TestArtifactProperties(t *testing.T) {
 }
 
 func TestAdditionalDiskArtifactProperties(t *testing.T) {
-	testSubject, err := NewArtifact("4085bb15-3644-4641-b9cd-f575918640b4", "https://storage.blob.core.windows.net/", "southcentralus", "Linux", 1, generatedData())
+	testSubject, err := NewArtifact("4085bb15-3644-4641-b9cd-f575918640b4", "packer", "images", "https://storage.blob.core.windows.net/", "southcentralus", "Linux", 1, generatedData())
 	if err != nil {
 		t.Fatalf("err=%s", err)
 	}

--- a/builder/azure/arm/artifact_test.go
+++ b/builder/azure/arm/artifact_test.go
@@ -327,16 +327,16 @@ func TestArtifactString(t *testing.T) {
 }
 
 func TestAdditionalDiskArtifactString(t *testing.T) {
-	artifact, err := NewArtifact("4085bb15-3644-4641-b9cd-f575918640b4", "packer", "images", "https://storage.blob.core.windows.net/", "southcentralus", "Linux", 1, generatedData())
+	artifact, err := NewArtifact("4085bb15-3644-4641-b9cd-f575918640b4", "anotherprefix", "anothercontainername", "https://storage.blob.core.windows.net/", "southcentralus", "Linux", 1, generatedData())
 	if err != nil {
 		t.Fatalf("err=%s", err)
 	}
 
 	testSubject := artifact.String()
-	if !strings.Contains(testSubject, "OSDiskUri: https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd") {
+	if !strings.Contains(testSubject, "OSDiskUri: https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/anothercontainername/anotherprefix-osDisk.4085bb15-3644-4641-b9cd-f575918640b4.vhd") {
 		t.Errorf("Expected String() output to contain OSDiskUri")
 	}
-	if !strings.Contains(testSubject, "TemplateUri: https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-vmTemplate.4085bb15-3644-4641-b9cd-f575918640b4.json") {
+	if !strings.Contains(testSubject, "TemplateUri: https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/anothercontainername/anotherprefix-vmTemplate.4085bb15-3644-4641-b9cd-f575918640b4.json") {
 		t.Errorf("Expected String() output to contain TemplateUri")
 	}
 	if !strings.Contains(testSubject, "StorageAccountLocation: southcentralus") {
@@ -345,7 +345,7 @@ func TestAdditionalDiskArtifactString(t *testing.T) {
 	if !strings.Contains(testSubject, "OSType: Linux") {
 		t.Errorf("Expected String() output to contain OSType")
 	}
-	if !strings.Contains(testSubject, "AdditionalDiskUri (datadisk-1): https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/images/packer-datadisk-1.4085bb15-3644-4641-b9cd-f575918640b4.vhd") {
+	if !strings.Contains(testSubject, "AdditionalDiskUri (datadisk-1): https://storage.blob.core.windows.net/system/Microsoft.Compute/Images/anothercontainername/anotherprefix-datadisk-1.4085bb15-3644-4641-b9cd-f575918640b4.vhd") {
 		t.Errorf("Expected String() output to contain AdditionalDiskUri")
 	}
 }

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -422,6 +422,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	ui.Say(fmt.Sprintf("%d", len(b.config.AdditionalDiskSize)))
 	return NewArtifact(
 		b.stateBag.Get(constants.ArmBuildVMInternalId).(string),
+		b.config.CaptureNamePrefix,
+		b.config.CaptureContainerName,
 		b.config.storageAccountBlobEndpoint,
 		b.config.StorageAccount,
 		b.config.OSType,


### PR DESCRIPTION
In v2.0.0 I hard coded my capture container name/prefix for VHD build Artifacts.  We should be using the same ones the VM is captured with, these fields are required for VHD builds.

This PR also fixes an issue where the additional disk VHD URIs were incorrectly numbered, I've attached a screenshot to show what it looks like in the storage account vs the matching URIs displayed in the output
Closes #339
<img width="1512" alt="Screenshot 2023-10-16 at 3 24 15 PM" src="https://github.com/hashicorp/packer-plugin-azure/assets/23503014/1e76a5b4-47ff-4354-b935-66971dc7d887">


