### PR TITLE
Updated code that validates managed_image_os_disk_snapshot_name and managed_image_data_disk_snapshot_prefix

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -68,8 +68,8 @@ var (
 	reCaptureNamePrefix    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_\-\.]{0,23}$`)
 	reManagedDiskName      = regexp.MustCompile(validManagedDiskName)
 	reResourceGroupName    = regexp.MustCompile(validResourceGroupNameRe)
-	reSnapshotName         = regexp.MustCompile(`^[A-Za-z0-9_]{1,79}$`)
-	reSnapshotPrefix       = regexp.MustCompile(`^[A-Za-z0-9_]{1,59}$`)
+	reSnapshotName         = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_\-\.]{0,78}[A-Za-z0-9_]$`)
+	reSnapshotPrefix       = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_\-\.]{0,58}[A-Za-z0-9_]$`)
 	reResourceNamePrefix   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]{0,9}$`)
 )
 
@@ -1628,14 +1628,14 @@ func assertManagedImageName(name, setting string) (bool, error) {
 
 func assertManagedImageOSDiskSnapshotName(name, setting string) (bool, error) {
 	if !isValidAzureName(reSnapshotName, name) {
-		return false, fmt.Errorf("The setting %s must only contain characters from a-z, A-Z, 0-9 and _ and the maximum length is 80 characters", setting)
+		return false, fmt.Errorf("The setting %s must begin with a letter or number, end with a letter, number or underscore and may contain only letters, numbers, underscores, periods, or hyphens. The maximum length is 80 characters", setting)
 	}
 	return true, nil
 }
 
 func assertManagedImageDataDiskSnapshotName(name, setting string) (bool, error) {
 	if !isValidAzureName(reSnapshotPrefix, name) {
-		return false, fmt.Errorf("The setting %s must only contain characters from a-z, A-Z, 0-9 and _ and the maximum length (excluding the prefix) is 60 characters", setting)
+		return false, fmt.Errorf("The setting %s must begin with a letter or number, end with a letter, number or underscore and may contain only letters, numbers, underscores, periods, or hyphens. The maximum length is 60 characters", setting)
 	}
 	return true, nil
 }

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -830,6 +830,9 @@ func TestConfigShouldRejectMalformedManagedImageOSDiskSnapshotName(t *testing.T)
 		"underscore_underscore",
 		"0leading_number",
 		"really_loooooooooooooooooooooooooooooooooooooooooooooooooong",
+		"01234567890123456789012345678901234567890123456789012345678901234567890123456789", // 80 characters
+		"MyImage2025-01-01",
+		"MyImage2025.01.01_",
 	}
 
 	for _, x := range wellFormedManagedImageOSDiskSnapshotName {
@@ -844,10 +847,12 @@ func TestConfigShouldRejectMalformedManagedImageOSDiskSnapshotName(t *testing.T)
 
 	malformedManagedImageOSDiskSnapshotName := []string{
 		"-leading-hyphen",
+		"_leading-underscore",
+		".leading-period",
 		"trailing-hyphen-",
 		"trailing-period.",
 		"punc-!@#$%^&*()_+-=-punc",
-		"really_looooooooooooooooooooooooooooooooooooooooooooooooooooooong_exceeding_80_char_limit",
+		"really_looooooooooooooooooooooooooooooooooooooooooooooong_exceeding_80_char_limit", // 81 characters
 	}
 
 	for _, x := range malformedManagedImageOSDiskSnapshotName {
@@ -882,6 +887,9 @@ func TestConfigShouldRejectMalformedManagedImageDataDiskSnapshotPrefix(t *testin
 		"underscore_underscore",
 		"0leading_number",
 		"less_than_sixty_characters",
+		"012345678901234567890123456789012345678901234567890123456789", // 60 characters
+		"MyImage2025-01-01",
+		"MyImage2025.01.01_",
 	}
 
 	for _, x := range wellFormedManagedImageDataDiskSnapshotPrefix {
@@ -896,10 +904,12 @@ func TestConfigShouldRejectMalformedManagedImageDataDiskSnapshotPrefix(t *testin
 
 	malformedManagedImageDataDiskSnapshotPrefix := []string{
 		"-leading-hyphen",
+		"_leading-underscore",
+		".leading-period",
 		"trailing-hyphen-",
 		"trailing-period.",
 		"punc-!@#$%^&*()_+-=-punc",
-		"really_looooooooooooooooooooooooooooooooooooooooooooooooooooooong_exceeding_60_char_limit",
+		"really_looooooooooooooooooooooooooong_exceeding_60_char_limit", // 61 characters
 	}
 
 	for _, x := range malformedManagedImageDataDiskSnapshotPrefix {


### PR DESCRIPTION
### Description
MyImage2025.01.01-snapshot is a perfectly valid snapshot name, but original code does not accept it. Original code does not allow to use dots in the snapshot name.

### Rollback Plan

### Changes to Security Controls
No

