### PR TITLE
fix: Handle checking for SIG-sourced parent when Azure API doesn't return Storage Profile

### DIFF
--- a/builder/azure/arm/step_get_source_image_name.go
+++ b/builder/azure/arm/step_get_source_image_name.go
@@ -76,13 +76,13 @@ func (s *StepGetSourceImageName) Run(ctx context.Context, state multistep.StateB
 				s.say(fmt.Sprintf(" -> SourceImageName: '%s'", parentSourceID))
 				s.GeneratedData.Put("SourceImageName", parentSourceID)
 				return multistep.ActionContinue
-			} else {
-				// If the Gallery Image Version was not sourced from a Managed Image, that means it was captured directly from a VM, so we just use the gallery ID itself as the source image
-				s.say(fmt.Sprintf(" -> SourceImageName: '%s'", *image.Id))
-				s.GeneratedData.Put("SourceImageName", *image.Id)
-				return multistep.ActionContinue
 			}
-
+		}
+		// If the Gallery Image Version was not sourced from a Managed Image, that means it was captured directly from a VM, so we just use the gallery ID itself as the source image
+		if image.Id != nil {
+			s.say(fmt.Sprintf(" -> SourceImageName: '%s'", *image.Id))
+			s.GeneratedData.Put("SourceImageName", *image.Id)
+			return multistep.ActionContinue
 		}
 
 		s.say("Received unexpected response from Azure API, HCP Packer will not be able to track the ancestry of this build.")


### PR DESCRIPTION
The step for getting the source name was added a few years back to fetch the parent image ID for HCP Packer Ancestry.  You can create a SIG image with either a managed image or a virtual machine, if you create it with a managed image, this plugin sends a different source image ID to correctly track the ancestry (since this type of build is stored by a managed image ID, and not its SIG ID).  

The way this logic worked before was that it looked for the fetch the Gallery Image Version of the parent SIG, and check its Storage Profile ID to see if it was a managed image build, if not it would assume VM built and set the ID, the problem however is that inconsistently Azure sometimes doesn't return the Storage Profile, I was never able to reproduce this myself but we got a bug report internally describing this, and customer support was able to verify the behavior.  It is unclear why this happens, but we see several cases of this when examining HCP Packer.

To fix this I simply made the logic a bit more graceful, so that if we don't have a storage profile, we check if we have an image ID we can use as the parent image ID.