### PR TITLE
Remove x5t Header Check

### DIFF
--- a/builder/azure/common/client/config.go
+++ b/builder/azure/common/client/config.go
@@ -211,15 +211,10 @@ func (c Config) Validate(errs *packersdk.MultiError) {
 		c.ClientJWT != "" {
 		p := jwt.Parser{}
 		claims := jwt.StandardClaims{}
-		token, _, err := p.ParseUnverified(c.ClientJWT, &claims)
+		_, _, err := p.ParseUnverified(c.ClientJWT, &claims)
 		if err != nil {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("client_jwt is not a JWT: %v", err))
-		} else {
-			if t, ok := token.Header["x5t"]; !ok || t == "" {
-				errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("client_jwt is missing the x5t header value, which is required for bearer JWT client authentication to Azure"))
-			}
 		}
-
 		return
 	}
 

--- a/builder/azure/common/client/config_test.go
+++ b/builder/azure/common/client/config_test.go
@@ -304,16 +304,6 @@ func Test_ClientConfig_CannotUseBothClientJWTAndSecret(t *testing.T) {
 	assertInvalid(t, cfg)
 }
 
-func Test_ClientConfig_ClientJWTShouldHaveThumbprint(t *testing.T) {
-	cfg := Config{
-		SubscriptionID: "12345",
-		ClientID:       "12345",
-		ClientJWT:      getJWT(10*time.Minute, false),
-	}
-
-	assertInvalid(t, cfg)
-}
-
 func Test_getJWT(t *testing.T) {
 	if getJWT(time.Minute, true) == "" {
 		t.Fatalf("getJWT is broken")


### PR DESCRIPTION
This check exists from the days of old, and does not seem relevant anymore.  When I search the Terraform AzureRM Provider for usages of the x5t header, the only references I see to it are in the now deprecated autorest library.  in the go-azure-sdk it is only referenced by the Microsoft Graph package, which this plugin does not use, so this should be safe to remove.

Closes https://github.com/hashicorp/packer-plugin-azure/issues/451

