### PR TITLE
Add ability to set individual replica count per region

### DIFF
--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -235,9 +235,8 @@ Providing `temp_resource_group_name` or `location` in combination with
 - `shared_gallery_image_version_end_of_life_date` (string) - The end of life date (2006-01-02T15:04:05.99Z) of the gallery Image Version. This property
   can be used for decommissioning purposes.
 
-- `shared_image_gallery_replica_count` (int64) - The number of replicas of the Image Version to be created per region.
-  Replica count must be between 1 and 100, but 50 replicas should be sufficient for most use cases.
-  When using shallow replication `use_shallow_replication=true` the value can only be 1.
+- `shared_image_gallery_replica_count` (int64) - The number of replicas of the Image Version to be created per region defined in `replication_regions`.
+  Users using `target_region` blocks can specify individual replica counts per region.
 
 - `shared_gallery_image_version_exclude_from_latest` (bool) - If set to true, Virtual Machines deployed from the latest version of the
   Image Definition won't use this Image Version.

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -226,11 +226,18 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			}
 		}
 
+		buildLocation := normalizeAzureRegion(b.stateBag.Get(constants.ArmLocation).(string))
 		if len(b.config.SharedGalleryDestination.SigDestinationTargetRegions) > 0 {
 			normalizedRegions := make([]TargetRegion, 0, len(b.config.SharedGalleryDestination.SigDestinationTargetRegions))
 			for _, tr := range b.config.SharedGalleryDestination.SigDestinationTargetRegions {
 				tr.Name = normalizeAzureRegion(tr.Name)
 				normalizedRegions = append(normalizedRegions, tr)
+				if strings.EqualFold(tr.Name, buildLocation) && tr.ReplicaCount != 0 {
+					// By default the global replica count takes precedence so lets update it to use
+					// the define replica count from the target_region config for the build target_region.
+					b.config.SharedGalleryImageVersionReplicaCount = tr.ReplicaCount
+					b.stateBag.Put(constants.ArmManagedImageSharedGalleryImageVersionReplicaCount, tr.ReplicaCount)
+				}
 			}
 			b.config.SharedGalleryDestination.SigDestinationTargetRegions = normalizedRegions
 		}
@@ -238,7 +245,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		// Convert deprecated replication_regions to []TargetRegion
 		if len(b.config.SharedGalleryDestination.SigDestinationReplicationRegions) > 0 {
 			var foundMandatoryReplicationRegion bool
-			buildLocation := normalizeAzureRegion(b.stateBag.Get(constants.ArmLocation).(string))
 			normalizedRegions := make([]TargetRegion, 0, len(b.config.SharedGalleryDestination.SigDestinationReplicationRegions))
 			for _, region := range b.config.SharedGalleryDestination.SigDestinationReplicationRegions {
 				region := normalizeAzureRegion(region)
@@ -264,9 +270,17 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 		if len(b.config.SharedGalleryDestination.SigDestinationTargetRegions) == 0 {
 			buildLocation := normalizeAzureRegion(b.stateBag.Get(constants.ArmLocation).(string))
-			b.config.SharedGalleryDestination.SigDestinationTargetRegions = []TargetRegion{{Name: buildLocation, DiskEncryptionSetId: b.config.DiskEncryptionSetId}}
+			b.config.SharedGalleryDestination.SigDestinationTargetRegions = []TargetRegion{
+				{
+					Name:                buildLocation,
+					DiskEncryptionSetId: b.config.DiskEncryptionSetId,
+					//Default region replica count is set at the Gallery Level
+					ReplicaCount: b.config.SharedGalleryImageVersionReplicaCount,
+				},
+			}
 		}
 
+		b.stateBag.Put(constants.ArmManagedImageSharedGalleryImageVersionReplicaCount, b.config.SharedGalleryImageVersionReplicaCount)
 		b.stateBag.Put(constants.ArmSharedImageGalleryDestinationTargetRegions, b.config.SharedGalleryDestination.SigDestinationTargetRegions)
 	}
 

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -249,11 +249,15 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 					foundMandatoryReplicationRegion = true
 					continue
 				}
