### PR TITLE
Fixed spacing issue on README

### DIFF
--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -765,7 +765,7 @@ post-processor "manifest" {
     strip_path = true
     custom_data = {
         source_image_name = "${build.SourceImageName}"
-	      tenant_id = "${build.TenantID}"
+        tenant_id = "${build.TenantID}"
         subscription_id = "${build.SubscriptionID}"
     }
 }

--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -765,7 +765,7 @@ post-processor "manifest" {
     strip_path = true
     custom_data = {
         source_image_name = "${build.SourceImageName}"
-        tenant_id = "${build.TenantID}"
+	tenant_id = "${build.TenantID}"
         subscription_id = "${build.SubscriptionID}"
     }
 }

--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -765,7 +765,7 @@ post-processor "manifest" {
     strip_path = true
     custom_data = {
         source_image_name = "${build.SourceImageName}"
-	tenant_id = "${build.TenantID}"
+        tenant_id = "${build.TenantID}"
         subscription_id = "${build.SubscriptionID}"
     }
 }

--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -765,7 +765,7 @@ post-processor "manifest" {
     strip_path = true
     custom_data = {
         source_image_name = "${build.SourceImageName}"
-	tenant_id = "${build.TenantID}"
+	      tenant_id = "${build.TenantID}"
         subscription_id = "${build.SubscriptionID}"
     }
 }

--- a/docs/builders/arm.mdx
+++ b/docs/builders/arm.mdx
@@ -178,7 +178,7 @@ post-processor "manifest" {
     strip_path = true
     custom_data = {
         source_image_name = "${build.SourceImageName}"
-	tenant_id = "${build.TenantID}"
+        tenant_id = "${build.TenantID}"
         subscription_id = "${build.SubscriptionID}"
     }
 }


### PR DESCRIPTION
Simple fix to adjust tabs on a code example for the recently added build variables (Tenant Id and Subscription Id).