### PR TITLE
Add default build location when no target region is set

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -248,7 +248,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		}
 
 		if len(b.config.SharedGalleryDestination.SigDestinationTargetRegions) == 0 {
-			return nil, errors.New("no target destination region specified for the Shared Image Gallery; use target_region to specify at least the primary destination region for storing the image version.")
+			buildLocation := normalizeAzureRegion(b.stateBag.Get(constants.ArmLocation).(string))
+			b.config.SharedGalleryDestination.SigDestinationTargetRegions = []TargetRegion{{Name: buildLocation, DiskEncryptionSetId: b.config.DiskEncryptionSetId}}
+			ui.Say(fmt.Sprintf("WARNING! No target region was set for the Shared Image Gallery. Adding %q as the primary target region for now but this may change in the future.", buildLocation))
 		}
 
 		b.stateBag.Put(constants.ArmSharedImageGalleryDestinationTargetRegions, b.config.SharedGalleryDestination.SigDestinationTargetRegions)

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -250,7 +250,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		if len(b.config.SharedGalleryDestination.SigDestinationTargetRegions) == 0 {
 			buildLocation := normalizeAzureRegion(b.stateBag.Get(constants.ArmLocation).(string))
 			b.config.SharedGalleryDestination.SigDestinationTargetRegions = []TargetRegion{{Name: buildLocation, DiskEncryptionSetId: b.config.DiskEncryptionSetId}}
-			ui.Say(fmt.Sprintf("WARNING! No target region was set for the Shared Image Gallery. Adding %q as the primary target region for now but this may change in the future.", buildLocation))
 		}
 
 		b.stateBag.Put(constants.ArmSharedImageGalleryDestinationTargetRegions, b.config.SharedGalleryDestination.SigDestinationTargetRegions)


### PR DESCRIPTION
Previously users were able to build to a Shared Image Gallery without
specifying a primary target region, as it would default to the build
location. This functionality was removed for the `target_region` block
attribute in hopes that users would be more explicit on which regions to
publish to. However, not having a primary target region breaks the
existing behavior for publishing with no region set.

To avoid further breaking changes support for automatically adding a
default target region is being added back but with a WARNING indicating
that the behavior will change in a future release.
