### PR TITLE
Add temp resource names to Generated Data

### DIFF
--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -742,6 +742,22 @@ shared images the resulting name will point to the actual source used to create 
 
 - `TenantID` - The ID of the Azure Tenant where the build takes place.
 
+All of the following variables are temporary resource names that the plugin uses to build resources that are generally deleted at the end of a build.
+
+The presence of these variables does not mean these resources are created, they are just the names that are used for any temporary resources the builder creates. They are all randomly specified, but most can be overridden by builder fields.
+
+- `TempComputeName` - Virtual machine name
+- `TempNicName` - Network interface name
+- `TempOSDiskName` - OS Disk Name
+- `TempDataDiskName` - Data Disk Name
+- `TempDeploymentName` - ARM Deployment name
+- `TempVirtualNetworkName` - Virtual Network name
+- `TempKeyVaultName` - Key vault name
+- `TempResourceGroupName` - Resource Group Name, will be unset if a build resource group name is provided.
+- `TempNsgName` - Network security group name
+- `TempSubnetName` - Subnet name
+- `TempPublicIPAddressName` - Public IP Address name
+
 Usage example:
 
 **HCL2**
@@ -766,8 +782,19 @@ post-processor "manifest" {
     strip_path = true
     custom_data = {
         source_image_name = "${build.SourceImageName}"
-        tenant_id = "${build.TenantID}"
+	tenant_id = "${build.TenantID}"
         subscription_id = "${build.SubscriptionID}"
+        temp_deployment_name = "${build.TempDeploymentName}"
+        temp_compute_name = "${build.TempComputeName}"
+        temp_nic_name = "${build.TempNicName}"
+        temp_os_disk_name = "${build.TempOSDiskName}"
+        temp_data_disk_name = "${build.TempDataDiskName}"
+        temp_resource_group_name = "${build.TempResourceGroupName}"
+        temp_nsg_name = "${build.TempNsgName}"
+        temp_key_vault_name = "${build.TempKeyVaultName}"
+        temp_subnet_name = "${build.TempSubnetName}"
+        temp_virtual_network_name = "${build.TempVirtualNetworkName}"
+        temp_public_ip_address_name = "${build.TempPublicIPAddressName}"
     }
 }
 ```
@@ -780,9 +807,20 @@ post-processor "manifest" {
     "output": "manifest.json",
     "strip_path": true,
     "custom_data": {
-        "source_image_name": "{{ build `SourceImageName` }}",
-        "tenant_id": "{{ build `TenantID` }}",
-        "subscription_id": "{{ build `SubscriptionID` }}"
+    	"source_image_name": "{{ build `SourceImageName` }}",
+    	"tenant_id": "{{ build `TenantID` }}",
+    	"subscription_id": "{{ build `SubscriptionID` }}",
+    	"temp_deployment_name": "{{ build `TempDeploymentName`}}",
+	"temp_compute_name": "{{ build `TempComputeName`}}",
+	"temp_nic_name": "{{ build `TempNicName`}}",
+	"temp_os_disk_name": "{{ build `TempOSDiskName`}}",
+	"temp_data_disk_name": "{{ build `TempDataDiskName`}}",
+	"temp_resource_group_name": "{{ build `TempResourceGroupName`}}",
+	"temp_nsg_name": "{{ build `TempNsgName`}}",
+	"temp_key_vault_name": "{{ build `TempKeyVaultName`}}",
+	"temp_subnet_name": "{{ build `TempSubnetName`}}",
+	"temp_virtual_network_name": "{{ build `TempVirtualNetworkName`}}",
+	"temp_public_ip_address_name": "{{ build `TempPublicIPAddressName`}}"
     }
   }
 ]

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -59,7 +59,22 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	b.setTemplateParameters(b.stateBag)
 	b.setImageParameters(b.stateBag)
 
-	generatedDataKeys := []string{"SourceImageName", "TenantID", "SubscriptionID"}
+	generatedDataKeys := []string{
+		"SourceImageName",
+		"TenantID",
+		"SubscriptionID",
+		"TempDeploymentName",
+		"TempComputeName",
+		"TempNicName",
+		"TempOSDiskName",
+		"TempResourceGroupName",
+		"TempNsgName",
+		"TempKeyVaultName",
+		"TempSubnetName",
+		"TempDataDiskName",
+		"TempVirtualNetworkName",
+		"TempPublicIPAddressName",
+	}
 
 	return generatedDataKeys, warnings, nil
 }

--- a/builder/azure/arm/step_set_generated_data.go
+++ b/builder/azure/arm/step_set_generated_data.go
@@ -19,6 +19,17 @@ func (s *StepSetGeneratedData) Run(ctx context.Context, state multistep.StateBag
 
 	s.GeneratedData.Put("TenantID", s.Config.ClientConfig.TenantID)
 	s.GeneratedData.Put("SubscriptionID", s.Config.ClientConfig.SubscriptionID)
+	s.GeneratedData.Put("TempComputeName", s.Config.tmpComputeName)
+	s.GeneratedData.Put("TempNicName", s.Config.tmpNicName)
+	s.GeneratedData.Put("TempOSDiskName", s.Config.tmpOSDiskName)
+	s.GeneratedData.Put("TempDataDiskName", s.Config.tmpDataDiskName)
+	s.GeneratedData.Put("TempDeploymentName", s.Config.tmpDeploymentName)
+	s.GeneratedData.Put("TempVirtualNetworkName", s.Config.tmpVirtualNetworkName)
+	s.GeneratedData.Put("TempKeyVaultName", s.Config.tmpKeyVaultName)
+	s.GeneratedData.Put("TempResourceGroupName", s.Config.tmpResourceGroupName)
+	s.GeneratedData.Put("TempNsgName", s.Config.tmpNsgName)
+	s.GeneratedData.Put("TempSubnetName", s.Config.tmpSubnetName)
+	s.GeneratedData.Put("TempPublicIPAddressName", s.Config.tmpPublicIPAddressName)
 	return multistep.ActionContinue
 }
 

--- a/docs/builders/arm.mdx
+++ b/docs/builders/arm.mdx
@@ -154,6 +154,22 @@ shared images the resulting name will point to the actual source used to create 
 
 - `TenantID` - The ID of the Azure Tenant where the build takes place.
 
+All of the following variables are temporary resource names that the plugin uses to build resources that are generally deleted at the end of a build.
+
+The presence of these variables does not mean these resources are created, they are just the names that are used for any temporary resources the builder creates. They are all randomly specified, but most can be overridden by builder fields.
+
+- `TempComputeName` - Virtual machine name
+- `TempNicName` - Network interface name
+- `TempOSDiskName` - OS Disk Name
+- `TempDataDiskName` - Data Disk Name
+- `TempDeploymentName` - ARM Deployment name
+- `TempVirtualNetworkName` - Virtual Network name
+- `TempKeyVaultName` - Key vault name
+- `TempResourceGroupName` - Resource Group Name, will be unset if a build resource group name is provided.
+- `TempNsgName` - Network security group name
+- `TempSubnetName` - Subnet name
+- `TempPublicIPAddressName` - Public IP Address name
+
 Usage example:
 
 **HCL2**
@@ -178,8 +194,19 @@ post-processor "manifest" {
     strip_path = true
     custom_data = {
         source_image_name = "${build.SourceImageName}"
-        tenant_id = "${build.TenantID}"
+	tenant_id = "${build.TenantID}"
         subscription_id = "${build.SubscriptionID}"
+        temp_deployment_name = "${build.TempDeploymentName}"
+        temp_compute_name = "${build.TempComputeName}"
+        temp_nic_name = "${build.TempNicName}"
+        temp_os_disk_name = "${build.TempOSDiskName}"
+        temp_data_disk_name = "${build.TempDataDiskName}"
+        temp_resource_group_name = "${build.TempResourceGroupName}"
+        temp_nsg_name = "${build.TempNsgName}"
+        temp_key_vault_name = "${build.TempKeyVaultName}"
+        temp_subnet_name = "${build.TempSubnetName}"
+        temp_virtual_network_name = "${build.TempVirtualNetworkName}"
+        temp_public_ip_address_name = "${build.TempPublicIPAddressName}"
     }
 }
 ```
