### PR TITLE
fix: [arm builder] storage blob VHD deletion, cleanup post build deletion

### DIFF
--- a/builder/azure/arm/azure_client.go
+++ b/builder/azure/arm/azure_client.go
@@ -77,7 +77,7 @@ func errorCapture(client *AzureClient) client.ResponseMiddleware {
 }
 
 // Returns an Azure Client used for the Azure Resource Manager
-func NewAzureClient(ctx context.Context, isVHDBuild bool, cloud *environments.Environment, sharedGalleryTimeout time.Duration, pollingDuration time.Duration, authOptions commonclient.AzureAuthOptions) (*AzureClient, error) {
+func NewAzureClient(ctx context.Context, storageAccountName string, cloud *environments.Environment, sharedGalleryTimeout time.Duration, pollingDuration time.Duration, authOptions commonclient.AzureAuthOptions) (*AzureClient, error) {
 
 	var azureClient = &AzureClient{}
 
@@ -230,13 +230,12 @@ func NewAzureClient(ctx context.Context, isVHDBuild bool, cloud *environments.En
 	azureClient.GalleryImagesClient = *galleryImagesClient
 
 	// We only need the Blob Client to delete the OS VHD during VHD builds
-	if isVHDBuild {
+	if storageAccountName != "" {
 		storageAccountAuthorizer, err := commonclient.BuildStorageAuthorizer(ctx, authOptions, *cloud)
 		if err != nil {
 			return nil, err
 		}
-
-		blobClient, err := giovanniBlobStorageSDK.NewWithBaseUri(cloud.Storage.Name())
+		blobClient, err := giovanniBlobStorageSDK.NewWithBaseUri(fmt.Sprintf("https://%s.blob.core.windows.net", storageAccountName))
 		if err != nil {
 			return nil, err
 		}

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -100,11 +100,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	}
 
 	ui.Message("Creating Azure Resource Manager (ARM) client ...")
-	// For VHD Builds we need to enable the Blob Azure Storage client
-	configureBlobClient := (b.config.ResourceGroupName != "" || b.config.StorageAccount != "")
 	azureClient, err := NewAzureClient(
 		ctx,
-		configureBlobClient,
+		b.config.StorageAccount,
 		b.config.ClientConfig.CloudEnvironment(),
 		b.config.SharedGalleryTimeout,
 		b.config.PollingDurationTimeout,
@@ -474,8 +472,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	if b.config.isPublishToSIG() {
 		return b.sharedImageArtifact(stateData)
 	}
-	ui.Say(b.config.storageAccountBlobEndpoint)
-	ui.Say(fmt.Sprintf("%d", len(b.config.AdditionalDiskSize)))
 	return NewArtifact(
 		b.stateBag.Get(constants.ArmBuildVMInternalId).(string),
 		b.config.CaptureNamePrefix,

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/go-azure-sdk/resource-manager v0.20240411.1145857
 	github.com/hashicorp/go-azure-sdk/sdk v0.20240411.1145857
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/tombuildsstuff/giovanni v0.25.3
+	github.com/tombuildsstuff/giovanni v0.26.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -163,12 +163,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-azure-helpers v0.66.2 h1:+Pzuo7pdKl0hBXXr5ymmhs4Q40tHAo2nAvHq4WgSjx8=
 github.com/hashicorp/go-azure-helpers v0.66.2/go.mod h1:kJxXrFtJKJdOEqvad8pllAe7dhP4DbN8J6sqFZe47+4=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240327.1161949 h1:6kiYPtSO7l08UshpjOkeBvqDOIOdRXhYFMAYRdosLoo=
-github.com/hashicorp/go-azure-sdk/resource-manager v0.20240327.1161949/go.mod h1:6emA77HGPRTEV9n0VLpVfzsvinp6iDBqsf/W1C+eRhY=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240411.1145857 h1:pgbiUHdg4QGd2Seg48fsWVNS2ydMoS5ZzjYyVGbDndk=
 github.com/hashicorp/go-azure-sdk/resource-manager v0.20240411.1145857/go.mod h1:MpsjFWjpJGEFSenIPkWORZrvO7ZAA46bNZKu1HQrTaY=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240327.1161949 h1:Iu3U8RUGKQNza6MSFyTNjgasDaEcpehqr0Rn4ruBHBk=
-github.com/hashicorp/go-azure-sdk/sdk v0.20240327.1161949/go.mod h1:POOjeoqNp+mvlLBuibJTziUAkBZ7FxXGeGestwemL/w=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240411.1145857 h1:zc6BJzd1u6fvQ1zjwwWMMnhAKE/EYsL2DKBM5Yl1Iko=
 github.com/hashicorp/go-azure-sdk/sdk v0.20240411.1145857/go.mod h1:POOjeoqNp+mvlLBuibJTziUAkBZ7FxXGeGestwemL/w=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -375,8 +371,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/tombuildsstuff/giovanni v0.25.3 h1:sqUXiKvU4tmmGA3+YXZe87j4ngu7DkwijFO/ex8a4Hk=
-github.com/tombuildsstuff/giovanni v0.25.3/go.mod h1:s7xbU2lN5Iz9MBglmDDv9p2QPbn6x3UkJBtpCfUerLs=
+github.com/tombuildsstuff/giovanni v0.26.1 h1:RZgnpyIHtgw0GXYpw3xttNk35obJNoI1hztCZsh/Djo=
+github.com/tombuildsstuff/giovanni v0.26.1/go.mod h1:s7xbU2lN5Iz9MBglmDDv9p2QPbn6x3UkJBtpCfUerLs=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.2.6/go.mod h1:anCg0y61KIhDlPZmnH+so+RQbysYVyDko0IMgJv0Nn0=
 github.com/ugorji/go/codec v1.2.6 h1:7kbGefxLoDBuYXOms4yD7223OpNMMPNPZxXk5TvFcyQ=


### PR DESCRIPTION
This PR has three main purposes

- Fix #409 by passing in storage account name to client as expected
- Fix #273 by deleting the VM/Network Interface before deleting other networking resources, these errors were harmless and didn't actually lead to orphaned resources, but its noisy and unnecessary
- Make it possible to unit test these new changes with substantial refactoring to step_deploy_template's CleanUp step, moving several of the resource deletions into their own functions.

Closes #409
Closes #273

Before this PR when building a VHD image with additional disks that should be deleted, you can see extra print statements at the bottom of 2, and my storage account as well as the failed additional disk deletion, and NIC repeated retry errors.

```
==> azure-arm:
==> azure-arm: Deleting Virtual Machine deployment and its attached resources...
==> azure-arm: Adding to deletion queue -> Microsoft.Compute/virtualMachines : 'replaced'
==> azure-arm: Adding to deletion queue -> Microsoft.Network/networkInterfaces : 'replaced'
==> azure-arm: Adding to deletion queue -> Microsoft.Network/virtualNetworks : 'replaced'
==> azure-arm: Adding to deletion queue -> Microsoft.Network/publicIPAddresses : 'replaced'
==> azure-arm: Waiting for deletion of all resources...
==> azure-arm: Attempting deletion -> Microsoft.Compute/virtualMachines : 'replaced'==> azure-arm: Attempting deletion -> Microsoft.Network/publicIPAddresses : 'replaced'
==> azure-arm: Attempting deletion -> Microsoft.Network/virtualNetworks : 'replaced'==> azure-arm: Attempting deletion -> Microsoft.Network/networkInterfaces : 'replaced'
==> azure-arm: Couldn't delete Microsoft.Network/publicIPAddresses resource. Will retry.
==> azure-arm: Name: replaced
==> azure-arm: Couldn't delete Microsoft.Network/virtualNetworks resource. Will retry.
==> azure-arm: Name: replaced
==> azure-arm: Attempting deletion -> Microsoft.Network/publicIPAddresses : 'replaced'
==> azure-arm: Attempting deletion -> Microsoft.Network/virtualNetworks : 'replaced'==> azure-arm: Skipping deletion -> image : 'https://removedstorageaccount.blob.core.windows.net/images/removed.vhd' since 'keep_os_disk' is set to true
==> azure-arm:  Deleting Additional Disk -> 1: 'https://removedstorageaccount.blob.core.windows.net/images/pkrdisk-1.vhd'
==> azure-arm: Failed to delete the managed Additional Disk!
==> azure-arm:  Deleting Additional Disk -> 2: 'https://removedstorageaccount.blob.core.windows.net/images/pkrdisk-2.vhd'
==> azure-arm: Failed to delete the managed Additional Disk!
==> azure-arm: Removing the created Deployment object: 'pkrdplafewlqjyv'
==> azure-arm:
==> azure-arm: The resource group was not created by Packer, not deleting ...
==> azure-arm: https://removedstorageaccount.blob.core.windows.net/
==> azure-arm: 2
Build 'azure-arm' finished after 3 minutes 6 seconds.
```

After


```
==> azure-arm: Deleting Virtual Machine deployment and its attached resources...
==> azure-arm: Deleted -> Microsoft.Compute/virtualMachines : 'pkrvmq58v6zr4b1'
==> azure-arm: Deleted -> Microsoft.Network/networkInterfaces : 'pkrniq58v6zr4b1'
==> azure-arm: Deleted -> Microsoft.Network/publicIPAddresses : 'pkripq58v6zr4b1'
==> azure-arm: Deleted -> Microsoft.Network/virtualNetworks : 'pkrvnq58v6zr4b1'
==> azure-arm: Skipping deletion -> image : 'https://removed.blob.core.windows.net/images/removed.vhd' since 'keep_os_disk' is set to true
==> azure-arm:  Deleted Additional Disk -> 1: 'https://removed.blob.core.windows.net/images/removed-1.vhd'
==> azure-arm:  Deleted Additional Disk -> 2: 'https://removed.blob.core.windows.net/images/removed-2.vhd'
==> azure-arm: Removing the created Deployment object: 'pkrdpq58v6zr4b1'
==> azure-arm:
==> azure-arm: The resource group was not created by Packer, not deleting ...
Build 'azure-arm' finished after 3 minutes 1 second.
```


