### PR TITLE
Move SIG Regex check to builder to fix validation failures

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -374,7 +374,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	}
 	if b.config.SharedGallery.ID != "" {
 		if !b.IsSigIDValid() {
-			return nil, errors.New(fmt.Sprintf("shared_image_gallery.id (%s) does not match expected format of '/subscriptions/(subscriptionid)/resourceGroups/(rg-name)/providers/Microsoft.Compute/galleries/(gallery-name)/images/image-name/versions/(version)", b.config.SharedGallery.ID))
+			return nil, fmt.Errorf("shared_image_gallery.id (%s) does not match expected format of '/subscriptions/(subscriptionid)/resourceGroups/(rg-name)/providers/Microsoft.Compute/galleries/(gallery-name)/images/image-name/versions/(version)", b.config.SharedGallery.ID)
 		}
 		sigID := b.config.getSharedImageGalleryObjectFromId()
 		if sigID == nil {

--- a/builder/azure/arm/builder_test.go
+++ b/builder/azure/arm/builder_test.go
@@ -180,3 +180,20 @@ func TestBuilderConfig_SSHHost(t *testing.T) {
 	}
 
 }
+
+func Test_IsSIGValid(t *testing.T) {
+	var testSubject Builder
+	testSubject.config.SharedGallery = SharedImageGallery{
+		ID: "blorp",
+	}
+	if testSubject.IsSigIDValid() {
+		t.Fatal("Expected invalid SIG ID to be invalid, but was validated")
+	}
+	testSubject.config.SharedGallery = SharedImageGallery{
+		ID: "/subscriptions/acd03ed1-6c95-4568-b14c-2a793bd601a8/resourceGroups/jennatest/providers/Microsoft.Compute/galleries/blah_acctestgallery/images/blah-arm-linux-specialized-sig/versions/92827891.1928371238.12392323",
+	}
+	if !testSubject.IsSigIDValid() {
+		t.Fatal("Expected valid SIG ID to be valid, but was invalidated")
+	}
+
+}

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -1283,10 +1283,6 @@ func assertRequiredParametersSet(c *Config, errs *packersdk.MultiError) {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("VHD Target [capture_name_prefix] is not supported when using Shared Image Gallery as source. Use managed_image_name instead."))
 		}
 	} else if c.SharedGallery.ID != "" {
-		sigIDRegex := regexp.MustCompile("/subscriptions/[^/]*/resourceGroups/[^/]*/providers/Microsoft.Compute/galleries/[^/]*/images/[^/]*/versions/[^/]*")
-		if !sigIDRegex.Match([]byte(c.SharedGallery.ID)) {
-			errs = packer.MultiErrorAppend(errs, fmt.Errorf("shared_image_gallery.id does not match expected format of '/subscriptions/(subscriptionid)/resourceGroups/(rg-name)/providers/Microsoft.Compute/galleries/(gallery-name)/images/image-name/versions/(version)"))
-		}
 		if c.SharedGallery.Subscription != "" {
 			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("When setting shared_image_gallery.id, shared_image_gallery.subscription must not be specified"))
 		}


### PR DESCRIPTION
When running `packer validate` the HCP Packer Datasource does not make API requests, this is to avoid generating billable events for users who are just validating templates.  This causes a problem when doing regex validation on the source image SIG ID, this lead to @jsloan117 reporting issues, I was unable to reproduce at first, but then Jessica pointed out that all of my testing was using `packer build`, while she was using `packer validate`, as soon as I tried packer validate the issue immediately was apparent, and also why when she hardcodes the ID this issue goes away.

To fix this issue, I moved this regex comparison to outside of the config function that the validate template command calls.  So that the SIG ID is not validated when it might not be populated.

Closes https://github.com/hashicorp/packer-plugin-azure/issues/529

Before this change I see the following error:

```
packer validate builder/azure/arm/testdata/child_from_specialized_parent.pkr.hcl
Error: 1 error(s) occurred:

* shared_image_gallery.id does not match expected format of '/subscriptions/(subscriptionid)/resourceGroups/(rg-name)/providers/Microsoft.Compute/galleries/(gallery-name)/images/image-name/versions/(version)

  on builder/azure/arm/testdata/child_from_specialized_parent.pkr.hcl line 40:
  (source code not available)
```

After this change, 
```
packer validate builder/azure/arm/testdata/child_from_specialized_parent.pkr.hcl
The configuration is valid.
```