### PR TITLE
 Clearly log result of unexpected Azure payloads when fetching a source image name on SIG-sourced builds

### DIFF
--- a/builder/azure/arm/step_get_source_image_name.go
+++ b/builder/azure/arm/step_get_source_image_name.go
@@ -85,6 +85,7 @@ func (s *StepGetSourceImageName) Run(ctx context.Context, state multistep.StateB
 
 		}
 
+		s.say("Received unexpected response from Azure API, HCP Packer will not be able to track the ancestry of this build.")
 		log.Println("[TRACE] unable to identify the source image for provided gallery image version")
 		s.GeneratedData.Put("SourceImageName", "ERR_SOURCE_IMAGE_NAME_NOT_FOUND")
 		return multistep.ActionContinue


### PR DESCRIPTION
Similar to https://github.com/hashicorp/packer-plugin-azure/pull/476, I just realized this error, which is very unlikely to be thrown, could be the cause of the users error, so just in case I'll make this clearer too