### PR TITLE
ARM: Show API errors when failing to validate existing resources and when deleting them.

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -146,7 +146,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		groupId := commonids.NewResourceGroupID(b.config.ClientConfig.SubscriptionID, b.config.ManagedImageResourceGroupName)
 		_, err := azureClient.ResourceGroupsClient.Get(builderPollingContext, groupId)
 		if err != nil {
-			return nil, fmt.Errorf("Cannot locate the managed image resource group %s, received error %s", b.config.ManagedImageResourceGroupName, err.Error())
+			return nil, fmt.Errorf("Cannot locate the managed image resource group %s, received error %s", b.config.ManagedImageResourceGroupName, err)
 		}
 
 		// If a managed image already exists it cannot be overwritten.

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -214,7 +214,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		galleryId := galleryimages.NewGalleryImageID(sigSubscriptionID, b.config.SharedGalleryDestination.SigDestinationResourceGroup, b.config.SharedGalleryDestination.SigDestinationGalleryName, b.config.SharedGalleryDestination.SigDestinationImageName)
 		_, err = azureClient.GalleryImagesClient.Get(builderPollingContext, galleryId)
 		if err != nil {
-			return nil, fmt.Errorf("Cannot locate destination shared image gallery in resource group %s, with gallery name %s and image name %s, received error: %s ", b.config.SharedGalleryDestination.SigDestinationResourceGroup, b.config.SharedGalleryDestination.SigDestinationGalleryName, b.config.SharedGalleryDestination.SigDestinationImageName, err.Error())
+			return nil, fmt.Errorf("failed to get image %q from image gallery %q in resource group %q: %s",
+				b.config.SharedGalleryDestination.SigDestinationImageName,
+				b.config.SharedGalleryDestination.SigDestinationGalleryName,
+				b.config.SharedGalleryDestination.SigDestinationResourceGroup,
+				err)
 		}
 		// Check if a Image Version already exists for our target destination
 		galleryImageVersionId := galleryimageversions.NewImageVersionID(sigSubscriptionID, b.config.SharedGalleryDestination.SigDestinationResourceGroup, b.config.SharedGalleryDestination.SigDestinationGalleryName, b.config.SharedGalleryDestination.SigDestinationImageName, b.config.SharedGalleryDestination.SigDestinationImageVersion)

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -298,7 +298,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		id := galleryimages.NewGalleryImageID(b.config.SharedGallery.Subscription, b.config.SharedGallery.ResourceGroup, b.config.SharedGallery.GalleryName, b.config.SharedGallery.ImageName)
 		galleryImage, err := client.Get(builderPollingContext, id)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to get parent Shared Gallery Image %s in gallery %s in the resource group %s, received error: %s.", b.config.SharedGallery.GalleryName, b.config.SharedGallery.ImageName, b.config.SharedGallery.ResourceGroup, err.Error())
