### PR TITLE
Add docs for `target_region` replicas field, make error message for it clearer

### DIFF
--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -236,7 +236,7 @@ Providing `temp_resource_group_name` or `location` in combination with
   can be used for decommissioning purposes.
 
 - `shared_image_gallery_replica_count` (int64) - The number of replicas of the Image Version to be created per region defined in `replication_regions`.
-  Users using `target_region` blocks can specify individual replica counts per region.
+  Users using `target_region` blocks can specify individual replica counts per region using the `replicas` field.
 
 - `shared_gallery_image_version_exclude_from_latest` (bool) - If set to true, Virtual Machines deployed from the latest version of the
   Image Definition won't use this Image Version.
@@ -695,6 +695,22 @@ The shared_image_gallery_destination block is available for publishing a new ima
 
 <!-- End of code generated from the comments of the SharedImageGalleryDestination struct in builder/azure/arm/config.go; -->
 
+
+### Target Regions
+
+The `target_regions` block is available inside the `shared_image_gallery_destination` block for setting replica regions and the replica community
+
+<!-- Code generated from the comments of the TargetRegion struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
+
+- `disk_encryption_set_id` (string) - DiskEncryptionSetId for Disk Encryption Set in Region. Needed for supporting
+  the replication of encrypted disks across regions. CMKs must
+  already exist within the target regions.
+
+- `replicas` (int64) - The number of replicas of the Image Version to be created within the region. Defaults to 1.
+  Replica count must be between 1 and 100, but 50 replicas should be sufficient for most use cases.
+  When using shallow replication `use_shallow_replication=true` the value can only be 1 for the primary build region.
+
+<!-- End of code generated from the comments of the TargetRegion struct in builder/azure/arm/config.go; -->
 
 
 ### Spot

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -264,7 +264,7 @@ type Config struct {
 	// can be used for decommissioning purposes.
 	SharedGalleryImageVersionEndOfLifeDate string `mapstructure:"shared_gallery_image_version_end_of_life_date" required:"false"`
 	// The number of replicas of the Image Version to be created per region defined in `replication_regions`.
-	// Users using `target_region` blocks can specify individual replica counts per region.
+	// Users using `target_region` blocks can specify individual replica counts per region using the `replicas` field.
 	SharedGalleryImageVersionReplicaCount int64 `mapstructure:"shared_image_gallery_replica_count" required:"false"`
 	// If set to true, Virtual Machines deployed from the latest version of the
 	// Image Definition won't use this Image Version.
@@ -1364,7 +1364,7 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 		}
 
 		if (len(c.SharedGalleryDestination.SigDestinationTargetRegions) > 0) && c.SharedGalleryImageVersionReplicaCount != 0 {
-			errs = packersdk.MultiErrorAppend(errs, errors.New("`shared_image_gallery_replica_count` can not be defined alongside `target_region`; you can specify the number of replicas per region within target_region blocks."))
+			errs = packersdk.MultiErrorAppend(errs, errors.New("`shared_image_gallery_replica_count` can not be defined alongside `target_region`; you can define `replicas` inside each target_region block to set the number replicas for each region"))
 		}
 
 		if c.SharedGalleryDestination.SigDestinationUseShallowReplicationMode {

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -1385,7 +1385,7 @@ func TestConfigShouldRejectSigVersionReplicaWithTargetRegion(t *testing.T) {
 		},
 	}
 	var c Config
-	expectedErrorMessage := "`shared_image_gallery_replica_count` can not be defined alongside `target_region`; you can specify the number of replicas per region within target_region blocks"
+	expectedErrorMessage := "shared_image_gallery_replica_count` can not be defined alongside `target_region`; you can define `replicas` inside each target_region block to set the number replicas for each region"
 	_, err := c.Prepare(config, getPackerConfiguration())
 	if err == nil {
 		t.Fatal("expected config to reject target_region block with shared_image_gallery_replica_count set")

--- a/docs-partials/builder/azure/arm/Config-not-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-not-required.mdx
@@ -95,7 +95,7 @@
   can be used for decommissioning purposes.
 
 - `shared_image_gallery_replica_count` (int64) - The number of replicas of the Image Version to be created per region defined in `replication_regions`.
-  Users using `target_region` blocks can specify individual replica counts per region.
+  Users using `target_region` blocks can specify individual replica counts per region using the `replicas` field.
 
 - `shared_gallery_image_version_exclude_from_latest` (bool) - If set to true, Virtual Machines deployed from the latest version of the
   Image Definition won't use this Image Version.

--- a/docs/builders/arm.mdx
+++ b/docs/builders/arm.mdx
@@ -127,6 +127,11 @@ The shared_image_gallery_destination block is available for publishing a new ima
 
 @include 'builder/azure/arm/SharedImageGalleryDestination-not-required.mdx'
 
+### Target Regions
+
+The `target_regions` block is available inside the `shared_image_gallery_destination` block for setting replica regions and the replica community
+
+@include 'builder/azure/arm/TargetRegion-not-required.mdx'
 
 ### Spot
 


### PR DESCRIPTION
There's been some confusion around the target_region block and its replicas field, this PR fixes an issue where there we weren't including the specific information for the fields the target_region block in the docs.  I also modified the error message to make this easier to understand

closes https://github.com/hashicorp/packer-plugin-azure/issues/430