### PR TITLE
Disable DTL acceptance tests

### DIFF
--- a/builder/azure/dtl/builder_acc_test.go
+++ b/builder/azure/dtl/builder_acc_test.go
@@ -30,7 +30,12 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/acctest"
 )
 
+// DTL Tests were paused in April 2025 after the deprecation of Basic IP SKUs
+// This requires creating a network security group with either overly permissive ingress, or the expected clients IP
+// The complexity of maintaining this in CI is not worth the time currently when there are higher priority problems on the ARM builder, and DTL is very inactive
+
 func TestDTLBuilderAcc_ManagedDisk_Windows(t *testing.T) {
+	t.Skip()
 	t.Parallel()
 	common.CheckAcceptanceTestEnvVars(t, common.CheckAcceptanceTestEnvVarsParams{})
 	acctest.TestPlugin(t, &acctest.PluginTestCase{
@@ -48,6 +53,7 @@ func TestDTLBuilderAcc_ManagedDisk_Windows(t *testing.T) {
 	})
 }
 func TestDTLBuilderAcc_ManagedDisk_Linux_Artifacts(t *testing.T) {
+	t.Skip()
 	t.Parallel()
 	common.CheckAcceptanceTestEnvVars(t, common.CheckAcceptanceTestEnvVarsParams{})
 	acctest.TestPlugin(t, &acctest.PluginTestCase{

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -52,7 +52,8 @@ resource "azurerm_shared_image" "linux-sig" {
   }
 }
 
-## DTL Builder Resources
+/*
+## DTL Builder Resources - disabled
 
 resource "azurerm_dev_test_lab" "dtl" {
   name                = "${var.resource_prefix}-packer-acceptance-test"
@@ -68,3 +69,4 @@ resource "azurerm_dev_test_virtual_network" "vnet" {
     use_in_virtual_machine_creation = "Allow"
   }
 }
+*/


### PR DESCRIPTION
Dev Test Labs tests recently started failing after the April 1st removal of support for basic IP skus.  This is because Azure subnets without network security groups will now silently fail for labs.  Labs have very low usage in our internal telemetry (less than a percent, and we suspect a lot of this usage is from our internal runs of the acceptance tests, and not user usage).  There are very few user issues reported on DTL historically, and there is not much activity or blogs from Azure around this feature in a very long time. 

To get DTL tests to pass you must create a network security group that allows ingress from the runner's IP, or with very permissive rules, basic IPs behaved this way by default but this always had lax security implications.  Since both of these solutions have their costs and trade offs, and DTL is very under used, I think it is best to disable these two tests and focus developer resources on the builders with more user activity (ARM, chroot)

When I started working on the plugin a few years ago these tests were not being regularly run, so I do not feel like this