### PR TITLE
Use not winrm instead of is ssh condition

### DIFF
--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -21,7 +21,7 @@ import (
 type templateFactoryFunc func(*Config) (*deployments.Deployment, error)
 
 func GetCommunicatorSpecificKeyVaultDeployment(config *Config) (*deployments.Deployment, error) {
-	if config.Comm.Type == "ssh" {
+	if config.Comm.Type != "winrm" {
 		privateKey, err := ssh.ParseRawPrivateKey(config.Comm.SSHPrivateKey)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Communicator "none" issue

## Context

Your plugin gives packer the option to not set up a communicator for provisioning. This is especially useful when your packer provisioning step is just calling an ansible playbook or some other OS configurator.

## The issue

When this happened your plugin handled the connection as a winrm connection when creating the key vault. The problem with this is that the user did not provide any winrm specific configuration because they didn't want any communicator. This led to fatal deployment error.

### Example configuration:
```hcl
source "azure-arm" "baseimage" {
  <any configuration here without defining winrm>
  communicator = "none"
}
```
### Error output:
```
Debug mode enabled. Builds will not be parallelized.
azure-arm.baseimage: output will be in this color.

==> azure-arm.baseimage: Running builder ...
    azure-arm.baseimage: Creating Azure Resource Manager (ARM) client ...
    azure-arm.baseimage: ARM Client successfully created
    azure-arm.baseimage: temp admin user: 'packer'
    azure-arm.baseimage: temp admin password: 'VP0AHVC47GturUZCm3rGcOsVkoUYnUHR'
==> azure-arm.baseimage: Getting source image id for the deployment ...
==> azure-arm.baseimage: Using existing resource group ...
==> azure-arm.baseimage:  -> ResourceGroupName : '<rg>'
==> azure-arm.baseimage:  -> Location          : '<loc>'
==> azure-arm.baseimage: Validating deployment template ...
==> azure-arm.baseimage:  -> ResourceGroupName : '<rg>'
==> azure-arm.baseimage:  -> DeploymentName    : 'kvpkrdp72fap2n0ot'
==> azure-arm.baseimage: Deploying deployment template ...
==> azure-arm.baseimage:  -> ResourceGroupName : '<rg>'
==> azure-arm.baseimage:  -> DeploymentName    : 'kvpkrdp72fap2n0ot'
==> azure-arm.baseimage: Getting the certificate's URL ...
==> azure-arm.baseimage:  -> Key Vault Name        : 'pkrkv72fap2n0ot'
==> azure-arm.baseimage:  -> Key Vault Secret Name : 'packerKeyVaultSecret'
==> azure-arm.baseimage:  -> Certificate URL       : 'https://pkrkv72fap2n0ot.vault.azure.net/secrets/packerKeyVaultSecret/7caa02c566b341cb8e800b8c7591c420'
==> azure-arm.baseimage: Setting the certificate's URL ...
==> azure-arm.baseimage: Validating deployment template ...
==> azure-arm.baseimage:  -> ResourceGroupName : '<rg>'
==> azure-arm.baseimage:  -> DeploymentName    : 'pkrdp72fap2n0ot'
==> azure-arm.baseimage: Deploying deployment template ...
==> azure-arm.baseimage:  -> ResourceGroupName : '<rg>'
==> azure-arm.baseimage:  -> DeploymentName    : 'pkrdp72fap2n0ot'
==> azure-arm.baseimage: ERROR: -> DeploymentFailed : At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.
==> azure-arm.baseimage: ERROR:   -> ResourceDeploymentFailure : The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'.
==> azure-arm.baseimage:
==> azure-arm.baseimage: polling after CreateOrUpdate: polling failed: the Azure API returned the following error:
==> azure-arm.baseimage: 
==> azure-arm.baseimage: Status: "DeploymentFailed"
==> azure-arm.baseimage: Code: "ResourceDeploymentFailure"
==> azure-arm.baseimage: Message: "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.\nThe resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'."
==> azure-arm.baseimage: Activity Id: ""
==> azure-arm.baseimage: 
==> azure-arm.baseimage: ---
==> azure-arm.baseimage: 
==> azure-arm.baseimage: API Response:
==> azure-arm.baseimage: 
==> azure-arm.baseimage: ----[start]----
==> azure-arm.baseimage: {"status":"Failed","error":{"code":"DeploymentFailed","target":"/subscriptions/<subscription_id>/resourceGroups/<rg>/providers/Microsoft.Resources/deployments/pkrdp72fap2n0ot","message":"At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.","details":[{"code":"ResourceDeploymentFailure","target":"/subscriptions/<subscription_id>/resourceGroups/<rg>/providers/Microsoft.Compute/virtualMachines/pkrvm72fap2n0ot","message":"The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'.","details":[{"code":"CertificateImproperlyFormatted","message":"The secret retrieved from https://pkrkv72fap2n0ot.vault.azure.net/secrets/packerKeyVaultSecret/7caa02c566b341cb8e800b8c7591c420 is empty string."}]}]}}
==> azure-arm.baseimage: -----[end]-----
==> azure-arm.baseimage:
==> azure-arm.baseimage: 
==> azure-arm.baseimage: Deleting Virtual Machine deployment and its attached resources...
==> azure-arm.baseimage: Could not retrieve OS Image details: unable to obtain a OS disk for "pkrvm72fap2n0ot", please check that the instance has been created
==> azure-arm.baseimage: Deleted -> pkrvm72fap2n0ot : 'Microsoft.Compute/virtualMachines'
==> azure-arm.baseimage: Deleted -> pkrni72fap2n0ot : 'Microsoft.Network/networkInterfaces'
==> azure-arm.baseimage: Failed to find temporary OS disk on VM.  Please delete manually.

```

## The fix

Originally the communicator type was checked if it was set to "ssh" and if not then it defaulted to the winrm deployment. This should be changed to a "not winrm" check. This way if the user set it to "none" it will still deploy a correct certificate without any extra configuration.
