### PR TITLE
Add SIG ID to output when SIG ID fails validation

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1285,7 +1285,7 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 	} else if c.SharedGallery.ID != "" {
 		sigIDRegex := regexp.MustCompile("/subscriptions/[^/]*/resourceGroups/[^/]*/providers/Microsoft.Compute/galleries/[^/]*/images/[^/]*/versions/[^/]*")
 		if !sigIDRegex.Match([]byte(c.SharedGallery.ID)) {
-			errs = packer.MultiErrorAppend(errs, fmt.Errorf("shared_image_gallery.id does not match expected format of '/subscriptions/(subscriptionid)/resourceGroups/(rg-name)/providers/Microsoft.Compute/galleries/(gallery-name)/images/image-name/versions/(version)"))
+			errs = packer.MultiErrorAppend(errs, fmt.Errorf("shared_image_gallery.id (%s) does not match expected format of '/subscriptions/(subscriptionid)/resourceGroups/(rg-name)/providers/Microsoft.Compute/galleries/(gallery-name)/images/image-name/versions/(version)", c.SharedGallery.ID))
 		}
 		if c.SharedGallery.Subscription != "" {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("When setting shared_image_gallery.id, shared_image_gallery.subscription must not be specified"))

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -3684,6 +3684,33 @@ func TestConfigShouldAcceptSigID(t *testing.T) {
 	}
 }
 
+func TestConfigShouldRejectInvalidSigID(t *testing.T) {
+	config := map[string]interface{}{
+		"subscription_id":        "ignore",
+		"os_type":                constants.Target_Linux,
+		"communicator":           "none",
+		"location":               "ignore",
+		"disk_encryption_set_id": "ignore",
+		"shared_image_gallery": map[string]interface{}{
+			"id": "coolranchdip",
+		},
+		"shared_image_gallery_destination": map[string]interface{}{
+			"resource_group": "ignore",
+			"gallery_name":   "ignore",
+			"image_name":     "ignore",
+			"image_version":  "1.0.1",
+		},
+	}
+	var cfg Config
+	_, err := cfg.Prepare(config, getPackerConfiguration())
+	if err == nil {
+		t.Fatalf("Config unexpectedly allowed invalid SIG ID")
+	}
+	expectedErrorMessage := "shared_image_gallery.id (coolranchdip) does not match expected format of '/subscriptions/(subscriptionid)/resourceGroups/(rg-name)/providers/Microsoft.Compute/galleries/(gallery-name)/images/image-name/versions/(version)"
+	if !strings.Contains(err.Error(), expectedErrorMessage) {
+		t.Fatalf("Unexpected error (%s), expected (%s)", err.Error(), expectedErrorMessage)
+	}
+}
 func TestConfigShouldParseValidSigID(t *testing.T) {
 	cfg := &Config{}
 	cfg.SharedGallery = SharedImageGallery{


### PR DESCRIPTION
Related to https://github.com/hashicorp/packer-plugin-azure/issues/529

Customer is having an issue where a hard coded SIG ID works and passes validation, but referencing it from the external identifier of an HCP Packer artifact does not, I was able to reproduce this with basic testing, so I'd like to gurantee we know what value is being compared against the SIG Regex