@@ -192,9 +219,20 @@ post-processor "manifest" {
     "output": "manifest.json",
     "strip_path": true,
     "custom_data": {
-        "source_image_name": "{{ build `SourceImageName` }}",
-        "tenant_id": "{{ build `TenantID` }}",
-        "subscription_id": "{{ build `SubscriptionID` }}"
+    	"source_image_name": "{{ build `SourceImageName` }}",
+    	"tenant_id": "{{ build `TenantID` }}",
+    	"subscription_id": "{{ build `SubscriptionID` }}",
+    	"temp_deployment_name": "{{ build `TempDeploymentName`}}",
+	"temp_compute_name": "{{ build `TempComputeName`}}",
+	"temp_nic_name": "{{ build `TempNicName`}}",
+	"temp_os_disk_name": "{{ build `TempOSDiskName`}}",
+	"temp_data_disk_name": "{{ build `TempDataDiskName`}}",
+	"temp_resource_group_name": "{{ build `TempResourceGroupName`}}",
+	"temp_nsg_name": "{{ build `TempNsgName`}}",
+	"temp_key_vault_name": "{{ build `TempKeyVaultName`}}",
+	"temp_subnet_name": "{{ build `TempSubnetName`}}",
+	"temp_virtual_network_name": "{{ build `TempVirtualNetworkName`}}",
+	"temp_public_ip_address_name": "{{ build `TempPublicIPAddressName`}}"
     }
   }
 ]


### PR DESCRIPTION
Add temp resource names to ARM builder generated data.

Full list:

- `TempComputeName` - Virtual machine name
- `TempNicName` - Network interface name
- `TempOSDiskName` - OS Disk Name
- `TempDataDiskName` - Data Disk Name
- `TempDeploymentName` - ARM Deployment name
- `TempVirtualNetworkName` - Virtual Network name
- `TempKeyVaultName` - Key vault name
- `TempResourceGroupName` - Resource Group Name, will be unset if a build resource group name is provided.
- `TempNsgName` - Network security group name
- `TempSubnetName` - Subnet name
- `TempPublicIPAddressName` - Public IP Address name

Closes #369 