### PR TITLE
Fix: Cross Subscription ACG Utilisation for "Azure-Chroot"

### DIFF
--- a/.web-docs/components/builder/chroot/README.md
+++ b/.web-docs/components/builder/chroot/README.md
@@ -35,6 +35,22 @@ There are some restrictions however:
 - The host system SKU has to allow for all of the specified disks to be
   attached.
 
+### Availability Zones
+
+When the host VM is placed in an availability zone, the builder automatically
+creates disks in the same zone. The zone is detected via the Azure Instance
+Metadata Service (IMDS) and is also available as a template variable via
+`{{ vm \`zone\` }}`.
+
+### Cross-Subscription Azure Compute Gallery (ACG)
+
+The `azure-chroot` builder supports sourcing images from an Azure Compute
+Gallery in a different subscription. When specifying a `source` that references
+a shared image version in another subscription, the builder will use the
+subscription ID from the image resource ID rather than the host VM's
+subscription. Ensure the identity used by the builder has the appropriate
+read permissions on the source gallery.
+
 ## Configuration Reference
 
 There are many configuration options available for the builder. We'll start
@@ -290,6 +306,7 @@ available called `vm`, which returns the following VM metadata:
 - subscription_id
 - resource_group
 - location
+- zone
 - resource_id
 
 This function can be used in the configuration templates, for example, use
@@ -308,7 +325,6 @@ The generated variables available for this builder are:
 
 - `SourceImageName` - The full name of the source image used in the deployment. When using
 shared images the resulting name will point to the actual source used to create the said version.
-  building the AMI.
 
 Usage example:
 
@@ -320,7 +336,7 @@ Usage example:
 // won't be easily resolvable until legacy json templates are deprecated:
 
 {
-source "amazon-arm" "basic-example" {
+source "azure-chroot" "basic-example" {
   source = "credativ:Debian:9:latest"
 }
 

--- a/builder/azure/chroot/builder.go
+++ b/builder/azure/chroot/builder.go
@@ -519,7 +519,8 @@ func buildsteps(
 				OSDiskSizeGB:             config.OSDiskSizeGB,
 				OSDiskStorageAccountType: config.OSDiskStorageAccountType,
 				HyperVGeneration:         config.ImageHyperVGeneration,
-				Location:                 info.Location}))
+				Location:                 info.Location,
+				Zone:                     info.Zone}))
 	} else {
 		switch config.sourceType {
 		case sourcePlatformImage:
@@ -544,8 +545,7 @@ func buildsteps(
 						OSDiskStorageAccountType: config.OSDiskStorageAccountType,
 						HyperVGeneration:         config.ImageHyperVGeneration,
 						Location:                 info.Location,
-						SourcePlatformImage:      pi,
-
+					Zone:                     info.Zone,
 						SkipCleanup: config.SkipCleanup,
 					}),
 				)
@@ -571,6 +571,7 @@ func buildsteps(
 					HyperVGeneration:         config.ImageHyperVGeneration,
 					SourceOSDiskResourceID:   config.Source,
 					Location:                 info.Location,
+					Zone:                     info.Zone,
 
 					SkipCleanup: config.SkipCleanup,
 				}),
@@ -596,6 +597,7 @@ func buildsteps(
 					DataDiskStorageAccountType: config.DataDiskStorageAccountType,
 					SourceImageResourceID:      config.Source,
 					Location:                   info.Location,
+					Zone:                       info.Zone,
 
 					SkipCleanup: config.SkipCleanup,
 				}),

