### PR TITLE
Increase SAS token validity in grantDiskAccess()

### DIFF
--- a/builder/azure/arm/step_capture_image.go
+++ b/builder/azure/arm/step_capture_image.go
@@ -253,7 +253,7 @@ func (s *StepCaptureImage) grantDiskAccess(ctx context.Context, subscriptionId s
 	diskID := commonids.NewManagedDiskID(subscriptionId, resourceGroupName, diskName)
 	grantAccessData := disks.GrantAccessData{
 		Access:            disks.AccessLevelRead,
-		DurationInSeconds: 600,
+		DurationInSeconds: 3600,
 	}
 
 	opts := sdkclient.RequestOptions{


### PR DESCRIPTION
### Description

Increasing SAS token validity as the current one is expiring before the disk capture finishes in some situations, which will end in an empty Blob object in target storage account and a failed packer run.

This is needed for situations where
 a) the disk is a bit bigger
 b) export process is slow for some reasons (Azure backend busy, slow
     DiskType selected...)

As the copy process is running entirely on Azure provided infrastructure we do not have much control. The copy process has to be restarted by creating a new blob object in case of any error. This is not handled during image capture process and would lead to some unnecessary retries.

Result of local `make test`:
```
?   	github.com/hashicorp/packer-plugin-azure	[no test files]
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/arm	6.599s
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/chroot	1.804s
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/common	2.143s
?   	github.com/hashicorp/packer-plugin-azure/builder/azure/common/cli	[no test files]
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/common/client	2.610s
?   	github.com/hashicorp/packer-plugin-azure/builder/azure/common/constants	[no test files]
?   	github.com/hashicorp/packer-plugin-azure/builder/azure/common/log	[no test files]
?   	github.com/hashicorp/packer-plugin-azure/builder/azure/common/logutil	[no test files]
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/common/template	2.006s
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/dtl	3.045s
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/pkcs12	3.013s
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/pkcs12/rc2	2.860s
ok  	github.com/hashicorp/packer-plugin-azure/datasource/keyvaultsecret	2.881s
?   	github.com/hashicorp/packer-plugin-azure/provisioner/azure-dtlartifact	[no test files]
ok  	github.com/hashicorp/packer-plugin-azure/version	3.007s
```

### Resolved Issues
Closes #544 

### Rollback Plan

Just decrease the timeout again.
If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

Increased SAS token timeout.
It is safe to increase the timeout. Disk access will be revoked by revokeDiskAccess() as soon as the copy process finished on the storage account and additionally, the whole source image is deleted anyway (in most cases).