### PR TITLE
[HPR-1606] Add support specifying disk encryption set keys across replicated regions

### DIFF
--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -643,6 +643,12 @@ The shared_image_gallery_destination block is available for publishing a new ima
 - `replication_regions` ([]string) - A list of regions to replicate the image version in, by default the build location will be used as a replication region (the build location is either set in the location field, or the location of the resource group used in `build_resource_group_name` will be included.
   Can not contain any region but the build region when using shallow replication
 
+- `target_region` ([]TargetRegion) - A target region to store the image version in. The attribute supersedes `replication_regions` which is now considered deprecated.
+  One or more target_region blocks can be specified for storing an imager version to various regions. In addition to specifying a region,
+  a DiskEncryptionSetId can be specified for each target region to support multi-region disk encryption.
+  At a minimum their must be one target region entry for the primary build region where the image version will be stored.
+  Target region must only contain one entry matching the build region when using shallow replication.
+
 - `storage_account_type` (string) - Specify a storage account type for the Shared Image Gallery Image Version.
   Defaults to `Standard_LRS`. Accepted values are `Standard_LRS`, `Standard_ZRS` and `Premium_LRS`
 

--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -209,8 +209,16 @@ Providing `temp_resource_group_name` or `location` in combination with
       gallery_name = "GalleryName"
       image_name = "ImageName"
       image_version = "1.0.0"
-      replication_regions = ["regionA", "regionB", "regionC"]
       storage_account_type = "Standard_LRS"
+      target_region {
+        name = "regionA"
+      }
+      target_region {
+        name = "regionB"
+      }
+      target_region {
+        name = "regionC"
+      }
   }
   managed_image_name = "TargetImageName"
   managed_image_resource_group_name = "TargetResourceGroup"

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -215,20 +215,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			return nil, fmt.Errorf("a gallery image version for image name:version %s:%s already exists in gallery %s", b.config.SharedGalleryDestination.SigDestinationImageName, b.config.SharedGalleryDestination.SigDestinationImageVersion, b.config.SharedGalleryDestination.SigDestinationGalleryName)
 		}
 
-		// TODO It would be better if validation could be handled in a central location
-		// Currently we rely on the build Resource Group being queried if used to get the build location
-		// So we have to do this validation afterwards
-		// We should remove this logic builder and handle this logic via the `Step` pattern
-		if b.config.SharedGalleryDestination.SigDestinationUseShallowReplicationMode {
-			err := errors.New("when `use_shallow_replication` there can only be one destination region defined and it must match `location` or match the region of `build_resource_group_name`.")
-			switch {
-			case len(b.config.SharedGalleryDestination.SigDestinationTargetRegions) > 1:
-				return nil, err
-			case len(b.config.SharedGalleryDestination.SigDestinationReplicationRegions) > 1:
-				return nil, err
-			}
-		}
-
 		if len(b.config.SharedGalleryDestination.SigDestinationTargetRegions) > 0 {
 			normalizedRegions := make([]TargetRegion, 0, len(b.config.SharedGalleryDestination.SigDestinationTargetRegions))
 			for _, tr := range b.config.SharedGalleryDestination.SigDestinationTargetRegions {

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -215,11 +215,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			return nil, fmt.Errorf("a gallery image version for image name:version %s:%s already exists in gallery %s", b.config.SharedGalleryDestination.SigDestinationImageName, b.config.SharedGalleryDestination.SigDestinationImageVersion, b.config.SharedGalleryDestination.SigDestinationGalleryName)
 		}
 
-		// Validate target region settings; it can be the deprecated replicated_regsions attribute or multiple target_region blocks
-		if (len(b.config.SharedGalleryDestination.SigDestinationReplicationRegions) > 0) && (len(b.config.SharedGalleryDestination.SigDestinationTargetRegions) > 0) {
-			return nil, fmt.Errorf("`replicated_regions` can not be defined alongside `target_regions`; you can defined a target_region for each destination region you wish to replicate to.")
-		}
-
 		// TODO It would be better if validation could be handled in a central location
 		// Currently we rely on the build Resource Group being queried if used to get the build location
 		// So we have to do this validation afterwards

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -215,33 +215,64 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			return nil, fmt.Errorf("a gallery image version for image name:version %s:%s already exists in gallery %s", b.config.SharedGalleryDestination.SigDestinationImageName, b.config.SharedGalleryDestination.SigDestinationImageVersion, b.config.SharedGalleryDestination.SigDestinationGalleryName)
 		}
 
