### PR TITLE
client: propagate ClientID to MSI auth

### DIFF
--- a/builder/azure/common/client/azure_authorizer.go
+++ b/builder/azure/common/client/azure_authorizer.go
@@ -52,6 +52,7 @@ func buildAuthorizer(ctx context.Context, authOpts AzureAuthOptions, env environ
 		authConfig = auth.Credentials{
 			Environment:                              env,
 			EnableAuthenticatingUsingManagedIdentity: true,
+			ClientID:                                 authOpts.ClientID,
 		}
 	case AuthTypeClientSecret:
 		authConfig = auth.Credentials{


### PR DESCRIPTION
Manages System Identity authentication methods support using a ClientID, but wasn't propagated to the SDK.

This causes issues for users that had more than one identity managed by the endpoint, as the authenticator would default to using the system-assigned identity, which may not have the permissions required to perform the build.

Since this is already supported by the SDK used by the plugin, we forward this information (already available as part of the configuration for the builders) to the SDK so it gets the requested user-assigned identity token from the authentication endpoint.

Closes #353 