+			return nil, fmt.Errorf("failed to get parent Shared Gallery Image %s in gallery %s in the resource group %s, received error: %s.", b.config.SharedGallery.GalleryName, b.config.SharedGallery.ImageName, b.config.SharedGallery.ResourceGroup, err.Error())
 		}
 		if galleryImage.Model == nil {
 			return nil, commonclient.NullModelSDKErr

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -146,7 +146,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		groupId := commonids.NewResourceGroupID(b.config.ClientConfig.SubscriptionID, b.config.ManagedImageResourceGroupName)
 		_, err := azureClient.ResourceGroupsClient.Get(builderPollingContext, groupId)
 		if err != nil {
-			return nil, fmt.Errorf("Cannot locate the managed image resource group %s.", b.config.ManagedImageResourceGroupName)
+			return nil, fmt.Errorf("Cannot locate the managed image resource group %s, received error %s", b.config.ManagedImageResourceGroupName, err.Error())
 		}
 
 		// If a managed image already exists it cannot be overwritten.
@@ -214,7 +214,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		galleryId := galleryimages.NewGalleryImageID(sigSubscriptionID, b.config.SharedGalleryDestination.SigDestinationResourceGroup, b.config.SharedGalleryDestination.SigDestinationGalleryName, b.config.SharedGalleryDestination.SigDestinationImageName)
 		_, err = azureClient.GalleryImagesClient.Get(builderPollingContext, galleryId)
 		if err != nil {
-			return nil, fmt.Errorf("the Shared Gallery Image '%s' to which to publish the managed image version to does not exist in the resource group '%s' or does not contain managed image '%s'", b.config.SharedGalleryDestination.SigDestinationGalleryName, b.config.SharedGalleryDestination.SigDestinationResourceGroup, b.config.SharedGalleryDestination.SigDestinationImageName)
+			return nil, fmt.Errorf("Cannot locate destination shared image gallery in resource group %s, with gallery name %s and image name %s, received error: %s ", b.config.SharedGalleryDestination.SigDestinationResourceGroup, b.config.SharedGalleryDestination.SigDestinationGalleryName, b.config.SharedGalleryDestination.SigDestinationImageName, err.Error())
 		}
 		// Check if a Image Version already exists for our target destination
 		galleryImageVersionId := galleryimageversions.NewImageVersionID(sigSubscriptionID, b.config.SharedGalleryDestination.SigDestinationResourceGroup, b.config.SharedGalleryDestination.SigDestinationGalleryName, b.config.SharedGalleryDestination.SigDestinationImageName, b.config.SharedGalleryDestination.SigDestinationImageVersion)
@@ -226,7 +226,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 				defer cancel()
 				err := azureClient.GalleryImageVersionsClient.DeleteThenPoll(deleteImageContext, galleryImageVersionId)
 				if err != nil {
-					return nil, fmt.Errorf("failed to delete gallery image version for image name:version %s:%s in gallery %s", b.config.SharedGalleryDestination.SigDestinationImageName, b.config.SharedGalleryDestination.SigDestinationImageVersion, b.config.SharedGalleryDestination.SigDestinationGalleryName)
+					return nil, fmt.Errorf("failed to delete gallery image version for image name:version %s:%s in gallery %s, received error: %s", b.config.SharedGalleryDestination.SigDestinationImageName, b.config.SharedGalleryDestination.SigDestinationImageVersion, b.config.SharedGalleryDestination.SigDestinationGalleryName, err.Error())
 				}
 
 			} else {
@@ -298,7 +298,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		id := galleryimages.NewGalleryImageID(b.config.SharedGallery.Subscription, b.config.SharedGallery.ResourceGroup, b.config.SharedGallery.GalleryName, b.config.SharedGallery.ImageName)
 		galleryImage, err := client.Get(builderPollingContext, id)
 		if err != nil {
-			return nil, fmt.Errorf("the parent Shared Gallery Image '%s' from which to source the managed image version to does not exist in the resource group '%s' or does not contain managed image '%s'", b.config.SharedGallery.GalleryName, b.config.SharedGallery.ResourceGroup, b.config.SharedGallery.ImageName)
+			return nil, fmt.Errorf("Failed to get parent Shared Gallery Image %s in gallery %s in the resource group %s, received error: %s.", b.config.SharedGallery.GalleryName, b.config.SharedGallery.ImageName, b.config.SharedGallery.ResourceGroup, err.Error())
 		}
 		if galleryImage.Model == nil {
 			return nil, commonclient.NullModelSDKErr


### PR DESCRIPTION
Currently when failing to fetch the destination SIG, or the resource group with managed images, or when trying to delete existing resources, we don't show the actual error from the API.  For the get requests we just say its not found, even though the API gives us more specific information about what is not found.  We should return those error messages to make it easier for users to diagnose issues with their builds

Before this PR for one of these error cases

```
packer build ~/azure-templates/hcl/sig-ubuntu.pkr.hcl
azure-arm.autogenerated_1: output will be in this color.

==> azure-arm.autogenerated_1: Running builder ...
    azure-arm.autogenerated_1: Creating Azure Resource Manager (ARM) client ...
    azure-arm.autogenerated_1: ARM Client successfully created
Build 'azure-arm.autogenerated_1' errored after 1 second 18 milliseconds: the Shared Gallery Image 'gallery' to which to publish the managed image version to does not exist in the resource group 'jenna' or does not contain managed image 'image'

==> Wait completed after 1 second 18 milliseconds

==> Some builds didn't complete successfully and had errors:
--> azure-arm.autogenerated_1: the Shared Gallery Image 'gallery' to which to publish the managed image version to does not exist in the resource group 'jenna' or does not contain managed image 'image'

==> Builds finished but no artifacts were created.

```

After
```
packer build ~/azure-templates/hcl/sig-ubuntu.pkr.hcl
azure-arm.autogenerated_1: output will be in this color.

==> azure-arm.autogenerated_1: Running builder ...
    azure-arm.autogenerated_1: Creating Azure Resource Manager (ARM) client ...
    azure-arm.autogenerated_1: ARM Client successfully created
Build 'azure-arm.autogenerated_1' errored after 1 second 858 milliseconds: failed to get image "image" from destination image gallery "gallery" in resource group "jenna": unexpected status 404 (404 Not Found) with error: ResourceGroupNotFound: Resource group 'jenna' could not be found.

==> Wait completed after 1 second 858 milliseconds

==> Some builds didn't complete successfully and had errors:
--> azure-arm.autogenerated_1: failed to get image "image" from destination image gallery "gallery" in resource group "jenna": unexpected status 404 (404 Not Found) with error: ResourceGroupNotFound: Resource group 'jenna' could not be found.

==> Builds finished but no artifacts were created.

```
After we clearly can tell that the resource group is missing