-		// SIG requires that replication regions include the region in which the created image version resides
-		buildLocation := normalizeAzureRegion(b.stateBag.Get(constants.ArmLocation).(string))
-		foundMandatoryReplicationRegion := false
-		var normalizedReplicationRegions []string
-		for _, region := range b.config.SharedGalleryDestination.SigDestinationReplicationRegions {
-			// change region to lower-case and strip spaces
-			normalizedRegion := normalizeAzureRegion(region)
-			normalizedReplicationRegions = append(normalizedReplicationRegions, normalizedRegion)
-			if strings.EqualFold(normalizedRegion, buildLocation) {
-				foundMandatoryReplicationRegion = true
-				continue
-			}
+		// Validate target region settings; it can be the deprecated replicated_regsions attribute or multiple target_region blocks
+		if (len(b.config.SharedGalleryDestination.SigDestinationReplicationRegions) > 0) && (len(b.config.SharedGalleryDestination.SigDestinationTargetRegions) > 0) {
+			return nil, fmt.Errorf("`replicated_regions` can not be defined alongside `target_regions`; you can defined a target_region for each destination region you wish to replicate to.")
 		}
-		if foundMandatoryReplicationRegion == false {
-			b.config.SharedGalleryDestination.SigDestinationReplicationRegions = append(normalizedReplicationRegions, buildLocation)
-		}
+
 		// TODO It would be better if validation could be handled in a central location
 		// Currently we rely on the build Resource Group being queried if used to get the build location
 		// So we have to do this validation afterwards
 		// We should remove this logic builder and handle this logic via the `Step` pattern
 		if b.config.SharedGalleryDestination.SigDestinationUseShallowReplicationMode {
-			if len(b.config.SharedGalleryDestination.SigDestinationReplicationRegions) != 1 {
-				return nil, fmt.Errorf("when `use_shallow_replication` is enabled the value of `replicated_regions` must match the build region specified by `location` or match the region of `build_resource_group_name`.")
+			err := errors.New("when `use_shallow_replication` there can only be one destination region defined and it must match `location` or match the region of `build_resource_group_name`.")
+			switch {
+			case len(b.config.SharedGalleryDestination.SigDestinationTargetRegions) > 1:
+				return nil, err
+			case len(b.config.SharedGalleryDestination.SigDestinationReplicationRegions) > 1:
+				return nil, err
 			}
 		}
-		b.stateBag.Put(constants.ArmManagedImageSharedGalleryReplicationRegions, b.config.SharedGalleryDestination.SigDestinationReplicationRegions)
+
+		if len(b.config.SharedGalleryDestination.SigDestinationTargetRegions) > 0 {
+			normalizedRegions := make([]TargetRegion, 0, len(b.config.SharedGalleryDestination.SigDestinationTargetRegions))
+			for _, tr := range b.config.SharedGalleryDestination.SigDestinationTargetRegions {
+				tr.Name = normalizeAzureRegion(tr.Name)
+				normalizedRegions = append(normalizedRegions, tr)
+			}
+			b.config.SharedGalleryDestination.SigDestinationTargetRegions = normalizedRegions
+		}
+
+		// Convert deprecated replication_regions to []TargetRegion
+		if len(b.config.SharedGalleryDestination.SigDestinationReplicationRegions) > 0 {
+			var foundMandatoryReplicationRegion bool
+			buildLocation := normalizeAzureRegion(b.stateBag.Get(constants.ArmLocation).(string))
+			normalizedRegions := make([]TargetRegion, 0, len(b.config.SharedGalleryDestination.SigDestinationReplicationRegions))
+			for _, region := range b.config.SharedGalleryDestination.SigDestinationReplicationRegions {
+				region := normalizeAzureRegion(region)
+				if strings.EqualFold(region, buildLocation) {
+					// backwards compatibility DiskEncryptionSetId was set on the global config not on the target region.
+					// Users using target_region blocks are responsible for setting the DES within the block
+					normalizedRegions = append(normalizedRegions, TargetRegion{Name: region, DiskEncryptionSetId: b.config.DiskEncryptionSetId})
+					foundMandatoryReplicationRegion = true
+					continue
+				}
+				normalizedRegions = append(normalizedRegions, TargetRegion{Name: region})
+			}
+			// SIG requires that replication regions include the region in which the created image version resides
+			if foundMandatoryReplicationRegion == false {
+				normalizedRegions = append(normalizedRegions, TargetRegion{Name: buildLocation, DiskEncryptionSetId: b.config.DiskEncryptionSetId})
+			}
+			b.config.SharedGalleryDestination.SigDestinationTargetRegions = normalizedRegions
+		}
+
+		if len(b.config.SharedGalleryDestination.SigDestinationTargetRegions) == 0 {
+			return nil, errors.New("no target destination region specified for the Shared Image Gallery; use target_region to specify at least the primary destination region for storing the image version.")
+		}
+
+		b.stateBag.Put(constants.ArmSharedImageGalleryDestinationTargetRegions, b.config.SharedGalleryDestination.SigDestinationTargetRegions)
 	}
+
 	sourceImageSpecialized := false
 	if b.config.SharedGallery.GalleryName != "" {
 		client := azureClient.GalleryImagesClient

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -13,6 +13,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -1300,6 +1301,10 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 			if c.SharedGalleryImageVersionReplicaCount != 1 {
 				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("When using shallow replication the replica count can only be 1, leaving this value unset will default to 1"))
 			}
+		}
+		// Validate target region settings; it can be the deprecated replicated_regions attribute or multiple target_region blocks
+		if (len(c.SharedGalleryDestination.SigDestinationReplicationRegions) > 0) && (len(c.SharedGalleryDestination.SigDestinationTargetRegions) > 0) {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("`replicated_regions` can not be defined alongside `target_region`; you can defined a target_region for each destination region you wish to replicate to."))
 		}
 	}
 	if c.SharedGalleryTimeout == 0 {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -218,8 +218,16 @@ type Config struct {
 	//     gallery_name = "GalleryName"
 	//     image_name = "ImageName"
 	//     image_version = "1.0.0"
-	//     replication_regions = ["regionA", "regionB", "regionC"]
 	//     storage_account_type = "Standard_LRS"
+	//     target_region {
+	//       name = "regionA"
+	//     }
+	//     target_region {
+	//       name = "regionB"
+	//     }
+	//     target_region {
+	//       name = "regionC"
+	//     }
 	// }
 	// managed_image_name = "TargetImageName"
 	// managed_image_resource_group_name = "TargetResourceGroup"

--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -361,15 +361,16 @@ func (*FlatSharedImageGallery) HCL2Spec() map[string]hcldec.Spec {
 // FlatSharedImageGalleryDestination is an auto-generated flat version of SharedImageGalleryDestination.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatSharedImageGalleryDestination struct {
-	SigDestinationSubscription              *string  `mapstructure:"subscription" cty:"subscription" hcl:"subscription"`
-	SigDestinationResourceGroup             *string  `mapstructure:"resource_group" cty:"resource_group" hcl:"resource_group"`
-	SigDestinationGalleryName               *string  `mapstructure:"gallery_name" cty:"gallery_name" hcl:"gallery_name"`
-	SigDestinationImageName                 *string  `mapstructure:"image_name" cty:"image_name" hcl:"image_name"`
-	SigDestinationImageVersion              *string  `mapstructure:"image_version" cty:"image_version" hcl:"image_version"`
-	SigDestinationReplicationRegions        []string `mapstructure:"replication_regions" cty:"replication_regions" hcl:"replication_regions"`
-	SigDestinationStorageAccountType        *string  `mapstructure:"storage_account_type" cty:"storage_account_type" hcl:"storage_account_type"`
-	SigDestinationSpecialized               *bool    `mapstructure:"specialized" cty:"specialized" hcl:"specialized"`
-	SigDestinationUseShallowReplicationMode *bool    `mapstructure:"use_shallow_replication" required:"false" cty:"use_shallow_replication" hcl:"use_shallow_replication"`
+	SigDestinationSubscription              *string            `mapstructure:"subscription" cty:"subscription" hcl:"subscription"`
+	SigDestinationResourceGroup             *string            `mapstructure:"resource_group" cty:"resource_group" hcl:"resource_group"`
+	SigDestinationGalleryName               *string            `mapstructure:"gallery_name" cty:"gallery_name" hcl:"gallery_name"`
+	SigDestinationImageName                 *string            `mapstructure:"image_name" cty:"image_name" hcl:"image_name"`
+	SigDestinationImageVersion              *string            `mapstructure:"image_version" cty:"image_version" hcl:"image_version"`
+	SigDestinationReplicationRegions        []string           `mapstructure:"replication_regions" cty:"replication_regions" hcl:"replication_regions"`
+	SigDestinationTargetRegions             []FlatTargetRegion `mapstructure:"target_region" cty:"target_region" hcl:"target_region"`
+	SigDestinationStorageAccountType        *string            `mapstructure:"storage_account_type" cty:"storage_account_type" hcl:"storage_account_type"`
+	SigDestinationSpecialized               *bool              `mapstructure:"specialized" cty:"specialized" hcl:"specialized"`
+	SigDestinationUseShallowReplicationMode *bool              `mapstructure:"use_shallow_replication" required:"false" cty:"use_shallow_replication" hcl:"use_shallow_replication"`
 }
 
 // FlatMapstructure returns a new FlatSharedImageGalleryDestination.
@@ -390,6 +391,7 @@ func (*FlatSharedImageGalleryDestination) HCL2Spec() map[string]hcldec.Spec {
 		"image_name":              &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"image_version":           &hcldec.AttrSpec{Name: "image_version", Type: cty.String, Required: false},
 		"replication_regions":     &hcldec.AttrSpec{Name: "replication_regions", Type: cty.List(cty.String), Required: false},
+		"target_region":           &hcldec.BlockListSpec{TypeName: "target_region", Nested: hcldec.ObjectSpec((*FlatTargetRegion)(nil).HCL2Spec())},
 		"storage_account_type":    &hcldec.AttrSpec{Name: "storage_account_type", Type: cty.String, Required: false},
 		"specialized":             &hcldec.AttrSpec{Name: "specialized", Type: cty.Bool, Required: false},
 		"use_shallow_replication": &hcldec.AttrSpec{Name: "use_shallow_replication", Type: cty.Bool, Required: false},
@@ -418,6 +420,31 @@ func (*FlatSpot) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"eviction_policy": &hcldec.AttrSpec{Name: "eviction_policy", Type: cty.String, Required: false},
 		"max_price":       &hcldec.AttrSpec{Name: "max_price", Type: cty.Number, Required: false},
+	}
+	return s
+}
+
+// FlatTargetRegion is an auto-generated flat version of TargetRegion.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatTargetRegion struct {
+	Name                *string `mapstructure:"name" required:"true" cty:"name" hcl:"name"`
+	DiskEncryptionSetId *string `mapstructure:"disk_encryption_set_id" cty:"disk_encryption_set_id" hcl:"disk_encryption_set_id"`
+}
+
+// FlatMapstructure returns a new FlatTargetRegion.
+// FlatTargetRegion is an auto-generated flat version of TargetRegion.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*TargetRegion) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatTargetRegion)
+}
+
+// HCL2Spec returns the hcl spec of a TargetRegion.
+// This spec is used by HCL to read the fields of TargetRegion.
+// The decoded values from this spec will then be applied to a FlatTargetRegion.
+func (*FlatTargetRegion) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"name":                   &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
+		"disk_encryption_set_id": &hcldec.AttrSpec{Name: "disk_encryption_set_id", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -1362,6 +1362,116 @@ func TestConfigShouldAcceptShallowReplicationWithWithUnsetReplicaCount(t *testin
 		t.Fatalf("expected config to accept shallow replication with unset replica count build: %v", err)
 	}
 }
