### PR TITLE
Replace deprecated ui.Message with ui.Say

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -120,7 +120,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		OidcRequestToken:   b.config.ClientConfig.OidcRequestToken,
 	}
 
-	ui.Message("Creating Azure Resource Manager (ARM) client ...")
+	ui.Say("Creating Azure Resource Manager (ARM) client ...")
 	azureClient, err := NewAzureClient(
 		ctx,
 		b.config.StorageAccount,
@@ -132,7 +132,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	if err != nil {
 		return nil, err
 	}
-	ui.Message("ARM Client successfully created")
+	ui.Say("ARM Client successfully created")
 
 	resolver := newResourceResolver(azureClient)
 	if err := resolver.Resolve(&b.config); err != nil {
@@ -145,7 +145,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	if b.config.ClientConfig.ObjectID == "" {
 		b.config.ClientConfig.ObjectID = objectID
 	} else {
-		ui.Message("You have provided Object_ID which is no longer needed, Azure Packer ARM builder determines this automatically using the Azure Access Token")
+		ui.Say("You have provided Object_ID which is no longer needed, Azure Packer ARM builder determines this automatically using the Azure Access Token")
 	}
 
 	if b.config.ClientConfig.ObjectID == "" && b.config.OSType != constants.Target_Linux {
@@ -155,7 +155,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	// If the user is bringing their own vnet, don't warn, if its an invalid SKU it will get disabled at a different date and Microsoft will send out warings
 	if b.config.VirtualNetworkName == "" {
 		if b.config.PublicIpSKU == string(publicipaddresses.PublicIPAddressSkuNameBasic) {
-			ui.Message(publicIPWarning)
+			ui.Say(publicIPWarning)
 		}
 	}
 
@@ -422,7 +422,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		}
 
 		if b.config.SkipCreateBuildKeyVault {
-			ui.Message("Skipping build keyvault creation...")
+			ui.Say("Skipping build keyvault creation...")
 		} else if b.config.BuildKeyVaultName == "" {
 			keyVaultDeploymentName := b.stateBag.Get(constants.ArmKeyVaultDeploymentName).(string)
 			steps = append(steps,
@@ -513,12 +513,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	steps = append(steps, captureSteps...)
 
 	if b.config.PackerDebug {
-		ui.Message(fmt.Sprintf("temp admin user: '%s'", b.config.UserName))
-		ui.Message(fmt.Sprintf("temp admin password: '%s'", b.config.Password))
+		ui.Say(fmt.Sprintf("temp admin user: '%s'", b.config.UserName))
+		ui.Say(fmt.Sprintf("temp admin password: '%s'", b.config.Password))
 
 		if len(b.config.Comm.SSHPrivateKey) != 0 {
 			debugKeyPath := fmt.Sprintf("%s-%s.pem", b.config.PackerBuildName, b.config.tmpComputeName)
-			ui.Message(fmt.Sprintf("temp ssh key: %s", debugKeyPath))
+			ui.Say(fmt.Sprintf("temp ssh key: %s", debugKeyPath))
 
 			b.writeSSHPrivateKey(ui, debugKeyPath)
 		}

--- a/builder/azure/dtl/builder.go
+++ b/builder/azure/dtl/builder.go
@@ -84,7 +84,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		OidcRequestUrl:     b.config.ClientConfig.OidcRequestURL,
 		OidcRequestToken:   b.config.ClientConfig.OidcRequestToken,
 	}
-	ui.Message("Creating Azure DevTestLab (DTL) client ...")
+	ui.Say("Creating Azure DevTestLab (DTL) client ...")
 	azureClient, err := NewAzureClient(
 		ctx,
 		b.config.ClientConfig.SubscriptionID,
@@ -106,7 +106,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	if b.config.ClientConfig.ObjectID == "" {
 		b.config.ClientConfig.ObjectID = objectId
 	} else {
-		ui.Message("You have provided Object_ID which is no longer needed, azure packer builder determines this dynamically from the authentication token")
+		ui.Say("You have provided Object_ID which is no longer needed, azure packer builder determines this dynamically from the authentication token")
 	}
 
 	if b.config.ClientConfig.ObjectID == "" && b.config.OSType != constants.Target_Linux {
@@ -191,7 +191,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		b.config.LabVirtualNetworkName = *virtualNetwork
 		b.config.LabSubnetName = *subnet
 
-		ui.Message(fmt.Sprintf("No lab network information provided. Using %s Virtual network and %s subnet for Virtual Machine creation", b.config.LabVirtualNetworkName, b.config.LabSubnetName))
+		ui.Say(fmt.Sprintf("No lab network information provided. Using %s Virtual network and %s subnet for Virtual Machine creation", b.config.LabVirtualNetworkName, b.config.LabSubnetName))
 	}
 
 	if b.config.OSType == constants.Target_Linux {
@@ -244,12 +244,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	steps = append(steps, NewStepDeleteVirtualMachine(azureClient, ui, &b.config))
 
 	if b.config.PackerDebug {
-		ui.Message(fmt.Sprintf("temp admin user: '%s'", b.config.UserName))
-		ui.Message(fmt.Sprintf("temp admin password: '%s'", b.config.Password))
+		ui.Say(fmt.Sprintf("temp admin user: '%s'", b.config.UserName))
+		ui.Say(fmt.Sprintf("temp admin password: '%s'", b.config.Password))
 
 		if len(b.config.Comm.SSHPrivateKey) != 0 {
 			debugKeyPath := fmt.Sprintf("%s-%s.pem", b.config.PackerBuildName, b.config.tmpComputeName)
-			ui.Message(fmt.Sprintf("temp ssh key: %s", debugKeyPath))
+			ui.Say(fmt.Sprintf("temp ssh key: %s", debugKeyPath))
 
 			b.writeSSHPrivateKey(ui, debugKeyPath)
 		}

--- a/provisioner/azure-dtlartifact/provisioner.go
+++ b/provisioner/azure-dtlartifact/provisioner.go
@@ -135,7 +135,7 @@ func (p *Provisioner) Provision(ctx context.Context, ui packersdk.Ui, comm packe
 		TenantID:       p.config.ClientConfig.TenantID,
 		SubscriptionID: p.config.ClientConfig.SubscriptionID,
 	}
-	ui.Message("Creating Azure DevTestLab (DTL) client ...")
+	ui.Say("Creating Azure DevTestLab (DTL) client ...")
 	azureClient, err := dtlBuilder.NewAzureClient(
 		ctx,
 		p.config.ClientConfig.SubscriptionID,


### PR DESCRIPTION
### Description

`ui.Message` is marked as deprecated. `ui.Say` appears to be a direct replacement. All instances have been replaced. 

```
➜ make test 
?   	github.com/hashicorp/packer-plugin-azure	[no test files]
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/arm	27.019s
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/chroot	1.073s
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/common	1.050s
?   	github.com/hashicorp/packer-plugin-azure/builder/azure/common/cli	[no test files]
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/common/client	2.019s
?   	github.com/hashicorp/packer-plugin-azure/builder/azure/common/constants	[no test files]
?   	github.com/hashicorp/packer-plugin-azure/builder/azure/common/log	[no test files]
?   	github.com/hashicorp/packer-plugin-azure/builder/azure/common/logutil	[no test files]
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/common/template	1.141s
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/dtl	4.242s
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/pkcs12	4.344s
ok  	github.com/hashicorp/packer-plugin-azure/builder/azure/pkcs12/rc2	1.019s
ok  	github.com/hashicorp/packer-plugin-azure/datasource/keyvaultsecret	1.060s
?   	github.com/hashicorp/packer-plugin-azure/provisioner/azure-dtlartifact	[no test files]
ok  	github.com/hashicorp/packer-plugin-azure/version	1.018s
```

### Resolved Issues
If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

