### PR TITLE
Clearly log result of failing to get the source name for SIG-sourced builds.

### DIFF
--- a/builder/azure/arm/step_get_source_image_name.go
+++ b/builder/azure/arm/step_get_source_image_name.go
@@ -56,7 +56,7 @@ func (s *StepGetSourceImageName) Run(ctx context.Context, state multistep.StateB
 
 		image, err := s.getGalleryVersion(ctx)
 		if err != nil {
-			log.Println("[TRACE] unable to derive managed image URL for shared gallery version image")
+			s.say(fmt.Sprintf("Failed to fetch source gallery image from Azure API, HCP Packer will not be able to track the ancestry of this build: %s", err.Error()))
 			s.GeneratedData.Put("SourceImageName", "ERR_SOURCE_IMAGE_NAME_NOT_FOUND")
 			return multistep.ActionContinue
 		}


### PR DESCRIPTION
A user reported issues with HCP Packer ancestry, they didn't know the issue was caused by the Azure API because the plugin doesn't make it clear what will result from being unable to set the source image name

To make this clearer that this is an actual error which may be a plugin bug, or user configuration error, we want to actually log the Azure API error.