+
+func TestConfigValidateShallowReplicationRegion(t *testing.T) {
+	tt := []struct {
+		name          string
+		config        map[string]interface{}
+		errorExpected bool
+	}{
+		{
+			name: "with replication region",
+			config: map[string]interface{}{
+				"image_offer":     "ignore",
+				"image_publisher": "ignore",
+				"image_sku":       "ignore",
+				"location":        "ignore",
+				"subscription_id": "ignore",
+				"communicator":    "none",
+				"os_type":         constants.Target_Linux,
+				"shared_image_gallery_destination": map[string]interface{}{
+					"resource_group":          "ignore",
+					"gallery_name":            "ignore",
+					"image_name":              "ignore",
+					"image_version":           "1.0.1",
+					"replication_regions":     "ignore",
+					"use_shallow_replication": "true",
+				},
+			},
+		},
+		{
+			name: "with target region",
+			config: map[string]interface{}{
+				"image_offer":     "ignore",
+				"image_publisher": "ignore",
+				"image_sku":       "ignore",
+				"location":        "ignore",
+				"subscription_id": "ignore",
+				"communicator":    "none",
+				"os_type":         constants.Target_Linux,
+				"shared_image_gallery_destination": map[string]interface{}{
+					"resource_group": "ignore",
+					"gallery_name":   "ignore",
+					"image_name":     "ignore",
+					"image_version":  "1.0.1",
+					"target_region": map[string]interface{}{
+						"name": "ignore",
+					},
+					"use_shallow_replication": "true",
+				},
+			},
+		},
+		{
+			name:          "with multiple replication regions",
+			errorExpected: true,
+			config: map[string]interface{}{
+				"image_offer":     "ignore",
+				"image_publisher": "ignore",
+				"image_sku":       "ignore",
+				"location":        "ignore",
+				"subscription_id": "ignore",
+				"communicator":    "none",
+				"os_type":         constants.Target_Linux,
+				"shared_image_gallery_destination": map[string]interface{}{
+					"resource_group":          "ignore",
+					"gallery_name":            "ignore",
+					"image_name":              "ignore",
+					"image_version":           "1.0.1",
+					"replication_regions":     []string{"one", "two"},
+					"use_shallow_replication": "true",
+				},
+			},
+		},
+		{
+			name:          "with multiple target region",
+			errorExpected: true,
+			config: map[string]interface{}{
+				"image_offer":     "ignore",
+				"image_publisher": "ignore",
+				"image_sku":       "ignore",
+				"location":        "ignore",
+				"subscription_id": "ignore",
+				"communicator":    "none",
+				"os_type":         constants.Target_Linux,
+				"shared_image_gallery_destination": map[string]interface{}{
+					"resource_group": "ignore",
+					"gallery_name":   "ignore",
+					"image_name":     "ignore",
+					"image_version":  "1.0.1",
+					"target_region": map[string]interface{}{
+						"name":  "ignore",
+						"name2": "ignore",
+					},
+					"use_shallow_replication": "true",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			var c Config
+			_, err := c.Prepare(tc.config, getPackerConfiguration())
+			if !tc.errorExpected && err != nil {
+				t.Errorf("unexpected error returned when validating shallow replication regions: %s", err)
+			}
+			if tc.errorExpected && err == nil {
+				t.Errorf("expected an error but got none for %s", tc.name)
+			}
+		})
+	}
+}
+
 func TestConfigShouldRejectManagedImageOSDiskSnapshotNameAndManagedImageDataDiskSnapshotPrefixWithCaptureContainerName(t *testing.T) {
 	config := map[string]interface{}{
 		"image_offer":                         "ignore",

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -2883,3 +2883,34 @@ func TestConfigSpotEmptyEvictionPolicyMaxPriceSet(t *testing.T) {
 		t.Fatal("expected config to not accept spot settings", err)
 	}
 }
+
+func TestConfigShouldRejectSharedImageGalleryDestinationReplicationRegions(t *testing.T) {
+	config := map[string]interface{}{
+		"location":        "ignore",
+		"subscription_id": "ignore",
+		"os_type":         "linux",
+		"image_sku":       "ignore",
+		"image_offer":     "ignore",
+		"image_publisher": "ignore",
+		"shared_image_gallery_destination": map[string]interface{}{
+			"resource_group":      "ignore",
+			"gallery_name":        "ignore",
+			"image_name":          "ignore",
+			"image_version":       "1.0.1",
+			"replication_regions": "ignore",
+			"target_region": map[string]string{
+				"name": "useast",
+			},
+		},
+	}
+
+	var c Config
+	_, err := c.Prepare(config, getPackerConfiguration())
+	if err == nil {
+		t.Fatal("expected config to reject invalid shared image gallery destination the defines both replication_regions and target_region block", err)
+	}
+	errorMessage := "`replicated_regions` can not be defined alongside `target_region`; you can defined a target_region for each destination region you wish to replicate to."
+	if !strings.Contains(err.Error(), errorMessage) {
+		t.Errorf("expected config to reject with error containing %s but got %s", errorMessage, err)
+	}
+}

--- a/builder/azure/common/constants/stateBag.go
+++ b/builder/azure/common/constants/stateBag.go
@@ -57,6 +57,7 @@ const (
 	ArmSharedImageGalleryDestinationSubscription               string = "arm.ArmSharedImageGalleryDestinationSubscription"
 	ArmSharedImageGalleryDestinationSpecialized                string = "arm.ArmSharedImageGalleryDestinationSpecialized"
 	ArmSharedImageGalleryDestinationShallowReplication         string = "arm.ArmSharedImageGalleryDestinationShallowReplication"
+	ArmSharedImageGalleryDestinationTargetRegions              string = "arm.SharedImageGalleryTargetRegions"
 	ArmManagedImageSubscription                                string = "arm.ArmManagedImageSubscription"
 	ArmAsyncResourceGroupDelete                                string = "arm.AsyncResourceGroupDelete"
 	ArmManagedImageOSDiskSnapshotName                          string = "arm.ManagedImageOSDiskSnapshotName"

--- a/docs-partials/builder/azure/arm/Config-not-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-not-required.mdx
@@ -68,8 +68,16 @@
       gallery_name = "GalleryName"
       image_name = "ImageName"
       image_version = "1.0.0"
-      replication_regions = ["regionA", "regionB", "regionC"]
       storage_account_type = "Standard_LRS"
+      target_region {
+        name = "regionA"
+      }
+      target_region {
+        name = "regionB"
+      }
+      target_region {
+        name = "regionC"
+      }
   }
   managed_image_name = "TargetImageName"
   managed_image_resource_group_name = "TargetResourceGroup"

--- a/docs-partials/builder/azure/arm/SharedImageGalleryDestination-not-required.mdx
+++ b/docs-partials/builder/azure/arm/SharedImageGalleryDestination-not-required.mdx
@@ -13,6 +13,12 @@
 - `replication_regions` ([]string) - A list of regions to replicate the image version in, by default the build location will be used as a replication region (the build location is either set in the location field, or the location of the resource group used in `build_resource_group_name` will be included.
   Can not contain any region but the build region when using shallow replication
 
+- `target_region` ([]TargetRegion) - A target region to store the image version in. The attribute supersedes `replication_regions` which is now considered deprecated.
+  One or more target_region blocks can be specified for storing an imager version to various regions. In addition to specifying a region,
+  a DiskEncryptionSetId can be specified for each target region to support multi-region disk encryption.
+  At a minimum their must be one target region entry for the primary build region where the image version will be stored.
+  Target region must only contain one entry matching the build region when using shallow replication.
+
 - `storage_account_type` (string) - Specify a storage account type for the Shared Image Gallery Image Version.
   Defaults to `Standard_LRS`. Accepted values are `Standard_LRS`, `Standard_ZRS` and `Premium_LRS`
 

--- a/docs-partials/builder/azure/arm/TargetRegion-not-required.mdx
+++ b/docs-partials/builder/azure/arm/TargetRegion-not-required.mdx
@@ -1,0 +1,7 @@
+<!-- Code generated from the comments of the TargetRegion struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
+
+- `disk_encryption_set_id` (string) - DiskEncryptionSetId for Disk Encryption Set in Region. Needed for supporting
+  the replication of encrypted disks across regions. CMKs must
+  already exist within the target regions.
+
+<!-- End of code generated from the comments of the TargetRegion struct in builder/azure/arm/config.go; -->

--- a/docs-partials/builder/azure/arm/TargetRegion-required.mdx
+++ b/docs-partials/builder/azure/arm/TargetRegion-required.mdx
@@ -1,0 +1,5 @@
+<!-- Code generated from the comments of the TargetRegion struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
+
+- `name` (string) - Name of the Azure region
+
+<!-- End of code generated from the comments of the TargetRegion struct in builder/azure/arm/config.go; -->

--- a/docs-partials/builder/azure/arm/TargetRegion.mdx
+++ b/docs-partials/builder/azure/arm/TargetRegion.mdx
@@ -1,0 +1,5 @@
+<!-- Code generated from the comments of the TargetRegion struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
+
+TargetRegion describes a destination region for storing the image version of a Shard Image Gallery.
+
+<!-- End of code generated from the comments of the TargetRegion struct in builder/azure/arm/config.go; -->


### PR DESCRIPTION
    Add support for target_region block in SharedImageGalleryDestination

As an alternative to specifying replication_regions for a Shared Image
Gallery Destination, users can not use one or more `target_region` block
attributes to define the target regions for a shared image version. The
target_region block attribute supports the setting of individual disk
encryption key id for multi-region replication of encrypted
disks using CMKs.

The `target_region` attribute is meant to replace the now deprecated
`replication_regions` attribute. Internally, any values set for
replication_regions will be transferred into a set of target_region
blocks to provide the same level of functionality. The one difference being that
Packer will no longer add a default entry for the SIG build location
when using target_region blocks.

Closes: https://github.com/hashicorp/packer-plugin-azure/issues/264


#### Example Config
```hcl
variable "resource_group" {
  type    = string
  default = "${env("ARM_RESOURCE_GROUP)}"
}

source "azure-arm" "autogenerated_1" {
  use_azure_cli_auth                = true
  image_offer                       = "UbuntuServer"
  image_publisher                   = "Canonical"
  image_sku                         = "16.04-LTS"
  location                          = "East US"
  os_type                           = "Linux"
  vm_size         = "Standard_DS2_v2"
  shared_image_gallery_destination {
    gallery_name        = "PackerSigGallery"
    image_name          = "PackerSigImageDefinition"
    image_version       = "1.0.1"
    resource_group      = var.resource_group
    target_region {
        name = "West US 2"
        disk_encryption_set_id = "KEY"
    }
    target_region {
        name = "East US"
        disk_encryption_set_id = "KEY"
    }
  }
}

build {
  sources = ["source.azure-arm.autogenerated_1"]

  provisioner "shell" {
    execute_command = "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'"
    inline          = ["apt-get update", "apt-get upgrade -y", "/usr/sbin/waagent -force -deprovision+user && export HISTSIZE=0 && sync"]
    inline_shebang  = "/bin/sh -x"
  }

}
```
