### PR TITLE
Add Subscription ID and Tenant ID to build variables

### DIFF
--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -765,6 +765,8 @@ post-processor "manifest" {
     strip_path = true
     custom_data = {
         source_image_name = "${build.SourceImageName}"
+	tenant_id = "${build.TenantID}"
+        subscription_id = "${build.SubscriptionID}"
     }
 }
 ```
@@ -777,7 +779,9 @@ post-processor "manifest" {
     "output": "manifest.json",
     "strip_path": true,
     "custom_data": {
-      "source_image_name": "{{ build `SourceImageName` }}"
+        "source_image_name": "{{ build `SourceImageName` }}",
+        "tenant_id": "{{ build `TenantID` }}",
+        "subscription_id": "{{ build `SubscriptionID` }}"
     }
   }
 ]

--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -737,6 +737,10 @@ The generated variables available for this builder are:
 shared images the resulting name will point to the actual source used to create the said version.
   building the AMI.
 
+- `SubscriptionID` - The ID of the Azure Subscription where the build takes place.  
+
+- `TenantID` - The ID of the Azure Tenant where the build takes place.
+
 Usage example:
 
 **HCL2**

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -390,10 +390,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			)
 		}
 		steps = append(steps,
-			&StepSetGeneratedData{
-				GeneratedData: generatedData,
-				Config:        &b.config,
-			},
 			NewStepValidateTemplate(azureClient, ui, &b.config, deploymentName, getVirtualMachineDeploymentFunction),
 			NewStepDeployTemplate(azureClient, ui, &b.config, deploymentName, getVirtualMachineDeploymentFunction, VirtualMachineTemplate),
 			NewStepGetIPAddress(azureClient, ui, endpointConnectType),
@@ -440,7 +436,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		NewStepCaptureImage(azureClient, ui),
 		NewStepPublishToSharedImageGallery(azureClient, ui, &b.config),
 	)
-
+	steps = append([]multistep.Step{
+		&StepSetGeneratedData{
+			GeneratedData: generatedData,
+			Config:        &b.config,
+		},
+	}, steps...)
 	steps = append(steps, captureSteps...)
 
 	if b.config.PackerDebug {

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -59,7 +59,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	b.setTemplateParameters(b.stateBag)
 	b.setImageParameters(b.stateBag)
 
-	generatedDataKeys := []string{"SourceImageName"}
+	generatedDataKeys := []string{"SourceImageName", "TenantID", "SubscriptionID"}
 
 	return generatedDataKeys, warnings, nil
 }
@@ -390,6 +390,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			)
 		}
 		steps = append(steps,
+			&StepSetGeneratedData{
+				GeneratedData: generatedData,
+				Config:        &b.config,
+			},
 			NewStepValidateTemplate(azureClient, ui, &b.config, deploymentName, getVirtualMachineDeploymentFunction),
 			NewStepDeployTemplate(azureClient, ui, &b.config, deploymentName, getVirtualMachineDeploymentFunction, VirtualMachineTemplate),
 			NewStepGetIPAddress(azureClient, ui, endpointConnectType),

--- a/builder/azure/arm/step_set_generated_data.go
+++ b/builder/azure/arm/step_set_generated_data.go
@@ -1,0 +1,27 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package arm
+
+import (
+	"context"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
+)
+
+type StepSetGeneratedData struct {
+	GeneratedData *packerbuilderdata.GeneratedData
+	Config        *Config
+}
+
+func (s *StepSetGeneratedData) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+
+	s.GeneratedData.Put("TenantID", s.Config.ClientConfig.TenantID)
+	s.GeneratedData.Put("SubscriptionID", s.Config.ClientConfig.SubscriptionID)
+	return multistep.ActionContinue
+}
+
+func (s *StepSetGeneratedData) Cleanup(state multistep.StateBag) {
+	// No cleanup...
+}

--- a/docs/builders/arm.mdx
+++ b/docs/builders/arm.mdx
@@ -178,6 +178,8 @@ post-processor "manifest" {
     strip_path = true
     custom_data = {
         source_image_name = "${build.SourceImageName}"
+	tenant_id = "${build.TenantID}"
+        subscription_id = "${build.SubscriptionID}"
     }
 }
 ```
@@ -190,7 +192,9 @@ post-processor "manifest" {
     "output": "manifest.json",
     "strip_path": true,
     "custom_data": {
-      "source_image_name": "{{ build `SourceImageName` }}"
+        "source_image_name": "{{ build `SourceImageName` }}",
+        "tenant_id": "{{ build `TenantID` }}",
+        "subscription_id": "{{ build `SubscriptionID` }}"
     }
   }
 ]

--- a/docs/builders/arm.mdx
+++ b/docs/builders/arm.mdx
@@ -150,6 +150,10 @@ The generated variables available for this builder are:
 shared images the resulting name will point to the actual source used to create the said version.
   building the AMI.
 
+- `SubscriptionID` - The ID of the Azure Subscription where the build takes place.  
+
+- `TenantID` - The ID of the Azure Tenant where the build takes place.
+
 Usage example:
 
 **HCL2**


### PR DESCRIPTION
This can be helpful when subscription ID and tenant ID aren't explicitly set already in the template/env variables due to CLI auth/other login methods.

Closes https://github.com/hashicorp/packer-plugin-azure/issues/436