### PR TITLE
BUG: Fetching the Blob Endpoint for Deletion from Account

### DIFF
--- a/builder/azure/arm/azure_client.go
+++ b/builder/azure/arm/azure_client.go
@@ -235,6 +235,8 @@ func NewAzureClient(ctx context.Context, storageAccountName string, cloud *envir
 		if err != nil {
 			return nil, err
 		}
+		// Note: The client may be initialized with a default or temporary Base URI
+		// that is intended to be overridden with a service-specific endpoint later.
 		blobClient, err := giovanniBlobStorageSDK.NewWithBaseUri(fmt.Sprintf("https://%s.blob.core.windows.net", storageAccountName))
 		if err != nil {
 			return nil, err

--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -126,11 +126,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		b.config.PollingDurationTimeout,
 		authOptions,
 	)
-
-	ui.Message("ARM Client successfully created")
 	if err != nil {
 		return nil, err
 	}
+	ui.Message("ARM Client successfully created")
 
 	resolver := newResourceResolver(azureClient)
 	if err := resolver.Resolve(&b.config); err != nil {
@@ -197,7 +196,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		if err != nil {
 			return nil, err
 		}
-		b.config.storageAccountBlobEndpoint = *account.Properties.PrimaryEndpoints.Blob
+
+		blobPrimaryEndpoint := *account.Properties.PrimaryEndpoints.Blob
+		b.config.storageAccountBlobEndpoint = blobPrimaryEndpoint
+		// Remove trailing slash
+		azureClient.GiovanniBlobClient.Client.BaseUri = blobPrimaryEndpoint[:len(blobPrimaryEndpoint)-1]
+
 		if !equalLocation(account.Location, b.config.Location) {
 			return nil, fmt.Errorf("The storage account is located in %s, but the build will take place in %s. The locations must be identical", account.Location, b.config.Location)
 		}


### PR DESCRIPTION
The code uses a separate SDK client for the VHD deletion, where the blob endpoint is hardcoded as `.blob.core.windows.net`. This causes errors while deleting VHDs for a different cloud env.

This PR updates the blob endpoint with the one we get from the storage account properties, which is already being used to create a new artifact.

Closes #502