### PR TITLE
Use pollingContext for data disk snapshot

### DIFF
--- a/builder/azure/arm/step_snapshot_data_disks.go
+++ b/builder/azure/arm/step_snapshot_data_disks.go
@@ -56,7 +56,7 @@ func (s *StepSnapshotDataDisks) createDataDiskSnapshot(ctx context.Context, subs
 		return err
 	}
 
-	snapshot, err := s.client.SnapshotsClient.Get(ctx, id)
+	snapshot, err := s.client.SnapshotsClient.Get(pollingContext, id)
 	if err != nil {
 		s.say(s.client.LastError.Error())
 		return err


### PR DESCRIPTION
With the move to the latest SDK, it appears that the polling context isn't utilized during data disk snapshot creation. This was causing the following error when a data disk snapshot was requested: `the context used must have a deadline attached for polling purposes, but got no deadline`

I've updated the Get call to utilize `pollingContext`.

Built the plugin from my forked branch and ran it and it was able to finish successfully

```
2024/05/24 19:49:54 packer-plugin-azure_v2.1.5_x5.0_linux_amd64 plugin: 2024/05/24 19:49:54 [DEBUG] GET https://management.azure.com/subscriptions/****/resourceGroups/****/providers/Microsoft.Compute/snapshots/****?api-version=2022-03-02
==> azure-arm.trek_image:  -> Snapshot ID : '/subscriptions/****/resourceGroups/****/providers/Microsoft.Compute/snapshots/****'
```