-				normalizedRegions = append(normalizedRegions, TargetRegion{Name: region})
+				normalizedRegions = append(normalizedRegions, TargetRegion{Name: region, ReplicaCount: b.config.SharedGalleryImageVersionReplicaCount})
 			}
 			// SIG requires that replication regions include the region in which the created image version resides
 			if foundMandatoryReplicationRegion == false {
-				normalizedRegions = append(normalizedRegions, TargetRegion{Name: buildLocation, DiskEncryptionSetId: b.config.DiskEncryptionSetId})
+				normalizedRegions = append(normalizedRegions, TargetRegion{
+					Name:                buildLocation,
+					DiskEncryptionSetId: b.config.DiskEncryptionSetId,
+					ReplicaCount:        b.config.SharedGalleryImageVersionReplicaCount,
+				})
 			}
 			b.config.SharedGalleryDestination.SigDestinationTargetRegions = normalizedRegions
 		}

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -146,6 +146,8 @@ type TargetRegion struct {
 	// the replication of encrypted disks across regions. CMKs must
 	// already exist within the target regions.
 	DiskEncryptionSetId string `mapstructure:"disk_encryption_set_id"`
+	// Number of replicas in this region. Default: 1
+	ReplicaCount int64 `mapstructure:"replicas"`
 }
 
 type Spot struct {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -146,7 +146,9 @@ type TargetRegion struct {
 	// the replication of encrypted disks across regions. CMKs must
 	// already exist within the target regions.
 	DiskEncryptionSetId string `mapstructure:"disk_encryption_set_id"`
-	// Number of replicas in this region. Default: 1
+	// The number of replicas of the Image Version to be created within the region. Defaults to 1.
+	// Replica count must be between 1 and 100, but 50 replicas should be sufficient for most use cases.
+	// When using shallow replication `use_shallow_replication=true` the value can only be 1 for the primary build region.
 	ReplicaCount int64 `mapstructure:"replicas"`
 }
 
@@ -260,9 +262,8 @@ type Config struct {
 	// The end of life date (2006-01-02T15:04:05.99Z) of the gallery Image Version. This property
 	// can be used for decommissioning purposes.
 	SharedGalleryImageVersionEndOfLifeDate string `mapstructure:"shared_gallery_image_version_end_of_life_date" required:"false"`
-	// The number of replicas of the Image Version to be created per region.
-	// Replica count must be between 1 and 100, but 50 replicas should be sufficient for most use cases.
-	// When using shallow replication `use_shallow_replication=true` the value can only be 1.
+	// The number of replicas of the Image Version to be created per region defined in `replication_regions`.
+	// Users using `target_region` blocks can specify individual replica counts per region.
 	SharedGalleryImageVersionReplicaCount int64 `mapstructure:"shared_image_gallery_replica_count" required:"false"`
 	// If set to true, Virtual Machines deployed from the latest version of the
 	// Image Definition won't use this Image Version.
@@ -1336,7 +1337,11 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 		}
 		// Validate target region settings; it can be the deprecated replicated_regions attribute or multiple target_region blocks
 		if (len(c.SharedGalleryDestination.SigDestinationReplicationRegions) > 0) && (len(c.SharedGalleryDestination.SigDestinationTargetRegions) > 0) {
-			errs = packersdk.MultiErrorAppend(errs, errors.New("`replicated_regions` can not be defined alongside `target_region`; you can defined a target_region for each destination region you wish to replicate to."))
+			errs = packersdk.MultiErrorAppend(errs, errors.New("`replicated_regions` can not be defined alongside `target_region`; you can define a target_region for each destination region you wish to replicate to."))
+		}
+
+		if (len(c.SharedGalleryDestination.SigDestinationTargetRegions) > 0) && c.SharedGalleryImageVersionReplicaCount != 0 {
+			errs = packersdk.MultiErrorAppend(errs, errors.New("`shared_image_gallery_replica_count` can not be defined alongside `target_region`; you can specify the number of replicas per region within a single target_region block."))
 		}
 
 		if c.SharedGalleryDestination.SigDestinationUseShallowReplicationMode {
@@ -1344,14 +1349,9 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 				errs = packersdk.MultiErrorAppend(errs, err)
 			}
 
-			if c.SharedGalleryImageVersionReplicaCount == 0 {
-				c.SharedGalleryImageVersionReplicaCount = 1
-			}
-
-			if c.SharedGalleryImageVersionReplicaCount != 1 {
+			if c.SharedGalleryImageVersionReplicaCount > 1 {
 				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("When using shallow replication the replica count can only be 1, leaving this value unset will default to 1"))
 			}
-
 		}
 
 		if c.SharedGalleryDestination.SigDestinationConfidentialVMImageEncryptionType != "" {

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1341,7 +1341,7 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 		}
 
 		if (len(c.SharedGalleryDestination.SigDestinationTargetRegions) > 0) && c.SharedGalleryImageVersionReplicaCount != 0 {
-			errs = packersdk.MultiErrorAppend(errs, errors.New("`shared_image_gallery_replica_count` can not be defined alongside `target_region`; you can specify the number of replicas per region within a single target_region block."))
+			errs = packersdk.MultiErrorAppend(errs, errors.New("`shared_image_gallery_replica_count` can not be defined alongside `target_region`; you can specify the number of replicas per region within target_region blocks."))
 		}
 
 		if c.SharedGalleryDestination.SigDestinationUseShallowReplicationMode {

--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -435,6 +435,7 @@ func (*FlatSpot) HCL2Spec() map[string]hcldec.Spec {
 type FlatTargetRegion struct {
 	Name                *string `mapstructure:"name" required:"true" cty:"name" hcl:"name"`
 	DiskEncryptionSetId *string `mapstructure:"disk_encryption_set_id" cty:"disk_encryption_set_id" hcl:"disk_encryption_set_id"`
+	ReplicaCount        *int64  `mapstructure:"replicas" cty:"replicas" hcl:"replicas"`
 }
 
 // FlatMapstructure returns a new FlatTargetRegion.
@@ -451,6 +452,7 @@ func (*FlatTargetRegion) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"name":                   &hcldec.AttrSpec{Name: "name", Type: cty.String, Required: false},
 		"disk_encryption_set_id": &hcldec.AttrSpec{Name: "disk_encryption_set_id", Type: cty.String, Required: false},
+		"replicas":               &hcldec.AttrSpec{Name: "replicas", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -1363,6 +1363,36 @@ func TestConfigShouldAcceptShallowReplicationWithWithUnsetReplicaCount(t *testin
 	}
 }
 
+func TestConfigShouldRejectSigVersionReplicaWithTargetRegion(t *testing.T) {
+	config := map[string]interface{}{
+		"image_offer":                        "ignore",
+		"image_publisher":                    "ignore",
+		"image_sku":                          "ignore",
+		"location":                           "ignore",
+		"subscription_id":                    "ignore",
+		"communicator":                       "none",
+		"shared_image_gallery_replica_count": "2",
+		"os_type":                            constants.Target_Linux,
+		"shared_image_gallery_destination": map[string]interface{}{
+			"resource_group": "ignore",
+			"gallery_name":   "ignore",
+			"image_name":     "ignore",
+			"image_version":  "1.0.1",
+			"target_region": map[string]interface{}{
+				"name": "ignore",
+			},
+		},
+	}
+	var c Config
+	expectedErrorMessage := "`shared_image_gallery_replica_count` can not be defined alongside `target_region`; you can specify the number of replicas per region within a single target_region block"
+	_, err := c.Prepare(config, getPackerConfiguration())
+	if err == nil {
+		t.Fatal("expected config to reject target_region block with shared_image_gallery_replica_count set")
+	} else if !strings.Contains(err.Error(), expectedErrorMessage) {
+		t.Fatalf("unexpected rejection reason, expected %s to contain %s", err.Error(), expectedErrorMessage)
+	}
+}
+
 func TestConfigValidateShallowReplicationRegion(t *testing.T) {
 	tt := []struct {
 		name          string

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -1384,7 +1384,7 @@ func TestConfigShouldRejectSigVersionReplicaWithTargetRegion(t *testing.T) {
 		},
 	}
 	var c Config
-	expectedErrorMessage := "`shared_image_gallery_replica_count` can not be defined alongside `target_region`; you can specify the number of replicas per region within a single target_region block"
+	expectedErrorMessage := "`shared_image_gallery_replica_count` can not be defined alongside `target_region`; you can specify the number of replicas per region within target_region blocks"
 	_, err := c.Prepare(config, getPackerConfiguration())
 	if err == nil {
 		t.Fatal("expected config to reject target_region block with shared_image_gallery_replica_count set")

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -3019,7 +3019,7 @@ func TestConfigShouldRejectSharedImageGalleryDestinationReplicationRegions(t *te
 	if err == nil {
 		t.Fatal("expected config to reject invalid shared image gallery destination the defines both replication_regions and target_region block", err)
 	}
-	errorMessage := "`replicated_regions` can not be defined alongside `target_region`; you can defined a target_region for each destination region you wish to replicate to."
+	errorMessage := "`replicated_regions` can not be defined alongside `target_region`; you can define a target_region for each destination region you wish to replicate to."
 	if !strings.Contains(err.Error(), errorMessage) {
 		t.Errorf("expected config to reject with error containing %s but got %s", errorMessage, err)
 	}

--- a/builder/azure/arm/step_publish_to_shared_image_gallery.go
+++ b/builder/azure/arm/step_publish_to_shared_image_gallery.go
@@ -247,7 +247,13 @@ func (s *StepPublishToSharedImageGallery) Run(ctx context.Context, stateBag mult
 
 	miSGImageVersionEndOfLifeDate, _ := stateBag.Get(constants.ArmManagedImageSharedGalleryImageVersionEndOfLifeDate).(string)
 	miSGImageVersionExcludeFromLatest, _ := stateBag.Get(constants.ArmManagedImageSharedGalleryImageVersionExcludeFromLatest).(bool)
-
+	miSigReplicaCount, _ := stateBag.Get(constants.ArmManagedImageSharedGalleryImageVersionReplicaCount).(int64)
+	// Replica count must be between 1 and 100 inclusive
+	if miSigReplicaCount <= 0 {
+		miSigReplicaCount = constants.SharedImageGalleryImageVersionDefaultMinReplicaCount
+	} else if miSigReplicaCount > constants.SharedImageGalleryImageVersionDefaultMaxReplicaCount {
+		miSigReplicaCount = constants.SharedImageGalleryImageVersionDefaultMaxReplicaCount
+	}
 	regionNames := make([]string, 0, len(sharedImageGallery.SigDestinationTargetRegions))
 	desIds := make([]string, 0, len(sharedImageGallery.SigDestinationTargetRegions))
 	for _, r := range sharedImageGallery.SigDestinationTargetRegions {
@@ -256,7 +262,6 @@ func (s *StepPublishToSharedImageGallery) Run(ctx context.Context, stateBag mult
 			desIds = append(desIds, r.DiskEncryptionSetId)
 		}
 	}
-
 	s.say(fmt.Sprintf(" -> Source ID used for SIG publish        : '%s'", sourceID))
 	s.say(fmt.Sprintf(" -> SIG publish resource group            : '%s'", sharedImageGallery.SigDestinationResourceGroup))
 	s.say(fmt.Sprintf(" -> SIG gallery name                      : '%s'", sharedImageGallery.SigDestinationGalleryName))

--- a/builder/azure/arm/step_publish_to_shared_image_gallery.go
+++ b/builder/azure/arm/step_publish_to_shared_image_gallery.go
@@ -297,6 +297,7 @@ func (s *StepPublishToSharedImageGallery) Run(ctx context.Context, stateBag mult
 			Location:           location,
 			ReplicationMode:    replicationMode,
 			Tags:               tags,
+			ReplicaCount:       miSigReplicaCount,
 		},
 	)
 

--- a/builder/azure/arm/step_publish_to_shared_image_gallery.go
+++ b/builder/azure/arm/step_publish_to_shared_image_gallery.go
@@ -109,6 +109,11 @@ func buildAzureImageTargetRegions(sig SharedImageGalleryDestination) []galleryim
 
 		encryption := buildAzureImageTargetRegionsWithEncryption(r.DiskEncryptionSetId, sig.SigDestinationConfidentialVMImageEncryptionType)
 		tr.Encryption = encryption
+		replicas := r.ReplicaCount
+		if replicas <= 0 {
+			replicas = 1
+		}
+		tr.RegionalReplicaCount = &replicas
 		targetRegions = append(targetRegions, tr)
 	}
 	return targetRegions

--- a/builder/azure/arm/step_publish_to_shared_image_gallery_test.go
+++ b/builder/azure/arm/step_publish_to_shared_image_gallery_test.go
@@ -287,6 +287,7 @@ func TestPublishToSharedImageGalleryBuildAzureImageTargetRegions(t *testing.T) {
 		{name: "empty regions non nil", in: SIG{SigDestinationTargetRegions: make([]TargetRegion, 0)}, expectedRegions: 0},
 		{name: "one named region", in: SIG{SigDestinationTargetRegions: []TargetRegion{{Name: "unit-test-location"}}}, expectedRegions: 1},
 		{name: "two named region", in: SIG{SigDestinationTargetRegions: []TargetRegion{{Name: "unit-test-location"}, {Name: "unit-test-location-2"}}}, expectedRegions: 2},
+		{name: "two named regions with replica counts", in: SIG{SigDestinationTargetRegions: []TargetRegion{{Name: "unit-test-location", ReplicaCount: 1}, {Name: "unit-test-location-2", ReplicaCount: 2}}}, expectedRegions: 2},
 		{
 			name:            "named region with encryption",
 			in:              SIG{SigDestinationTargetRegions: []TargetRegion{{Name: "unit-test-location", DiskEncryptionSetId: "boguskey"}}},
@@ -370,6 +371,15 @@ func TestPublishToSharedImageGalleryBuildAzureImageTargetRegions(t *testing.T) {
 					t.Errorf("[%q]: expected configured region to contain set DES Id %q but got %q", tc.name, inputRegion.DiskEncryptionSetId, *tr.Encryption.OsDiskImage.DiskEncryptionSetId)
 				}
 			}
+
+			if (inputRegion.ReplicaCount != 0) && (*tr.RegionalReplicaCount != inputRegion.ReplicaCount) {
+				t.Errorf("[%q]: expected configured region to contain replica count of %d but got %d", tc.name, inputRegion.ReplicaCount, *tr.RegionalReplicaCount)
+			}
+			// default replica count
+			if (inputRegion.ReplicaCount == 0) && (*tr.RegionalReplicaCount != 1) {
+				t.Errorf("[%q]: expected configured region to with no replica count to default to 1 but got %d", tc.name, *tr.RegionalReplicaCount)
+			}
+
 		}
 	}
 

--- a/docs-partials/builder/azure/arm/Config-not-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-not-required.mdx
@@ -94,9 +94,8 @@
 - `shared_gallery_image_version_end_of_life_date` (string) - The end of life date (2006-01-02T15:04:05.99Z) of the gallery Image Version. This property
   can be used for decommissioning purposes.
 
-- `shared_image_gallery_replica_count` (int64) - The number of replicas of the Image Version to be created per region.
-  Replica count must be between 1 and 100, but 50 replicas should be sufficient for most use cases.
-  When using shallow replication `use_shallow_replication=true` the value can only be 1.
+- `shared_image_gallery_replica_count` (int64) - The number of replicas of the Image Version to be created per region defined in `replication_regions`.
+  Users using `target_region` blocks can specify individual replica counts per region.
 
 - `shared_gallery_image_version_exclude_from_latest` (bool) - If set to true, Virtual Machines deployed from the latest version of the
   Image Definition won't use this Image Version.

--- a/docs-partials/builder/azure/arm/TargetRegion-not-required.mdx
+++ b/docs-partials/builder/azure/arm/TargetRegion-not-required.mdx
@@ -4,6 +4,8 @@
   the replication of encrypted disks across regions. CMKs must
   already exist within the target regions.
 
-- `replicas` (int64) - Number of replicas in this region. Default: 1
+- `replicas` (int64) - The number of replicas of the Image Version to be created within the region. Defaults to 1.
+  Replica count must be between 1 and 100, but 50 replicas should be sufficient for most use cases.
+  When using shallow replication `use_shallow_replication=true` the value can only be 1 for the primary build region.
 
 <!-- End of code generated from the comments of the TargetRegion struct in builder/azure/arm/config.go; -->

--- a/docs-partials/builder/azure/arm/TargetRegion-not-required.mdx
+++ b/docs-partials/builder/azure/arm/TargetRegion-not-required.mdx
@@ -4,4 +4,6 @@
   the replication of encrypted disks across regions. CMKs must
   already exist within the target regions.
 
+- `replicas` (int64) - Number of replicas in this region. Default: 1
+
 <!-- End of code generated from the comments of the TargetRegion struct in builder/azure/arm/config.go; -->


### PR DESCRIPTION
This changes allows a user to set different replica counts for each
target region defined with a shared_image_gallery_destination block.

Closes: https://github.com/hashicorp/packer-plugin-azure/issues/386
