### PR TITLE
Allow parent SIG images to referenced by their ID

### DIFF
--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -634,6 +634,8 @@ The shared_image_gallery block is available for building a new image from a priv
 
 <!-- Code generated from the comments of the SharedImageGallery struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
 
+- `id` (string) - ID
+
 - `subscription` (string) - Subscription
 
 - `resource_group` (string) - Resource Group

--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -154,9 +154,9 @@ Providing `temp_resource_group_name` or `location` in combination with
 
 - `shared_image_gallery` (SharedImageGallery) - Use a [Shared Gallery
   image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)
-  as the source for this build. *VHD targets are incompatible with this
-  build type* - the target must be a *Managed Image*. When using shared_image_gallery as a source, image_publisher,
-  image_offer, image_sku, image_version, and custom_managed_image_name should not be set.
+  as the source for this build.
+  *VHD targets are incompatible with this build type*
+  When using shared_image_gallery as a source, image_publisher, image_offer, image_sku, image_version, and custom_managed_image_name should not be set.
   
   In JSON
   ```json
@@ -167,8 +167,6 @@ Providing `temp_resource_group_name` or `location` in combination with
       "image_name": "ImageName",
       "image_version": "1.0.0",
   }
-  "managed_image_name": "TargetImageName",
-  "managed_image_resource_group_name": "TargetResourceGroup"
   ```
   In HCL2
   ```hcl
@@ -179,50 +177,9 @@ Providing `temp_resource_group_name` or `location` in combination with
       image_name = "ImageName"
       image_version = "1.0.0"
   }
-  managed_image_name = "TargetImageName"
-  managed_image_resource_group_name = "TargetResourceGroup"
   ```
 
-- `shared_image_gallery_destination` (SharedImageGalleryDestination) - The name of the Shared Image Gallery under which the managed image will be published as Shared Gallery Image version.
-  
-  Following is an example.
-  
-  In JSON
-  ```json
-  "shared_image_gallery_destination": {
-      "subscription": "00000000-0000-0000-0000-00000000000",
-      "resource_group": "ResourceGroup",
-      "gallery_name": "GalleryName",
-      "image_name": "ImageName",
-      "image_version": "1.0.0",
-      "replication_regions": ["regionA", "regionB", "regionC"],
-      "storage_account_type": "Standard_LRS"
-  }
-  "managed_image_name": "TargetImageName",
-  "managed_image_resource_group_name": "TargetResourceGroup"
-  ```
-  In HCL2
-  ```hcl
-  shared_image_gallery_destination {
-      subscription = "00000000-0000-0000-0000-00000000000"
-      resource_group = "ResourceGroup"
-      gallery_name = "GalleryName"
-      image_name = "ImageName"
-      image_version = "1.0.0"
-      storage_account_type = "Standard_LRS"
-      target_region {
-        name = "regionA"
-      }
-      target_region {
-        name = "regionB"
-      }
-      target_region {
-        name = "regionC"
-      }
-  }
-  managed_image_name = "TargetImageName"
-  managed_image_resource_group_name = "TargetResourceGroup"
-  ```
+- `shared_image_gallery_destination` (SharedImageGalleryDestination) - Shared Gallery Destination
 
 - `shared_image_gallery_timeout` (duration string | ex: "1h5m2s") - How long to wait for an image to be published to the shared image
   gallery before timing out. If your Packer build is failing on the
@@ -634,7 +591,9 @@ The shared_image_gallery block is available for building a new image from a priv
 
 <!-- Code generated from the comments of the SharedImageGallery struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
 
