### PR TITLE
make `subscription_id` configurable in cli

### DIFF
--- a/builder/azure/common/client/config.go
+++ b/builder/azure/common/client/config.go
@@ -289,7 +289,10 @@ func (c *Config) FillParameters() error {
 		}
 
 		c.TenantID = tenantID
-		c.SubscriptionID = subscriptionID
+		// we need to honor the subscription_id if specified in the config instead using the default CLI subscription_id
+		if c.SubscriptionID == "" {
+			c.SubscriptionID = subscriptionID
+		}
 	}
 
 	// Get Tenant ID from Access token

--- a/builder/azure/common/client/config_test.go
+++ b/builder/azure/common/client/config_test.go
@@ -163,6 +163,35 @@ func Test_ClientConfig_AzureCli(t *testing.T) {
 	if cfg.AuthType() != AuthTypeAzureCLI {
 		t.Fatalf("Expected authType to be %q, but got: %q", AuthTypeAzureCLI, cfg.AuthType())
 	}
+
+	if cfg.SubscriptionID == "" {
+		t.Fatalf("Expected SubscriptionId to not be empty, but got %s", cfg.SubscriptionID)
+	}
+}
+
+func Test_ClientConfig_AzureCli_with_subscription_id_set(t *testing.T) {
+	// Azure CLI tests skipped unless env 'AZURE_CLI_AUTH' is set, and an active `az login` session has been established
+	getEnvOrSkip(t, "AZURE_CLI_AUTH")
+	subId := "non-default-subscription_id"
+	cfg := Config{
+		UseAzureCLIAuth:  true,
+		cloudEnvironment: environments.AzurePublic(),
+		SubscriptionID:   subId,
+	}
+	assertValid(t, cfg)
+
+	err := cfg.FillParameters()
+	if err != nil {
+		t.Fatalf("Expected nil err, but got: %v", err)
+	}
+
+	if cfg.AuthType() != AuthTypeAzureCLI {
+		t.Fatalf("Expected authType to be %q, but got: %q", AuthTypeAzureCLI, cfg.AuthType())
+	}
+
+	if cfg.SubscriptionID != subId {
+		t.Fatalf("Expected SubscriptionId to be %s, but got: %s", subId, cfg.SubscriptionID)
+	}
 }
 
 func Test_ClientConfig_GitHubOIDC(t *testing.T) {


### PR DESCRIPTION
This changes will make the plugin use the `subscription_id` at the root even when using the `cli` auth mode

2 packer build were done to test the feature:
```hcl
packer {
  required_plugins {
    azure = {
      source  = "github.com/hashicorp/azure"
      version = "~> 2"
    }
  }
}

source "azure-arm" "ubuntu" {
  use_azure_cli_auth = true

  # subscription_id = "eeb6d260-e6c0-4ec6-83e0-492c8272798c"

  managed_image_name                = "ubuntu-20-04-{{timestamp}}"
  managed_image_resource_group_name = "packer_test"

  os_type         = "Linux"
  image_publisher = "Canonical"
  image_offer     = "0001-com-ubuntu-server-focal"
  image_sku       = "20_04-lts"

  location = "East US"
  vm_size  = "Standard_DS2_v2"

  azure_tags = {
    Environment = "Dev"
    Created_By  = "Packer"
  }
}

build {
  sources = ["source.azure-arm.ubuntu"]

  provisioner "shell" {
    inline = [
      "echo 'Installing updates...'",
      "sudo apt-get update",
      "sudo apt-get upgrade -y",
      "sudo apt-get install -y nginx",
      "echo 'Installation complete'"
    ]
  }
}

```
and ...
```hcl
packer {
  required_plugins {
    azure = {
      source  = "github.com/hashicorp/azure"
      version = "~> 2"
    }
  }
}

source "azure-arm" "ubuntu" {
  use_azure_cli_auth = true

  subscription_id = "eeb6d260-e6c0-4ec6-83e0-492c8272798c"

  managed_image_name                = "ubuntu-20-04-{{timestamp}}"
  managed_image_resource_group_name = "packer_test"

  os_type         = "Linux"
  image_publisher = "Canonical"
  image_offer     = "0001-com-ubuntu-server-focal"
  image_sku       = "20_04-lts"

  location = "East US"
  vm_size  = "Standard_DS2_v2"

  azure_tags = {
    Environment = "Dev"
    Created_By  = "Packer"
  }
}

build {
  sources = ["source.azure-arm.ubuntu"]

  provisioner "shell" {
    inline = [
      "echo 'Installing updates...'",
      "sudo apt-get update",
      "sudo apt-get upgrade -y",
      "sudo apt-get install -y nginx",
      "echo 'Installation complete'"
    ]
  }
}

```

both build were successful and we have both images in respective `subscription`

![image](https://github.com/user-attachments/assets/0ef6ba89-8c92-40a7-b22f-061226936f80)

![image](https://github.com/user-attachments/assets/4b631409-5953-4d3f-bcc5-9515bb98ab07)

Closes #461 
