### PR TITLE
Fix v2.1.0 regression when using `custom_managed_image_name` source 

### DIFF
--- a/builder/azure/arm/resource_resolver.go
+++ b/builder/azure/arm/resource_resolver.go
@@ -76,8 +76,10 @@ func getResourceGroupNameFromId(id string) string {
 }
 
 func findManagedImageByName(client *AzureClient, name, subscriptionId, resourceGroupName string) (*images.Image, error) {
+	managedImageContext, cancel := context.WithTimeout(context.TODO(), client.PollingDuration)
+	defer cancel()
 	id := commonids.NewResourceGroupID(subscriptionId, resourceGroupName)
-	images, err := client.ImagesClient.ListByResourceGroupComplete(context.TODO(), id)
+	images, err := client.ImagesClient.ListByResourceGroupComplete(managedImageContext, id)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/azure/chroot/step_attach_disk.go
+++ b/builder/azure/chroot/step_attach_disk.go
@@ -78,7 +78,9 @@ func (s *StepAttachDisk) CleanupFunc(state multistep.StateBag) error {
 		ui.Say(fmt.Sprintf("Detaching disk '%s'", diskResourceID))
 
 		da := NewDiskAttacher(azcli, ui)
-		err := da.DetachDisk(context.Background(), diskResourceID)
+		detatchDisk, detatchDiskCancel := context.WithTimeout(context.Background(), azcli.PollingDuration())
+		defer detatchDiskCancel()
+		err := da.DetachDisk(detatchDisk, diskResourceID)
 		if err != nil {
 			return fmt.Errorf("error detaching %q: %v", diskResourceID, err)
 		}

--- a/builder/azure/common/artifact.go
+++ b/builder/azure/common/artifact.go
@@ -80,13 +80,12 @@ func (a *Artifact) Destroy() error {
 			return fmt.Errorf("Unable to parse resource id (%s): %v", resource, err)
 		}
 
-		ctx := context.TODO()
 		restype := strings.ToLower(fmt.Sprintf("%s/%s", id.Provider, id.ResourceType))
 
 		switch restype {
 		case "microsoft.compute/images":
 			imageID := images.NewImageID(a.AzureClientSet.SubscriptionID(), id.ResourceGroup, id.ResourceName.String())
-			pollingContext, cancel := context.WithTimeout(ctx, a.AzureClientSet.PollingDuration())
+			pollingContext, cancel := context.WithTimeout(context.Background(), a.AzureClientSet.PollingDuration())
 			defer cancel()
 			err := a.AzureClientSet.ImagesClient().DeleteThenPoll(pollingContext, imageID)
 			if err != nil {

--- a/builder/azure/common/client/azure_client_set.go
+++ b/builder/azure/common/client/azure_client_set.go
@@ -78,7 +78,9 @@ func new(c Config, say func(string)) (*azureClientSet, error) {
 	}
 	cloudEnv := c.cloudEnvironment
 	resourceManagerEndpoint, _ := cloudEnv.ResourceManager.Endpoint()
-	authorizer, err := BuildResourceManagerAuthorizer(context.TODO(), authOptions, *cloudEnv)
+	authorizerContext, cancel := context.WithTimeout(context.Background(), time.Minute*15)
+	defer cancel()
+	authorizer, err := BuildResourceManagerAuthorizer(authorizerContext, authOptions, *cloudEnv)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/azure/common/client/config.go
+++ b/builder/azure/common/client/config.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/cli"
 	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/log"
@@ -122,7 +123,10 @@ func (c *Config) setCloudEnvironment() error {
 			c.MetadataHost = v
 		}
 	}
-	env, err := environments.FromEndpoint(context.TODO(), c.MetadataHost, c.CloudEnvironmentName)
+
+	environmentContext, cancel := context.WithTimeout(context.Background(), time.Minute*3)
+	defer cancel()
+	env, err := environments.FromEndpoint(environmentContext, c.MetadataHost, c.CloudEnvironmentName)
 	c.cloudEnvironment = env
 	if err != nil {
 		// fall back to old method of normalizing and looking up cloud names.

--- a/builder/azure/dtl/resource_resolver.go
+++ b/builder/azure/dtl/resource_resolver.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
-	hashiImagesSDK "github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/compute/2022-03-01/images"
 )
 
 type resourceResolver struct {
@@ -47,9 +47,11 @@ func (s *resourceResolver) shouldResolveManagedImageName(c *Config) bool {
 	return c.CustomManagedImageName != ""
 }
 
-func findManagedImageByName(client *AzureClient, name, subscriptionId, resourceGroupName string) (*hashiImagesSDK.Image, error) {
+func findManagedImageByName(client *AzureClient, name, subscriptionId, resourceGroupName string) (*images.Image, error) {
+	managedImageContext, cancel := context.WithTimeout(context.TODO(), client.PollingDuration)
+	defer cancel()
 	id := commonids.NewResourceGroupID(subscriptionId, resourceGroupName)
-	images, err := client.ImagesClient.ListByResourceGroupComplete(context.TODO(), id)
+	images, err := client.ImagesClient.ListByResourceGroupComplete(managedImageContext, id)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
On v2.1.0 we switched to using go-azure-sdk base layer clients, which require a polling context, we missed one of those and there isn't a case for this in our acceptance testing currently so this was missed.

Before this change when building using a custom_managed_image_name source

```
azure-arm.autogenerated_1: output will be in this color.

==> azure-arm.autogenerated_1: Running builder ...
    azure-arm.autogenerated_1: Creating Azure Resource Manager (ARM) client ...
    azure-arm.autogenerated_1: ARM Client successfully created
Build 'azure-arm.autogenerated_1' errored after 957 milliseconds 28 microseconds: loading results: the context used must have a deadline attached for polling purposes, but got no deadline

==> Wait completed after 957 milliseconds 237 microseconds

==> Some builds didn't complete successfully and had errors:
--> azure-arm.autogenerated_1: loading results: the context used must have a deadline attached for polling purposes, but got no deadline

==> Builds finished but no artifacts were created.
```

After this change the build succeeds

Closes #401 

