### PR TITLE
Fix regression in replicated_regions attribute

### DIFF
--- a/builder/azure/arm/step_publish_to_shared_image_gallery.go
+++ b/builder/azure/arm/step_publish_to_shared_image_gallery.go
@@ -101,11 +101,13 @@ func buildAzureImageTargetRegions(regions []TargetRegion) []galleryimageversions
 		name := r.Name
 		tr := galleryimageversions.TargetRegion{Name: name}
 
-		id := r.DiskEncryptionSetId
-		tr.Encryption = &galleryimageversions.EncryptionImages{
-			OsDiskImage: &galleryimageversions.OSDiskImageEncryption{
-				DiskEncryptionSetId: &id,
-			},
+		if r.DiskEncryptionSetId != "" {
+			id := r.DiskEncryptionSetId
+			tr.Encryption = &galleryimageversions.EncryptionImages{
+				OsDiskImage: &galleryimageversions.OSDiskImageEncryption{
+					DiskEncryptionSetId: &id,
+				},
+			}
 		}
 		targetRegions = append(targetRegions, tr)
 	}

--- a/builder/azure/arm/step_publish_to_shared_image_gallery_test.go
+++ b/builder/azure/arm/step_publish_to_shared_image_gallery_test.go
@@ -310,6 +310,10 @@ func TestPublishToSharedImageGalleryBuildAzureImageTargetRegions(t *testing.T) {
 				t.Errorf("expected configured region to contain same name as input %q but got %q", inputRegion.Name, tr.Name)
 			}
 
+			if (inputRegion.DiskEncryptionSetId == "") && (tr.Encryption != nil) {
+				t.Errorf("[%q]: expected configured region with no DES id to not contain encryption %q but got %v", tc.name, inputRegion.DiskEncryptionSetId, *tr.Encryption)
+			}
+
 			if (inputRegion.DiskEncryptionSetId != "") && (*tr.Encryption.OsDiskImage.DiskEncryptionSetId != inputRegion.DiskEncryptionSetId) {
 				t.Errorf("[%q]: expected configured region to contain set DES Id %q but got %q", tc.name, inputRegion.DiskEncryptionSetId, *tr.Encryption.OsDiskImage.DiskEncryptionSetId)
 			}


### PR DESCRIPTION
When implementing the target_region attribute for the Shared Image
Gallery Destination a regression introduced with replication_regions, where an empty Disk
encryption key was being sent along with the request. Ultimately
causing the image capture to fail with an invalid DES key error.

Related to: #264 