-- `id` (string) - ID
+- `id` (string) - ID of the Shared Image Gallery used as a base image in the build, this field is useful when using HCP Packer ancestry
+  If this field is set, no other fields in the SharedImageGallery block can be set
+  As those other fields simply build the reference ID
 
 - `subscription` (string) - Subscription
 

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -329,11 +329,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		}
 	}
 	if b.config.SharedGallery.ID != "" {
-		acg := b.config.getSharedImageGalleryObjectFromId()
-		if acg == nil {
+		sigID := b.config.getSharedImageGalleryObjectFromId()
+		if sigID == nil {
+			// The SIG ID should have already been validated at this point
 			return nil, errors.New("failed to parse Shared Image Gallery object from ID, this is always a Packer Azure plugin bug")
 		}
-		sourceImageSpecialized, err = isImageSpecialized(&azureClient.GalleryImagesClient, builderPollingContext, *b.config.getSharedImageGalleryObjectFromId())
+		sourceImageSpecialized, err = isImageSpecialized(&azureClient.GalleryImagesClient, builderPollingContext, *sigID)
 		if err != nil {
 			return nil, err
 		}

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -81,6 +81,9 @@ type PlanInformation struct {
 }
 
 type SharedImageGallery struct {
+	// ID of the Shared Image Gallery used as a base image in the build, this field is useful when using HCP Packer ancestry
+	// If this field is set, no other fields in the SharedImageGallery block can be set
+	// As those other fields simply build the reference ID
 	ID            string `mapstructure:"id"`
 	Subscription  string `mapstructure:"subscription"`
 	ResourceGroup string `mapstructure:"resource_group"`
@@ -183,9 +186,9 @@ type Config struct {
 	CaptureContainerName string `mapstructure:"capture_container_name"`
 	// Use a [Shared Gallery
 	// image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)
-	// as the source for this build. *VHD targets are incompatible with this
-	// build type* - the target must be a *Managed Image*. When using shared_image_gallery as a source, image_publisher,
-	// image_offer, image_sku, image_version, and custom_managed_image_name should not be set.
+	// as the source for this build.
+	// *VHD targets are incompatible with this build type*
+	// When using shared_image_gallery as a source, image_publisher, image_offer, image_sku, image_version, and custom_managed_image_name should not be set.
 	//
 	// In JSON
 	// ```json
@@ -196,8 +199,6 @@ type Config struct {
 	//     "image_name": "ImageName",
 	//     "image_version": "1.0.0",
 	// }
-	// "managed_image_name": "TargetImageName",
-	// "managed_image_resource_group_name": "TargetResourceGroup"
 	// ```
 	// In HCL2
 	// ```hcl
@@ -208,8 +209,6 @@ type Config struct {
 	//     image_name = "ImageName"
 	//     image_version = "1.0.0"
 	// }
-	// managed_image_name = "TargetImageName"
-	// managed_image_resource_group_name = "TargetResourceGroup"
 	// ```
 	SharedGallery SharedImageGallery `mapstructure:"shared_image_gallery" required:"false"`
 	// The name of the Shared Image Gallery under which the managed image will be published as Shared Gallery Image version.
@@ -227,8 +226,6 @@ type Config struct {
 	//     "replication_regions": ["regionA", "regionB", "regionC"],
 	//     "storage_account_type": "Standard_LRS"
 	// }
-	// "managed_image_name": "TargetImageName",
-	// "managed_image_resource_group_name": "TargetResourceGroup"
 	// ```
 	// In HCL2
 	// ```hcl
@@ -249,9 +246,9 @@ type Config struct {
 	//       name = "regionC"
 	//     }
 	// }
-	// managed_image_name = "TargetImageName"
-	// managed_image_resource_group_name = "TargetResourceGroup"
 	// ```
+	// A managed image target can also be set when using a shared image gallery destination
+
 	SharedGalleryDestination SharedImageGalleryDestination `mapstructure:"shared_image_gallery_destination"`
 	// How long to wait for an image to be published to the shared image
 	// gallery before timing out. If your Packer build is failing on the

--- a/builder/azure/arm/config.hcl2spec.go
+++ b/builder/azure/arm/config.hcl2spec.go
@@ -338,6 +338,7 @@ func (*FlatPlanInformation) HCL2Spec() map[string]hcldec.Spec {
 // FlatSharedImageGallery is an auto-generated flat version of SharedImageGallery.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatSharedImageGallery struct {
+	ID                         *string `mapstructure:"id" cty:"id" hcl:"id"`
 	Subscription               *string `mapstructure:"subscription" cty:"subscription" hcl:"subscription"`
 	ResourceGroup              *string `mapstructure:"resource_group" cty:"resource_group" hcl:"resource_group"`
 	GalleryName                *string `mapstructure:"gallery_name" cty:"gallery_name" hcl:"gallery_name"`
@@ -359,6 +360,7 @@ func (*SharedImageGallery) FlatMapstructure() interface{ HCL2Spec() map[string]h
 // The decoded values from this spec will then be applied to a FlatSharedImageGallery.
 func (*FlatSharedImageGallery) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
+		"id":                             &hcldec.AttrSpec{Name: "id", Type: cty.String, Required: false},
 		"subscription":                   &hcldec.AttrSpec{Name: "subscription", Type: cty.String, Required: false},
 		"resource_group":                 &hcldec.AttrSpec{Name: "resource_group", Type: cty.String, Required: false},
 		"gallery_name":                   &hcldec.AttrSpec{Name: "gallery_name", Type: cty.String, Required: false},

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -3683,3 +3683,49 @@ func TestConfigShouldAcceptSigID(t *testing.T) {
 		t.Fatalf("Unexpected err %s", err)
 	}
 }
+
+func TestConfigShouldParseValidSigID(t *testing.T) {
+	cfg := &Config{}
+	cfg.SharedGallery = SharedImageGallery{
+		ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Compute/galleries/myGallery/images/myImageDefinition/versions/1.0.0",
+	}
+	sigObject := cfg.getSharedImageGalleryObjectFromId()
+	if sigObject == nil {
+		t.Fatalf("getSharedImageGalleryObjectFromId did not parse valid SIG ID")
+	}
+
+	expectedSigObject := &SharedImageGallery{
+		Subscription:  "00000000-0000-0000-0000-000000000000",
+		ResourceGroup: "myResourceGroup",
+		GalleryName:   "myGallery",
+		ImageName:     "myImageDefinition",
+		ImageVersion:  "1.0.0",
+	}
+
+	if diff := cmp.Diff(expectedSigObject, sigObject); diff != "" {
+		t.Fatalf("unexpected diff %s", diff)
+	}
+}
+
+func TestConfigShouldntParseInvalidSigIDs(t *testing.T) {
+	cfg := &Config{}
+	cfg.SharedGallery = SharedImageGallery{
+		ID: "/bufo/some-bad-id",
+	}
+	sigObject := cfg.getSharedImageGalleryObjectFromId()
+	if sigObject != nil {
+		t.Fatalf("getSharedImageGalleryObjectFromId unexpectedly parsed invalid ID")
+	}
+
+	cfg.SharedGallery = SharedImageGallery{}
+	sigObject = cfg.getSharedImageGalleryObjectFromId()
+	if sigObject != nil {
+		t.Fatalf("getSharedImageGalleryObjectFromId unexpectedly parsed invalid ID")
+	}
+
+	cfg = &Config{}
+	sigObject = cfg.getSharedImageGalleryObjectFromId()
+	if sigObject != nil {
+		t.Fatalf("getSharedImageGalleryObjectFromId unexpectedly parsed invalid ID")
+	}
+}

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -3547,3 +3547,139 @@ func TestConfigShouldAcceptValidIPSkus(t *testing.T) {
 		t.Fatalf("Expected standard ip sku to be normalized to %s, but was %s", publicipaddresses.PublicIPAddressSkuNameBasic, basicConfig["public_ip_sku"])
 	}
 }
+
+func TestConfigShouldRejectSIGIDWhenSIGNameSet(t *testing.T) {
+	config := map[string]interface{}{
+		"subscription_id":        "ignore",
+		"os_type":                constants.Target_Linux,
+		"communicator":           "none",
+		"location":               "ignore",
+		"disk_encryption_set_id": "ignore",
+		"shared_image_gallery": map[string]interface{}{
+			"id":         "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Compute/galleries/myGallery/images/myImageDefinition/versions/1.0.0",
+			"image_name": "blorp",
+		},
+		"shared_image_gallery_destination": map[string]interface{}{
+			"resource_group": "ignore",
+			"gallery_name":   "ignore",
+			"image_name":     "ignore",
+			"image_version":  "1.0.1",
+		},
+	}
+	var cfg Config
+	_, err := cfg.Prepare(config, getPackerConfiguration())
+	if err == nil {
+		t.Fatal("Expected config to reject but didn't")
+	}
+	if !strings.Contains(err.Error(), "When setting shared_image_gallery.id, shared_image_gallery.image_name must not be specified") {
+		t.Fatalf("Unexpected err %s", err)
+	}
+}
+
+func TestConfigShouldRejectSIGIDWhenSIGVersionSet(t *testing.T) {
+	config := map[string]interface{}{
+		"subscription_id":        "ignore",
+		"os_type":                constants.Target_Linux,
+		"communicator":           "none",
+		"location":               "ignore",
+		"disk_encryption_set_id": "ignore",
+		"shared_image_gallery": map[string]interface{}{
+			"id":            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Compute/galleries/myGallery/images/myImageDefinition/versions/1.0.0",
+			"image_version": "1.0.1",
+		},
+		"shared_image_gallery_destination": map[string]interface{}{
+			"resource_group": "ignore",
+			"gallery_name":   "ignore",
+			"image_name":     "ignore",
+			"image_version":  "1.0.1",
+		},
+	}
+	var cfg Config
+	_, err := cfg.Prepare(config, getPackerConfiguration())
+	if err == nil {
+		t.Fatal("Expected config to reject but didn't")
+	}
+	if !strings.Contains(err.Error(), "When setting shared_image_gallery.id, shared_image_gallery.image_version must not be specified") {
+		t.Fatalf("Unexpected err %s", err)
+	}
+}
+
+func TestConfigShouldRejectSIGIDWhenSIGSubscriptionSet(t *testing.T) {
+	config := map[string]interface{}{
+		"subscription_id":        "ignore",
+		"os_type":                constants.Target_Linux,
+		"communicator":           "none",
+		"location":               "ignore",
+		"disk_encryption_set_id": "ignore",
+		"shared_image_gallery": map[string]interface{}{
+			"id":           "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Compute/galleries/myGallery/images/myImageDefinition/versions/1.0.0",
+			"subscription": "whatever",
+		},
+		"shared_image_gallery_destination": map[string]interface{}{
+			"resource_group": "ignore",
+			"gallery_name":   "ignore",
+			"image_name":     "ignore",
+			"image_version":  "1.0.1",
+		},
+	}
+	var cfg Config
+	_, err := cfg.Prepare(config, getPackerConfiguration())
+	if err == nil {
+		t.Fatal("Expected config to reject but didn't")
+	}
+	if !strings.Contains(err.Error(), "When setting shared_image_gallery.id, shared_image_gallery.subscription must not be specified") {
+		t.Fatalf("Unexpected err %s", err)
+	}
+}
+
+func TestConfigShouldRejectSIGIDWhenSIGrgSet(t *testing.T) {
+	config := map[string]interface{}{
+		"subscription_id":        "ignore",
+		"os_type":                constants.Target_Linux,
+		"communicator":           "none",
+		"location":               "ignore",
+		"disk_encryption_set_id": "ignore",
+		"shared_image_gallery": map[string]interface{}{
+			"id":             "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Compute/galleries/myGallery/images/myImageDefinition/versions/1.0.0",
+			"resource_group": "ignore",
+		},
+		"shared_image_gallery_destination": map[string]interface{}{
+			"resource_group": "ignore",
+			"gallery_name":   "ignore",
+			"image_name":     "ignore",
+			"image_version":  "1.0.1",
+		},
+	}
+	var cfg Config
+	_, err := cfg.Prepare(config, getPackerConfiguration())
+	if err == nil {
+		t.Fatal("Expected config to reject but didn't")
+	}
+	if !strings.Contains(err.Error(), "When setting shared_image_gallery.id, shared_image_gallery.resource_group must not be specified") {
+		t.Fatalf("Unexpected err %s", err)
+	}
+}
+
+func TestConfigShouldAcceptSigID(t *testing.T) {
+	config := map[string]interface{}{
+		"subscription_id":        "ignore",
+		"os_type":                constants.Target_Linux,
+		"communicator":           "none",
+		"location":               "ignore",
+		"disk_encryption_set_id": "ignore",
+		"shared_image_gallery": map[string]interface{}{
+			"id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Compute/galleries/myGallery/images/myImageDefinition/versions/1.0.0",
+		},
+		"shared_image_gallery_destination": map[string]interface{}{
+			"resource_group": "ignore",
+			"gallery_name":   "ignore",
+			"image_name":     "ignore",
+			"image_version":  "1.0.1",
+		},
+	}
+	var cfg Config
+	_, err := cfg.Prepare(config, getPackerConfiguration())
+	if err != nil {
+		t.Fatalf("Unexpected err %s", err)
+	}
+}

--- a/builder/azure/arm/step_get_source_image_name_test.go
+++ b/builder/azure/arm/step_get_source_image_name_test.go
@@ -154,7 +154,7 @@ func TestStepGetSourceImageName(t *testing.T) {
 					error:         func(e error) {},
 					getGalleryVersion: func(ctx context.Context, sig SharedImageGallery) (*galleryimageversions.GalleryImageVersion, error) {
 						if diff := cmp.Diff(sig, *tt.expectedSharedImageGallery); diff != "" {
-							return nil, fmt.Errorf(diff)
+							return nil, fmt.Errorf("%s", diff)
 						}
 						return tt.mockedGalleryImage, nil
 					},

--- a/builder/azure/arm/template_factory.go
+++ b/builder/azure/arm/template_factory.go
@@ -179,6 +179,12 @@ func GetVirtualMachineTemplateBuilder(config *Config) (*template.TemplateBuilder
 		if err != nil {
 			return nil, err
 		}
+	} else if config.SharedGallery.ID != "" {
+		imageID := config.SharedGallery.ID
+		err = builder.SetSharedGalleryImage(config.Location, imageID, config.diskCachingType)
+		if err != nil {
+			return nil, err
+		}
 	} else if config.SharedGallery.CommunityGalleryImageId != "" {
 		imageID := config.SharedGallery.CommunityGalleryImageId
 

--- a/builder/azure/arm/testdata/child_from_specialized_hcp_ancestry.pkr.hcl
+++ b/builder/azure/arm/testdata/child_from_specialized_hcp_ancestry.pkr.hcl
@@ -1,37 +1,67 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
+variable "subscription" {
+  default   = "${env("ARM_SUBSCRIPTION_ID")}"
+  type      = string
+  sensitive = true
+}
+
 variable "ssh_private_key_location" {
   default = "${env("ARM_SSH_PRIVATE_KEY_FILE")}"
   type    = string
 }
+variable "hcp_packer_bucket_name" {
+  default = "${env("HCP_PACKER_BUCKET_NAME")}"
+  type    = string
+}
+
 variable "resource_group_name" {
   default = "${env("ARM_RESOURCE_GROUP_NAME")}"
   type    = string
 }
+
 variable "resource_prefix" {
   default = "${env("ARM_RESOURCE_PREFIX")}"
   type    = string
 }
+
+data "hcp-packer-version" "hardened-source" {
+  bucket_name  = var.hcp_packer_bucket_name
+  channel_name = "latest"
+}
+
+data "hcp-packer-artifact" "parent" {
+  bucket_name  = var.hcp_packer_bucket_name
+  version_fingerprint = "${data.hcp-packer-version.hardened-source.fingerprint}"
+  platform            = "azure"
+  region              = "South Central US"
+}
+
+
 source "azure-arm" "linux-sig" {
-  image_offer          = "0001-com-ubuntu-server-jammy"
-  image_publisher      = "canonical"
-  image_sku            = "22_04-lts-arm64"
   use_azure_cli_auth   = true
   location             = "South Central US"
   vm_size              = "Standard_D4ps_v5"
   ssh_username         = "packer"
   ssh_private_key_file = var.ssh_private_key_location
   communicator         = "ssh"
+  shared_image_gallery {
+    id = data.hcp-packer-artifact.parent.external_identifier 
+  }
   shared_image_gallery_destination {
+    image_version           = "1.0.4"
     image_name              = "${var.resource_prefix}-arm-linux-specialized-sig"
     gallery_name            = "${var.resource_prefix}_acctestgallery"
-    image_version           = "1.0.0"
     resource_group          = var.resource_group_name
     specialized             = true
     use_shallow_replication = true
   }
 
   os_type = "Linux"
+}
+
+hcp_packer_registry {
+  bucket_name = "child"
 }
 
 build {

--- a/builder/azure/arm/testdata/example_hcp_ancestry.pkr.hcl
+++ b/builder/azure/arm/testdata/example_hcp_ancestry.pkr.hcl
@@ -1,5 +1,6 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
+
 variable "subscription" {
   default   = "${env("ARM_SUBSCRIPTION_ID")}"
   type      = string

--- a/docs-partials/builder/azure/arm/Config-not-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-not-required.mdx
@@ -13,9 +13,9 @@
 
 - `shared_image_gallery` (SharedImageGallery) - Use a [Shared Gallery
   image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)
-  as the source for this build. *VHD targets are incompatible with this
-  build type* - the target must be a *Managed Image*. When using shared_image_gallery as a source, image_publisher,
-  image_offer, image_sku, image_version, and custom_managed_image_name should not be set.
+  as the source for this build.
+  *VHD targets are incompatible with this build type*
+  When using shared_image_gallery as a source, image_publisher, image_offer, image_sku, image_version, and custom_managed_image_name should not be set.
   
   In JSON
   ```json
@@ -26,8 +26,6 @@
       "image_name": "ImageName",
       "image_version": "1.0.0",
   }
-  "managed_image_name": "TargetImageName",
-  "managed_image_resource_group_name": "TargetResourceGroup"
   ```
   In HCL2
   ```hcl
@@ -38,50 +36,9 @@
       image_name = "ImageName"
       image_version = "1.0.0"
   }
-  managed_image_name = "TargetImageName"
-  managed_image_resource_group_name = "TargetResourceGroup"
   ```
 
-- `shared_image_gallery_destination` (SharedImageGalleryDestination) - The name of the Shared Image Gallery under which the managed image will be published as Shared Gallery Image version.
-  
-  Following is an example.
-  
-  In JSON
-  ```json
-  "shared_image_gallery_destination": {
-      "subscription": "00000000-0000-0000-0000-00000000000",
-      "resource_group": "ResourceGroup",
-      "gallery_name": "GalleryName",
-      "image_name": "ImageName",
-      "image_version": "1.0.0",
-      "replication_regions": ["regionA", "regionB", "regionC"],
-      "storage_account_type": "Standard_LRS"
-  }
-  "managed_image_name": "TargetImageName",
-  "managed_image_resource_group_name": "TargetResourceGroup"
-  ```
-  In HCL2
-  ```hcl
-  shared_image_gallery_destination {
-      subscription = "00000000-0000-0000-0000-00000000000"
-      resource_group = "ResourceGroup"
-      gallery_name = "GalleryName"
-      image_name = "ImageName"
-      image_version = "1.0.0"
-      storage_account_type = "Standard_LRS"
-      target_region {
-        name = "regionA"
-      }
-      target_region {
-        name = "regionB"
-      }
-      target_region {
-        name = "regionC"
-      }
-  }
-  managed_image_name = "TargetImageName"
-  managed_image_resource_group_name = "TargetResourceGroup"
-  ```
+- `shared_image_gallery_destination` (SharedImageGalleryDestination) - Shared Gallery Destination
 
 - `shared_image_gallery_timeout` (duration string | ex: "1h5m2s") - How long to wait for an image to be published to the shared image
   gallery before timing out. If your Packer build is failing on the

--- a/docs-partials/builder/azure/arm/SharedImageGallery-not-required.mdx
+++ b/docs-partials/builder/azure/arm/SharedImageGallery-not-required.mdx
@@ -1,6 +1,8 @@
 <!-- Code generated from the comments of the SharedImageGallery struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
 
-- `id` (string) - ID
+- `id` (string) - ID of the Shared Image Gallery used as a base image in the build, this field is useful when using HCP Packer ancestry
+  If this field is set, no other fields in the SharedImageGallery block can be set
+  As those other fields simply build the reference ID
 
 - `subscription` (string) - Subscription
 

--- a/docs-partials/builder/azure/arm/SharedImageGallery-not-required.mdx
+++ b/docs-partials/builder/azure/arm/SharedImageGallery-not-required.mdx
@@ -1,5 +1,7 @@
 <!-- Code generated from the comments of the SharedImageGallery struct in builder/azure/arm/config.go; DO NOT EDIT MANUALLY -->
 
+- `id` (string) - ID
+
 - `subscription` (string) - Subscription
 
 - `resource_group` (string) - Resource Group


### PR DESCRIPTION
Allow SIG base image to be specified by resource ID, this is specifically useful when using HCP Packer with its ancestry feature.

Prior to this PR you had to set a bunch of fields inside of the shared_image_gallery block to set the base image.  When using HCP Packer this looked like
```
 shared_image_gallery {
    subscription   = var.az_subscription_id
    resource_group = data.hcp-packer-artifact.example.labels.sig_resource_group
    gallery_name   = data.hcp-packer-artifact.example.labels.sig_name
    image_name     = data.hcp-packer-artifact.example.labels.sig_image_name
    image_version  = data.hcp-packer-artifact.example.labels.sig_image_version
  }
```

After this PR, you can 
```
 shared_image_gallery {
    id = data.hcp-packer-artifact.parent.external_identifier 
  }
 ```

This is an ask from last year that has a significant amount of thumbs up, and requests from users internally.

closes https://github.com/hashicorp/packer-plugin-azure/issues/431