### PR TITLE
Don't hardcode go version in acceptance tests

### DIFF
--- a/.github/workflows/acceptance-tests.yaml
+++ b/.github/workflows/acceptance-tests.yaml
@@ -27,19 +27,33 @@ jobs:
             echo "available=true" | tee ${GITHUB_OUTPUT}
           fi
 
+  get-go-version:
+    runs-on: ubuntu-latest
+    outputs:
+      go-version: ${{ steps.get-go-version.outputs.go-version }}
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: 'Determine Go version'
+        id: get-go-version
+        run: |
+          echo "Found Go $(cat .go-version)"
+          echo "go-version=$(cat .go-version)" >> $GITHUB_OUTPUT
+
   acceptance-tests:
     runs-on: ubuntu-latest
-    needs: [secrets-check]
+    needs: 
+      - secrets-check
+      - get-go-version 
     if: needs.secrets-check.outputs.available == 'true'
     steps:
-      - name: Install Go
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
-        with:
-          go-version: '1.19.5'
-
       - name: Checkout
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      
+     
+     - name: Set up Go
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: ${{ needs.get-go-version.outputs.go-version }} 
+
       - name: Setup `terraform`
         uses: hashicorp/setup-terraform@v2
 


### PR DESCRIPTION
We hardcore the go version in the acceptance tests currently to go 1.19, which causes a failure currently.

But in general we shouldn't hardcore this version