### PR TITLE
chore: update `version.go`

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -8,15 +8,8 @@ import (
 )
 
 var (
-	// Version is the main version number that is being run at the moment.
-	Version = "2.1.7"
-
-	// VersionPrerelease is A pre-release marker for the Version. If this is ""
-	// (empty string) then it means that it is a final release. Otherwise, this
-	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = ""
-
-	// AzurePluginVersion is used by the plugin set to allow Packer to recognize
-	// what version this plugin is.
-	AzurePluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
+	Version            = "2.1.7"
+	VersionPrerelease  = ""
+	VersionMetadata    = ""
+	AzurePluginVersion = version.NewVersion(Version, VersionPrerelease, VersionMetadata)
 )


### PR DESCRIPTION
### Summary

- Replaces the deprecated `InitializePluginVersion` with `NewPluginVersion` from `packer-plugin-sdk`, which is the recommended approach in `version/version.go`.
- Removed superfluous comments that are already included in the SDK.


