### PR TITLE
VHD Migrations Fixes - VHD Acceptance Tests, and Disk Revoke Access on Failures

### DIFF
--- a/.web-docs/components/builder/arm/README.md
+++ b/.web-docs/components/builder/arm/README.md
@@ -147,7 +147,7 @@ Providing `temp_resource_group_name` or `location` in combination with
 
 - `capture_name_prefix` (string) - VHD prefix.
 
-- `capture_container_name` (string) - Destination container name.
+- `capture_container_name` (string) - Destination container name. This must be created before the build in the storage account
 
 - `shared_image_gallery` (SharedImageGallery) - Use a [Shared Gallery
   image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)

--- a/builder/azure/arm/builder_acc_test.go
+++ b/builder/azure/arm/builder_acc_test.go
@@ -348,7 +348,7 @@ func testBuilderUserDataLinux(userdata string) string {
 
 	  "storage_account": "{{user `+"`storage_account`"+`}}",
 	  "resource_group_name": "{{user `+"`resource_group_name`"+`}}",
-	  "capture_container_name": "test",
+	  "capture_container_name": "packeracc",
 	  "capture_name_prefix": "testBuilderUserDataLinux",
 
 	  "os_type": "Linux",
@@ -528,7 +528,7 @@ const testBuilderAccBlobWindows = `
 
 	  "storage_account": "{{user ` + "`storage_account`" + `}}",
 	  "resource_group_name": "{{user ` + "`resource_group_name`" + `}}",
-	  "capture_container_name": "azure-arm",
+	  "capture_container_name": "packeracc",
 	  "capture_name_prefix": "testBuilderAccBlobWin",
 
 	  "os_type": "Windows",
@@ -566,7 +566,7 @@ const testBuilderAccBlobLinux = `
 
 	  "storage_account": "{{user ` + "`storage_account`" + `}}",
 	  "resource_group_name": "{{user ` + "`resource_group_name`" + `}}",
-	  "capture_container_name": "test",
+	  "capture_container_name": "packeracc",
 	  "capture_name_prefix": "testBuilderAccBlobLinux",
 
 	  "os_type": "Linux",

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -181,7 +181,7 @@ type Config struct {
 
 	// VHD prefix.
 	CaptureNamePrefix string `mapstructure:"capture_name_prefix"`
-	// Destination container name.
+	// Destination container name. This must be created before the build in the storage account
 	CaptureContainerName string `mapstructure:"capture_container_name"`
 	// Use a [Shared Gallery
 	// image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)

--- a/docs-partials/builder/azure/arm/Config-not-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-not-required.mdx
@@ -9,7 +9,7 @@
 
 - `capture_name_prefix` (string) - VHD prefix.
 
-- `capture_container_name` (string) - Destination container name.
+- `capture_container_name` (string) - Destination container name. This must be created before the build in the storage account
 
 - `shared_image_gallery` (SharedImageGallery) - Use a [Shared Gallery
   image](https://azure.microsoft.com/en-us/blog/announcing-the-public-preview-of-shared-image-gallery/)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,6 +15,11 @@ resource "azurerm_storage_account" "storage-account" {
   account_replication_type = "GRS"
 }
 
+resource "azurerm_storage_container" "example" {
+  name                  = "packeracc"
+  storage_account_id    = azurerm_storage_account.storage-account.id
+}
+
 resource "azurerm_shared_image_gallery" "gallery" {
   name                = "${var.resource_prefix}_acctestgallery"
   resource_group_name = azurerm_resource_group.rg.name


### PR DESCRIPTION
This PR contains 2 main changes

1. After the VHD unmanaged disk removals, acceptance tests started failing, this is due to the capture container name expected to be created before a build is started now, to fix this I added the capture container we'll use to the acceptance testing Terraform
2. I also made a change to fix an issue caused by DiskRevokeAccess only being called after a copy is successful.  If the copy fails (such as due to the above error where a user doesn't know they need to create a container now), we still need to Revoke the DIsk Access, otherwise deletion of the build disk will fail.  To fix this I've moved this into the Cleanup of the CaptureImage step