### PR TITLE
Add manual mount command option

### DIFF
--- a/.web-docs/components/builder/chroot/README.md
+++ b/.web-docs/components/builder/chroot/README.md
@@ -122,6 +122,10 @@ information.
   a command with sudo or so on. This is a configuration template where the `.Command` variable
   is replaced with the command to be run. Defaults to `{{.Command}}`.
 
+- `manual_mount_command` (string) - Manual Mount Command that is executed to manually mount the
+  root device and before the post mount commands. The device and
+  mount path are provided by `{{.Device}}` and `{{.MountPath}}`.
+
 - `pre_mount_commands` ([]string) - A series of commands to execute after attaching the root volume and before mounting the chroot.
   This is not required unless using `from_scratch`. If so, this should include any partitioning
   and filesystem creation commands. The path to the device is provided by `{{.Device}}`.

--- a/builder/azure/chroot/builder.hcl2spec.go
+++ b/builder/azure/chroot/builder.hcl2spec.go
@@ -35,6 +35,7 @@ type FlatConfig struct {
 	FromScratch                       *bool                              `mapstructure:"from_scratch" cty:"from_scratch" hcl:"from_scratch"`
 	Source                            *string                            `mapstructure:"source" required:"true" cty:"source" hcl:"source"`
 	CommandWrapper                    *string                            `mapstructure:"command_wrapper" cty:"command_wrapper" hcl:"command_wrapper"`
+	ManualMountCommand                *string                            `mapstructure:"manual_mount_command" required:"false" cty:"manual_mount_command" hcl:"manual_mount_command"`
 	PreMountCommands                  []string                           `mapstructure:"pre_mount_commands" cty:"pre_mount_commands" hcl:"pre_mount_commands"`
 	MountOptions                      []string                           `mapstructure:"mount_options" cty:"mount_options" hcl:"mount_options"`
 	MountPartition                    *string                            `mapstructure:"mount_partition" cty:"mount_partition" hcl:"mount_partition"`
@@ -94,6 +95,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"from_scratch":                    &hcldec.AttrSpec{Name: "from_scratch", Type: cty.Bool, Required: false},
 		"source":                          &hcldec.AttrSpec{Name: "source", Type: cty.String, Required: false},
 		"command_wrapper":                 &hcldec.AttrSpec{Name: "command_wrapper", Type: cty.String, Required: false},
+		"manual_mount_command":            &hcldec.AttrSpec{Name: "manual_mount_command", Type: cty.String, Required: false},
 		"pre_mount_commands":              &hcldec.AttrSpec{Name: "pre_mount_commands", Type: cty.List(cty.String), Required: false},
 		"mount_options":                   &hcldec.AttrSpec{Name: "mount_options", Type: cty.List(cty.String), Required: false},
 		"mount_partition":                 &hcldec.AttrSpec{Name: "mount_partition", Type: cty.String, Required: false},

--- a/builder/azure/chroot/step_manual_mount_command.go
+++ b/builder/azure/chroot/step_manual_mount_command.go
@@ -1,0 +1,110 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package chroot
+
+// mostly borrowed from ./builder/amazon/chroot/step_mount_device.go
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+
+	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/log"
+
+	"github.com/hashicorp/packer-plugin-sdk/common"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
+)
+
+var _ multistep.Step = &StepManualMountCommand{}
+
+type StepManualMountCommand struct {
+	Command        string
+	MountPartition string
+	MountPath      string
+
+	mountPath string
+}
+
+func (s *StepManualMountCommand) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packersdk.Ui)
+	device := state.Get("device").(string)
+	config := state.Get("config").(*Config)
+
+	ictx := config.ctx
+
+	ictx.Data = &struct{ Device string }{Device: filepath.Base(device)}
+	mountPath, err := interpolate.Render(s.MountPath, &ictx)
+
+	if err != nil {
+		err := fmt.Errorf("error preparing mount directory: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	mountPath, err = filepath.Abs(mountPath)
+	if err != nil {
+		err := fmt.Errorf("error preparing mount directory: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	log.Printf("Mount path: %s", mountPath)
+
+	var deviceMount string
+	switch runtime.GOOS {
+	case "freebsd":
+		deviceMount = fmt.Sprintf("%sp%s", device, s.MountPartition)
+	default:
+		deviceMount = fmt.Sprintf("%s%s", device, s.MountPartition)
+	}
+
+	state.Put("deviceMount", deviceMount)
+
+	ui.Say("Mounting the root device...")
+	stderr := new(bytes.Buffer)
+
+	log.Printf("[DEBUG] (step mount) mount command is %s", s.Command)
+	cmd := common.ShellCommand(fmt.Sprintf("%s %s", s.Command, mountPath))
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		err := fmt.Errorf(
+			"error mounting root volume: %s\nStderr: %s", err, stderr.String())
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	// Set the mount path so we remember to unmount it later
+	s.mountPath = mountPath
+	state.Put("mount_path", s.mountPath)
+	state.Put("mount_device_cleanup", s)
+
+	return multistep.ActionContinue
+}
+
+func (s *StepManualMountCommand) Cleanup(state multistep.StateBag) {
+	ui := state.Get("ui").(packersdk.Ui)
+	if err := s.CleanupFunc(state); err != nil {
+		ui.Error(err.Error())
+	}
+}
+
+func (s *StepManualMountCommand) CleanupFunc(state multistep.StateBag) error {
+	if s.mountPath == "" {
+		return nil
+	}
+
+	ui := state.Get("ui").(packersdk.Ui)
+
+	ui.Say("Skipping Unmounting the root device, it is manually unmounted via manual mount command script...")
+
+	s.mountPath = ""
+	return nil
+}

--- a/docs-partials/builder/azure/chroot/Config-not-required.mdx
+++ b/docs-partials/builder/azure/chroot/Config-not-required.mdx
@@ -6,6 +6,10 @@
   a command with sudo or so on. This is a configuration template where the `.Command` variable
   is replaced with the command to be run. Defaults to `{{.Command}}`.
 
+- `manual_mount_command` (string) - Manual Mount Command that is executed to manually mount the
+  root device and before the post mount commands. The device and
+  mount path are provided by `{{.Device}}` and `{{.MountPath}}`.
+
 - `pre_mount_commands` ([]string) - A series of commands to execute after attaching the root volume and before mounting the chroot.
   This is not required unless using `from_scratch`. If so, this should include any partitioning
   and filesystem creation commands. The path to the device is provided by `{{.Device}}`.


### PR DESCRIPTION

### Description
Create a user controlled custom "manual-mount-command" option that when present will run in place of the packer-plugin-azures's mount step, providing the user total control over partitioning and mounting process. Aligning the chroot builder with similar capabilities to the ebssurrogate builder, allowing for reuse of configs/scripts for each builder with minimal edits. While packer still manages the overall workflow around the interactions with the cloud apis and registering/creating images and abstracting that workflow across the different providers.

### Use Case(s)

Allows users to use the chroot builder to create an image with an lvm-enabled root volume but also, instead of just targeting LVM, this is a flexible option that supports other complex mounting scenarios.

Much like the ebssurrogate builder supports total user control a "manual-mount-command" will bring this capability to the chroot builder.

We are also working to add this to the packer-plugin-amazon chroot builder to support issue: https://github.com/hashicorp/packer-plugin-amazon/issues/602

### Potential configuration
**"manual-mount-command"**: when set, the built in mounting step is skipped and a new manual mount command step is performed instead. It is a string that represents the command(s) to run.


****Note:** mount path and device are still processed in the manual step. If user wants to use the configured/detected devices/mount paths they can reference like the second example.

```
source "azure-chroot" "manual-mount-example" {
  from_scratch    = true
  ...
  manual_mount_command  = "chmod +x ./scripts/mount.sh && bash -x ./scripts/mount.sh"
}
```

```
source "azure-chroot" "manual-mount-device-example" {
  from_scratch    = true
  ...
  manual-mount-command="chmod +x ./scripts/mount.sh && export SOURCE_NAME_ENV='${source.name}' && export BUILD_DEVICE='{{ .Device }}' && bash -x ./scripts/mount.sh"
}
```

### Resolved Issues

Closes #510 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

None