--- a/builder/azure/chroot/builder.go
+++ b/builder/azure/chroot/builder.go
@@ -544,9 +544,10 @@ func buildsteps(
 						OSDiskSizeGB:             config.OSDiskSizeGB,
 						OSDiskStorageAccountType: config.OSDiskStorageAccountType,
 						HyperVGeneration:         config.ImageHyperVGeneration,
+						SourcePlatformImage:      pi,
 						Location:                 info.Location,
-					Zone:                     info.Zone,
-						SkipCleanup: config.SkipCleanup,
+						Zone:                     info.Zone,
+						SkipCleanup:              config.SkipCleanup,
 					}),
 				)
 			} else {

--- a/builder/azure/chroot/step_create_new_diskset.go
+++ b/builder/azure/chroot/step_create_new_diskset.go
@@ -102,7 +102,7 @@ func (s *StepCreateNewDiskset) Run(ctx context.Context, state multistep.StateBag
 			"Microsoft.Compute/galleries/images/versions") {
 			return errorMessage("source image id is not a shared image version %q, expected type 'Microsoft.Compute/galleries/images/versions'", imageID)
 		}
-		galleryImageVersionId := galleryimageversions.NewImageVersionID(azcli.SubscriptionID(),
+		galleryImageVersionId := galleryimageversions.NewImageVersionID(imageID.Subscription,
 			imageID.ResourceGroup, imageID.ResourceName[0], imageID.ResourceName[1], imageID.ResourceName[2])
 		image, err := s.getVersion(ctx, azcli, galleryImageVersionId)
 		if err != nil {

--- a/builder/azure/chroot/step_create_new_diskset.go
+++ b/builder/azure/chroot/step_create_new_diskset.go
@@ -43,6 +43,9 @@ type StepCreateNewDiskset struct {
 	// Location is needed for platform and shared images
 	Location string
 
+	// Availability zone of the VM (from IMDS). If set, disks are created in this zone.
+	Zone string
+
 	SkipCleanup bool
 
 	getVersion func(context.Context, client.AzureClientSet, galleryimageversions.ImageVersionId) (*galleryimageversions.GalleryImageVersion, error)
@@ -144,6 +147,11 @@ func (s StepCreateNewDiskset) getOSDiskDefinition(subscriptionID string) disks.D
 		},
 	}
 
+	if s.Zone != "" {
+		z := []string{s.Zone}
+		disk.Zones = &z
+	}
+
 	if s.OSDiskStorageAccountType != "" {
 		hashiDiskSkuName := disks.DiskStorageAccountTypes(s.OSDiskStorageAccountType)
 		disk.Sku = &disks.DiskSku{
@@ -189,6 +197,11 @@ func (s StepCreateNewDiskset) getDatadiskDefinitionFromImage(lun int64) disks.Di
 		Properties: &disks.DiskProperties{
 			CreationData: disks.CreationData{},
 		},
+	}
+
+	if s.Zone != "" {
+		z := []string{s.Zone}
+		disk.Zones = &z
 	}
 
 	disk.Properties.CreationData.CreateOption = disks.DiskCreateOptionFromImage

--- a/builder/azure/chroot/step_create_new_diskset_test.go
+++ b/builder/azure/chroot/step_create_new_diskset_test.go
@@ -230,6 +230,9 @@ func TestStepCreateNewDisk_Run(t *testing.T) {
 				SourceImageResourceID:      tt.fields.SourceImageResourceID,
 				SourcePlatformImage:        tt.fields.SourcePlatformImage,
 				getVersion: func(ctx context.Context, acs client.AzureClientSet, id galleryimageversions.ImageVersionId) (*galleryimageversions.GalleryImageVersion, error) {
+					if id.SubscriptionId != "ImageSubscriptionID" {
+						t.Fatalf("expected gallery image version lookup in subscription 'ImageSubscriptionID', got '%s'", id.SubscriptionId)
+					}
 					return &galleryimageversions.GalleryImageVersion{
 						Properties: &galleryimageversions.GalleryImageVersionProperties{
 							StorageProfile: galleryimageversions.GalleryImageVersionStorageProfile{

--- a/builder/azure/chroot/step_create_new_diskset_test.go
+++ b/builder/azure/chroot/step_create_new_diskset_test.go
@@ -139,7 +139,7 @@ func TestStepCreateNewDisk_Run(t *testing.T) {
 				DataDiskIDPrefix:           "/subscriptions/SubscriptionID/resourcegroups/ResourceGroupName/providers/Microsoft.Compute/disks/TemporaryDataDisk-",
 				HyperVGeneration:           string(disks.HyperVGenerationVOne),
 				Location:                   "westus",
-				SourceImageResourceID:      "/subscriptions/SubscriptionID/resourcegroups/imagegroup/providers/Microsoft.Compute/galleries/MyGallery/images/MyImage/versions/1.2.3",
+				SourceImageResourceID:      "/subscriptions/ImageSubscriptionID/resourcegroups/imagegroup/providers/Microsoft.Compute/galleries/MyGallery/images/MyImage/versions/1.2.3",
 			},
 
 			disks: []disks.Disk{
@@ -149,7 +149,7 @@ func TestStepCreateNewDisk_Run(t *testing.T) {
 						CreationData: disks.CreationData{
 							CreateOption: disks.DiskCreateOptionFromImage,
 							GalleryImageReference: &disks.ImageDiskReference{
-								Id: common.StringPtr("/subscriptions/SubscriptionID/resourcegroups/imagegroup/providers/Microsoft.Compute/galleries/MyGallery/images/MyImage/versions/1.2.3"),
+								Id: common.StringPtr("/subscriptions/ImageSubscriptionID/resourcegroups/imagegroup/providers/Microsoft.Compute/galleries/MyGallery/images/MyImage/versions/1.2.3"),
 							},
 						},
 						HyperVGeneration: &hyperVGeneration,
@@ -165,7 +165,7 @@ func TestStepCreateNewDisk_Run(t *testing.T) {
 						CreationData: disks.CreationData{
 							CreateOption: disks.DiskCreateOptionFromImage,
 							GalleryImageReference: &disks.ImageDiskReference{
-								Id:  common.StringPtr("/subscriptions/SubscriptionID/resourcegroups/imagegroup/providers/Microsoft.Compute/galleries/MyGallery/images/MyImage/versions/1.2.3"),
+								Id:  common.StringPtr("/subscriptions/ImageSubscriptionID/resourcegroups/imagegroup/providers/Microsoft.Compute/galleries/MyGallery/images/MyImage/versions/1.2.3"),
 								Lun: common.Int64Ptr(5),
 							},
 						},
@@ -180,7 +180,7 @@ func TestStepCreateNewDisk_Run(t *testing.T) {
 						CreationData: disks.CreationData{
 							CreateOption: disks.DiskCreateOptionFromImage,
 							GalleryImageReference: &disks.ImageDiskReference{
-								Id:  common.StringPtr("/subscriptions/SubscriptionID/resourcegroups/imagegroup/providers/Microsoft.Compute/galleries/MyGallery/images/MyImage/versions/1.2.3"),
+								Id:  common.StringPtr("/subscriptions/ImageSubscriptionID/resourcegroups/imagegroup/providers/Microsoft.Compute/galleries/MyGallery/images/MyImage/versions/1.2.3"),
 								Lun: common.Int64Ptr(9),
 							},
 						},
@@ -195,7 +195,7 @@ func TestStepCreateNewDisk_Run(t *testing.T) {
 						CreationData: disks.CreationData{
 							CreateOption: disks.DiskCreateOptionFromImage,
 							GalleryImageReference: &disks.ImageDiskReference{
-								Id:  common.StringPtr("/subscriptions/SubscriptionID/resourcegroups/imagegroup/providers/Microsoft.Compute/galleries/MyGallery/images/MyImage/versions/1.2.3"),
+								Id:  common.StringPtr("/subscriptions/ImageSubscriptionID/resourcegroups/imagegroup/providers/Microsoft.Compute/galleries/MyGallery/images/MyImage/versions/1.2.3"),
 								Lun: common.Int64Ptr(3),
 							},
 						},

--- a/builder/azure/chroot/step_create_new_diskset_test.go
+++ b/builder/azure/chroot/step_create_new_diskset_test.go
@@ -214,6 +214,38 @@ func TestStepCreateNewDisk_Run(t *testing.T) {
 				9:  resource("/subscriptions/SubscriptionID/resourceGroups/ResourceGroupName/providers/Microsoft.Compute/disks/TemporaryDataDisk-9"),
 			},
 		},
+		{
+			name: "from disk with availability zone",
+			fields: StepCreateNewDiskset{
+				OSDiskID:                 "/subscriptions/SubscriptionID/resourcegroups/ResourceGroupName/providers/Microsoft.Compute/disks/TemporaryOSDiskName",
+				OSDiskSizeGB:             42,
+				OSDiskStorageAccountType: string(disks.DiskStorageAccountTypesStandardLRS),
+				HyperVGeneration:         string(disks.HyperVGenerationVOne),
+				Location:                 "westus",
+				Zone:                     "3",
+				SourceOSDiskResourceID:   "SourceDisk",
+			},
+			disks: []disks.Disk{
+				{
+					Location: "westus",
+					Zones:    &[]string{"3"},
+					Sku: &disks.DiskSku{
+						Name: &standardLRS,
+					},
+					Properties: &disks.DiskProperties{
+						HyperVGeneration: &hyperVGeneration,
+						OsType:           &osType,
+						CreationData: disks.CreationData{
+							CreateOption:     disks.DiskCreateOptionCopy,
+							SourceResourceId: common.StringPtr("SourceDisk"),
+						},
+						DiskSizeGB: common.Int64Ptr(42),
+					},
+				},
+			},
+			want:          multistep.ActionContinue,
+			verifyDiskset: &Diskset{-1: resource("/subscriptions/SubscriptionID/resourceGroups/ResourceGroupName/providers/Microsoft.Compute/disks/TemporaryOSDiskName")},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -226,6 +258,7 @@ func TestStepCreateNewDisk_Run(t *testing.T) {
 				DataDiskIDPrefix:           tt.fields.DataDiskIDPrefix,
 				HyperVGeneration:           tt.fields.HyperVGeneration,
 				Location:                   tt.fields.Location,
+				Zone:                       tt.fields.Zone,
 				SourceOSDiskResourceID:     tt.fields.SourceOSDiskResourceID,
 				SourceImageResourceID:      tt.fields.SourceImageResourceID,
 				SourcePlatformImage:        tt.fields.SourcePlatformImage,

--- a/builder/azure/chroot/step_get_source_image_name.go
+++ b/builder/azure/chroot/step_get_source_image_name.go
@@ -55,7 +55,7 @@ func (s *StepGetSourceImageName) Run(ctx context.Context, state multistep.StateB
 			return multistep.ActionContinue
 		}
 
-		imageVersionID := galleryimageversions.NewImageVersionID(azcli.SubscriptionID(), imageID.ResourceGroup, imageID.ResourceName[0], imageID.ResourceName[1], imageID.ResourceName[2])
+		imageVersionID := galleryimageversions.NewImageVersionID(imageID.Subscription, imageID.ResourceGroup, imageID.ResourceName[0], imageID.ResourceName[1], imageID.ResourceName[2])
 		image, err := s.get(ctx, azcli, imageVersionID)
 		if err != nil {
 			log.Printf("[TRACE] error retrieving managed image name for shared source image %q: %v", s.SourceImageResourceID, err)

--- a/builder/azure/chroot/step_get_source_image_name_test.go
+++ b/builder/azure/chroot/step_get_source_image_name_test.go
@@ -93,7 +93,7 @@ func TestChrootStepGetSourceImageName_SharedImage(t *testing.T) {
 	}{
 		{
 			name:                  "SharedImageWithManagedImageSource",
-			SourceImageResourceID: "/subscriptions/1234/resourceGroups/bar/providers/Microsoft.Compute/galleries/test/images/foo/versions/1.0.6",
+			SourceImageResourceID: "/subscriptions/5678/resourceGroups/bar/providers/Microsoft.Compute/galleries/test/images/foo/versions/1.0.6",
 			GeneratedData:         genData,
 			mockedGalleryReturn: &galleryimageversions.GalleryImageVersion{
 				Properties: &galleryimageversions.GalleryImageVersionProperties{
@@ -105,7 +105,7 @@ func TestChrootStepGetSourceImageName_SharedImage(t *testing.T) {
 				},
 			},
 			expectedImageId: galleryimageversions.ImageVersionId{
-				SubscriptionId:    "1234",
+				SubscriptionId:    "5678",
 				ResourceGroupName: "bar",
 				GalleryName:       "test",
 				ImageName:         "foo",
@@ -115,7 +115,7 @@ func TestChrootStepGetSourceImageName_SharedImage(t *testing.T) {
 		},
 		{
 			name:                  "SimulatedBadImageResponse",
-			SourceImageResourceID: "/subscriptions/1234/resourceGroups/bar/providers/Microsoft.Compute/galleries/test/images/foo/versions/0.0.0",
+			SourceImageResourceID: "/subscriptions/5678/resourceGroups/bar/providers/Microsoft.Compute/galleries/test/images/foo/versions/0.0.0",
 			GeneratedData:         genData,
 			expected:              "ERR_SOURCE_IMAGE_NAME_NOT_FOUND",
 		},

--- a/builder/azure/chroot/template_funcs.go
+++ b/builder/azure/chroot/template_funcs.go
@@ -31,10 +31,12 @@ func CreateVMMetadataTemplateFunc() func(string) (string, error) {
 			return data.ResourceGroupName, nil
 		case "location":
 			return data.Location, nil
+		case "zone":
+			return data.Zone, nil
 		case "resource_id":
 			return data.GetResourceID(), nil
 		default:
-			return "", fmt.Errorf("unknown metadata key: %s (supported: name, subscription_id, resource_group, location, resource_id)", key)
+			return "", fmt.Errorf("unknown metadata key: %s (supported: name, subscription_id, resource_group, location, zone, resource_id)", key)
 		}
 	}
 }

--- a/builder/azure/common/client/metadata.go
+++ b/builder/azure/common/client/metadata.go
@@ -35,6 +35,7 @@ type ComputeInfo struct {
 	ResourceGroupName string
 	SubscriptionID    string
 	Location          string
+	Zone              string
 	VmScaleSetName    string
 }
 

--- a/docs/builders/chroot.mdx
+++ b/docs/builders/chroot.mdx
@@ -45,6 +45,22 @@ There are some restrictions however:
 - The host system SKU has to allow for all of the specified disks to be
   attached.
 
+### Availability Zones
+
+When the host VM is placed in an availability zone, the builder automatically
+creates disks in the same zone. The zone is detected via the Azure Instance
+Metadata Service (IMDS) and is also available as a template variable via
+`{{ vm \`zone\` }}`.
+
+### Cross-Subscription Azure Compute Gallery (ACG)
+
+The `azure-chroot` builder supports sourcing images from an Azure Compute
+Gallery in a different subscription. When specifying a `source` that references
+a shared image version in another subscription, the builder will use the
+subscription ID from the image resource ID rather than the host VM's
+subscription. Ensure the identity used by the builder has the appropriate
+read permissions on the source gallery.
+
 ## Configuration Reference
 
 There are many configuration options available for the builder. We'll start
@@ -137,6 +153,7 @@ available called `vm`, which returns the following VM metadata:
 - subscription_id
 - resource_group
 - location
+- zone
 - resource_id
 
 This function can be used in the configuration templates, for example, use
@@ -155,7 +172,6 @@ The generated variables available for this builder are:
 
 - `SourceImageName` - The full name of the source image used in the deployment. When using
 shared images the resulting name will point to the actual source used to create the said version.
-  building the AMI.
 
 Usage example:
 
@@ -167,7 +183,7 @@ Usage example:
 // won't be easily resolvable until legacy json templates are deprecated:
 
 {
-source "amazon-arm" "basic-example" {
+source "azure-chroot" "basic-example" {
   source = "credativ:Debian:9:latest"
 }
 


### PR DESCRIPTION
### Description
When using `azure-chroot` with a Shared Image Gallery (Azure Compute Gallery) sourced in a different subscription, two code paths in the chroot builder incorrectly use the client's subscription (`azcli.SubscriptionID()`) - instead of the subscriptionId parsed from the user-passed resourceId.

The `arm` builder and other chroot steps already handled this correctly, but two specific files perpetuated this:
* `step_create_new_diskset.go` - discovering data disk LUNs (resultant HTTP/400)
* `step_get_source_image_name.go` - gets data about the source image, for use in post-processing, etc (resultant silent error)

Tests have been updated to account for this, also - and to ensure the "cross-subscription-yness" is tested for. All tests are passing with the changes.

Changes and testing supported by (and in collaboration with) @VRay27 🙌

### Resolved Issues
Closes #51 ([original ref](https://github.com/hashicorp/packer/issues/10761))
Closes #581 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

