### PR TITLE
Fix `replicated_regions` not using `shared_image_gallery_replica_count` for build location when its specified in the list

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -261,9 +261,16 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			for _, region := range b.config.SharedGalleryDestination.SigDestinationReplicationRegions {
 				region := normalizeAzureRegion(region)
 				if strings.EqualFold(region, buildLocation) {
-					// backwards compatibility DiskEncryptionSetId was set on the global config not on the target region.
-					// Users using target_region blocks are responsible for setting the DES within the block
-					normalizedRegions = append(normalizedRegions, TargetRegion{Name: region, DiskEncryptionSetId: b.config.DiskEncryptionSetId})
+					normalizedRegions = append(
+						normalizedRegions, TargetRegion{
+							Name: region,
+							// backwards compatibility DiskEncryptionSetId was set on the global config not on the target region.
+							// Users using target_region blocks are responsible for setting the DES within the block
+							DiskEncryptionSetId: b.config.DiskEncryptionSetId,
+
+							ReplicaCount: b.config.SharedGalleryImageVersionReplicaCount,
+						},
+					)
 					foundMandatoryReplicationRegion = true
 					continue
 				}


### PR DESCRIPTION
The logic that handles the backwards compatibility for creating the new Target Regions block from the replicated regions list doesn't add the replica count to the default region.  This causes the default region to always have a replica count of 1, this is currently a bit iffy to unit test and should probably be unwound into its own step still, but I don't think we should leave this functionality broken in the mean time