### PR TITLE
Updates Go version to 1.24.12 in module file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/hashicorp/packer-plugin-azure
 
-go 1.24.0
-
-toolchain go1.24.2
+go 1.24.12
 
 require (
 	github.com/approvals/go-approval-tests v0.0.0-20210131072903-38d0b0ec12b1


### PR DESCRIPTION
Updating the go version to `v1.24.12` to resolve the following vulnerabilities.
```
GO-2025-4175
GO-2025-4155
GO-2025-4013
GO-2025-4012
GO-2025-4011
GO-2025-4010
GO-2025-4009
GO-2025-4008
GO-2025-4007
GO-2025-3956
GO-2025-3751
GO-2025-3750
GO-2025-3749
```