### PR TITLE
Feat: Introduce Transparent LVM Support for azure-chroot Builder

### DIFF
--- a/.web-docs/components/builder/chroot/README.md
+++ b/.web-docs/components/builder/chroot/README.md
@@ -62,10 +62,10 @@ In most cases **no configuration is required** — LVM detection and activation
 happen transparently. The builder uses a multi-stage heuristic to find the root
 logical volume:
 
-1. Examines LV attributes (skipping snapshots and virtual LVs).
+1. Examines LV attributes (skipping snapshots, thin pools, and virtual LVs).
 2. Excludes swap volumes.
-3. Prefers LVs whose names contain `root`.
-4. Falls back to the largest remaining LV.
+3. Prefers LVs whose names contain `root` (exact match first, then partial).
+4. Falls back to the first remaining candidate.
 
 If auto-detection picks the wrong logical volume, you can set `lvm_root_device`
 to the exact device path (e.g., `/dev/mapper/rhel-root`).
@@ -224,10 +224,12 @@ information.
   instead of a partition on the raw disk. Normally, LVM is auto-detected and does not
   require any configuration. Use this only when auto-detection picks the wrong logical volume.
 
-- `pre_unmount_commands` ([]string) - A series of commands to execute after provisioning but before unmounting the chroot
-  and deactivating LVM. This is useful for flushing writes or running cleanup inside the
-  chroot while the filesystem is still mounted. The device and mount path are provided
-  by `{{.Device}}` and `{{.MountPath}}`.
+- `pre_unmount_commands` ([]string) - A series of commands to execute on the **host** after provisioning but before unmounting
+  the chroot and deactivating LVM. Useful for host-side operations on the still-mounted
+  filesystem such as `fstrim` or `sync`. These commands do **not** run inside the chroot;
+  to run a command inside the chroot, use a shell provisioner or prefix with
+  `chroot {{.MountPath}}`. The device and mount path are provided by `{{.Device}}` and
+  `{{.MountPath}}`.
 
 - `skip_cleanup` (bool) - If set to `true`, leaves the temporary disks and snapshots behind in the Packer VM resource group. Defaults to `false`
 

--- a/.web-docs/components/builder/chroot/README.md
+++ b/.web-docs/components/builder/chroot/README.md
@@ -51,6 +51,32 @@ subscription ID from the image resource ID rather than the host VM's
 subscription. Ensure the identity used by the builder has the appropriate
 read permissions on the source gallery.
 
+### LVM Support
+
+The `azure-chroot` builder has built-in support for source disks that use LVM
+(Logical Volume Manager). After the source disk is attached, the builder
+automatically scans for LVM physical volumes, activates any volume groups found
+on the disk, and locates the root logical volume to use as the mount target.
+
+In most cases **no configuration is required** — LVM detection and activation
+happen transparently. The builder uses a multi-stage heuristic to find the root
+logical volume:
+
+1. Examines LV attributes (skipping snapshots and virtual LVs).
+2. Excludes swap volumes.
+3. Prefers LVs whose names contain `root`.
+4. Falls back to the largest remaining LV.
+
+If auto-detection picks the wrong logical volume, you can set `lvm_root_device`
+to the exact device path (e.g., `/dev/mapper/rhel-root`).
+
+During cleanup the builder deactivates the volume groups before detaching the
+disk, ensuring no device-mapper references remain on the host.
+
+~> **Note:** LVM support requires the `lvm2` package (providing `pvscan`,
+`vgscan`, `vgchange`, `lvs`) to be installed on the host VM. The `partprobe`
+and `udevadm` utilities are also used for device discovery.
+
 ## Configuration Reference
 
 There are many configuration options available for the builder. We'll start
@@ -192,6 +218,16 @@ information.
 - `temporary_data_disk_id_prefix` (string) - The prefix for the resource ids of the temporary data disks that will be created. The disks will be suffixed with a number. Will be generated if not set.
 
 - `temporary_data_disk_snapshot_id` (string) - The prefix for the resource ids of the temporary data disk snapshots that will be created. The snapshots will be suffixed with a number. Will be generated if not set.
+
+- `lvm_root_device` (string) - Explicitly specify the LVM root device path to mount (e.g., `/dev/mapper/rhel-root`).
+  When set, LVM volume groups are activated and this device is used as the mount target
+  instead of a partition on the raw disk. Normally, LVM is auto-detected and does not
+  require any configuration. Use this only when auto-detection picks the wrong logical volume.
+
+- `pre_unmount_commands` ([]string) - A series of commands to execute after provisioning but before unmounting the chroot
+  and deactivating LVM. This is useful for flushing writes or running cleanup inside the
+  chroot while the filesystem is still mounted. The device and mount path are provided
+  by `{{.Device}}` and `{{.MountPath}}`.
 
 - `skip_cleanup` (bool) - If set to `true`, leaves the temporary disks and snapshots behind in the Packer VM resource group. Defaults to `false`
 
@@ -501,6 +537,56 @@ build {
       "inline_shebang": "/bin/sh -x",
       "type": "shell"
     }
+  ]
+}
+```
+
+
+### Using an LVM-based Source Image
+
+When the source disk uses LVM, the builder automatically detects and activates
+the volume groups. No additional configuration is needed in most cases:
+
+**HCL2**
+
+```hcl
+source "azure-chroot" "lvm-example" {
+  image_resource_id = "/subscriptions/{{vm `subscription_id`}}/resourceGroups/{{vm `resource_group`}}/providers/Microsoft.Compute/images/MyRHELImage-{{timestamp}}"
+  source            = "/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/disks/rhel-osdisk"
+}
+
+build {
+  sources = ["source.azure-chroot.lvm-example"]
+
+  provisioner "shell" {
+    inline         = ["yum update -y"]
+    inline_shebang = "/bin/sh -x"
+  }
+}
+```
+
+If auto-detection picks the wrong logical volume, set `lvm_root_device` to the
+exact path:
+
+```hcl
+source "azure-chroot" "lvm-explicit" {
+  image_resource_id = "/subscriptions/{{vm `subscription_id`}}/resourceGroups/{{vm `resource_group`}}/providers/Microsoft.Compute/images/MyRHELImage-{{timestamp}}"
+  source            = "/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/disks/rhel-osdisk"
+  lvm_root_device   = "/dev/mapper/rhel-root"
+}
+```
+
+The `pre_unmount_commands` option lets you run commands after provisioning
+but before the filesystem is unmounted and LVM is deactivated:
+
+```hcl
+source "azure-chroot" "lvm-pre-unmount" {
+  image_resource_id = "/subscriptions/{{vm `subscription_id`}}/resourceGroups/{{vm `resource_group`}}/providers/Microsoft.Compute/images/MyRHELImage-{{timestamp}}"
+  source            = "/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/disks/rhel-osdisk"
+
+  pre_unmount_commands = [
+    "sync",
+    "fstrim {{.MountPath}}"
   ]
 }
 ```

--- a/builder/azure/chroot/builder.go
+++ b/builder/azure/chroot/builder.go
@@ -131,10 +131,12 @@ type Config struct {
 	// require any configuration. Use this only when auto-detection picks the wrong logical volume.
 	LVMRootDevice string `mapstructure:"lvm_root_device"`
 
-	// A series of commands to execute after provisioning but before unmounting the chroot
-	// and deactivating LVM. This is useful for flushing writes or running cleanup inside the
-	// chroot while the filesystem is still mounted. The device and mount path are provided
-	// by `{{.Device}}` and `{{.MountPath}}`.
+	// A series of commands to execute on the **host** after provisioning but before unmounting
+	// the chroot and deactivating LVM. Useful for host-side operations on the still-mounted
+	// filesystem such as `fstrim` or `sync`. These commands do **not** run inside the chroot;
+	// to run a command inside the chroot, use a shell provisioner or prefix with
+	// `chroot {{.MountPath}}`. The device and mount path are provided by `{{.Device}}` and
+	// `{{.MountPath}}`.
 	PreUnmountCommands []string `mapstructure:"pre_unmount_commands"`
 
 	// If set to `true`, leaves the temporary disks and snapshots behind in the Packer VM resource group. Defaults to `false`

--- a/builder/azure/chroot/builder.go
+++ b/builder/azure/chroot/builder.go
@@ -438,8 +438,8 @@ func validateLVMRootDevice(device string) error {
 		}
 	}
 
-	// Use POSIX path (not filepath) since device paths are always Linux/FreeBSD; LVM 
-	// not a Windows concept. 
+	// Use POSIX path (not filepath) since device paths are always Linux/FreeBSD; LVM
+	// not a Windows concept.
 	cleaned := posixpath.Clean(device)
 
 	// Check for path traversal: reject if any component is ".."

--- a/builder/azure/chroot/builder.go
+++ b/builder/azure/chroot/builder.go
@@ -443,10 +443,8 @@ func validateLVMRootDevice(device string) error {
 	cleaned := posixpath.Clean(device)
 
 	// Check for path traversal: reject if any component is ".."
-	for _, component := range strings.Split(cleaned, "/") {
-		if component == ".." {
-			return fmt.Errorf("%q must not contain path traversal (..)", device)
-		}
+	if slices.Contains(strings.Split(cleaned, "/"), "..") {
+		return fmt.Errorf("%q must not contain path traversal (..)", device)
 	}
 
 	if !strings.HasPrefix(cleaned, "/dev/") {

--- a/builder/azure/chroot/builder.go
+++ b/builder/azure/chroot/builder.go
@@ -125,6 +125,18 @@ type Config struct {
 	// The prefix for the resource ids of the temporary data disk snapshots that will be created. The snapshots will be suffixed with a number. Will be generated if not set.
 	TemporaryDataDiskSnapshotIDPrefix string `mapstructure:"temporary_data_disk_snapshot_id"`
 
+	// Explicitly specify the LVM root device path to mount (e.g., `/dev/mapper/rhel-root`).
+	// When set, LVM volume groups are activated and this device is used as the mount target
+	// instead of a partition on the raw disk. Normally, LVM is auto-detected and does not
+	// require any configuration. Use this only when auto-detection picks the wrong logical volume.
+	LVMRootDevice string `mapstructure:"lvm_root_device"`
+
+	// A series of commands to execute after provisioning but before unmounting the chroot
+	// and deactivating LVM. This is useful for flushing writes or running cleanup inside the
+	// chroot while the filesystem is still mounted. The device and mount path are provided
+	// by `{{.Device}}` and `{{.MountPath}}`.
+	PreUnmountCommands []string `mapstructure:"pre_unmount_commands"`
+
 	// If set to `true`, leaves the temporary disks and snapshots behind in the Packer VM resource group. Defaults to `false`
 	SkipCleanup bool `mapstructure:"skip_cleanup"`
 
@@ -174,6 +186,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 				"command_wrapper",
 				"post_mount_commands",
 				"pre_mount_commands",
+				"pre_unmount_commands",
 				"manual_mount_command",
 				"mount_path",
 			},
@@ -291,6 +304,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	// checks, accumulate any errors or warnings
 
 	if b.config.FromScratch {
+		if b.config.LVMRootDevice != "" {
+			errs = packersdk.MultiErrorAppend(
+				errs, errors.New("lvm_root_device cannot be specified when building from_scratch"))
+		}
 		if b.config.Source != "" {
 			errs = packersdk.MultiErrorAppend(
 				errs, errors.New("source cannot be specified when building from_scratch"))
@@ -365,6 +382,11 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	if err := checkHyperVGeneration(b.config.ImageHyperVGeneration); err != nil {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("image_hyperv_generation: %v", err))
+	}
+
+	if b.config.LVMRootDevice != "" && !strings.HasPrefix(b.config.LVMRootDevice, "/dev/") {
+		errs = packersdk.MultiErrorAppend(errs,
+			fmt.Errorf("lvm_root_device: %q must be an absolute device path starting with /dev/", b.config.LVMRootDevice))
 	}
 
 	if errs != nil {
@@ -611,6 +633,15 @@ func buildsteps(
 
 	addSteps(
 		&StepAttachDisk{}, // uses os_disk_resource_id and sets 'device' in stateBag
+		// StepSetupLVM always runs: it auto-detects LVM on the attached disk.
+		// If LVM is found, it activates volume groups and replaces 'device' in
+		// the state bag with the root LV path. If not, it's a no-op.
+		&StepSetupLVM{
+			LVMRootDevice: config.LVMRootDevice,
+		},
+	)
+
+	addSteps(
 		&chroot.StepPreMountCommands{
 			Commands: config.PreMountCommands,
 		},
@@ -630,7 +661,12 @@ func buildsteps(
 			Files: config.CopyFiles,
 		},
 		&chroot.StepChrootProvision{},
-		&chroot.StepEarlyCleanup{},
+		&StepPreUnmountCommands{
+			Commands: config.PreUnmountCommands,
+		},
+		// Custom StepEarlyCleanup that includes LVM deactivation between
+		// unmount and disk detach (the SDK's version lacks "lvm_cleanup").
+		&StepEarlyCleanup{},
 	)
 
 	var captureSteps []multistep.Step

--- a/builder/azure/chroot/builder.hcl2spec.go
+++ b/builder/azure/chroot/builder.hcl2spec.go
@@ -53,6 +53,8 @@ type FlatConfig struct {
 	TemporaryOSDiskSnapshotID         *string                            `mapstructure:"temporary_os_disk_snapshot_id" cty:"temporary_os_disk_snapshot_id" hcl:"temporary_os_disk_snapshot_id"`
 	TemporaryDataDiskIDPrefix         *string                            `mapstructure:"temporary_data_disk_id_prefix" cty:"temporary_data_disk_id_prefix" hcl:"temporary_data_disk_id_prefix"`
 	TemporaryDataDiskSnapshotIDPrefix *string                            `mapstructure:"temporary_data_disk_snapshot_id" cty:"temporary_data_disk_snapshot_id" hcl:"temporary_data_disk_snapshot_id"`
+	LVMRootDevice                     *string                            `mapstructure:"lvm_root_device" cty:"lvm_root_device" hcl:"lvm_root_device"`
+	PreUnmountCommands                []string                           `mapstructure:"pre_unmount_commands" cty:"pre_unmount_commands" hcl:"pre_unmount_commands"`
 	SkipCleanup                       *bool                              `mapstructure:"skip_cleanup" cty:"skip_cleanup" hcl:"skip_cleanup"`
 	ImageResourceID                   *string                            `mapstructure:"image_resource_id" cty:"image_resource_id" hcl:"image_resource_id"`
 	SharedImageGalleryDestination     *FlatSharedImageGalleryDestination `mapstructure:"shared_image_destination" cty:"shared_image_destination" hcl:"shared_image_destination"`
@@ -113,6 +115,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"temporary_os_disk_snapshot_id":   &hcldec.AttrSpec{Name: "temporary_os_disk_snapshot_id", Type: cty.String, Required: false},
 		"temporary_data_disk_id_prefix":   &hcldec.AttrSpec{Name: "temporary_data_disk_id_prefix", Type: cty.String, Required: false},
 		"temporary_data_disk_snapshot_id": &hcldec.AttrSpec{Name: "temporary_data_disk_snapshot_id", Type: cty.String, Required: false},
+		"lvm_root_device":                 &hcldec.AttrSpec{Name: "lvm_root_device", Type: cty.String, Required: false},
+		"pre_unmount_commands":            &hcldec.AttrSpec{Name: "pre_unmount_commands", Type: cty.List(cty.String), Required: false},
 		"skip_cleanup":                    &hcldec.AttrSpec{Name: "skip_cleanup", Type: cty.Bool, Required: false},
 		"image_resource_id":               &hcldec.AttrSpec{Name: "image_resource_id", Type: cty.String, Required: false},
 		"shared_image_destination":        &hcldec.BlockSpec{TypeName: "shared_image_destination", Nested: hcldec.ObjectSpec((*FlatSharedImageGalleryDestination)(nil).HCL2Spec())},

--- a/builder/azure/chroot/builder_test.go
+++ b/builder/azure/chroot/builder_test.go
@@ -14,6 +14,36 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
 )
 
+func Test_validateLVMRootDevice(t *testing.T) {
+	tests := []struct {
+		name    string
+		device  string
+		wantErr bool
+	}{
+		{"valid mapper path", "/dev/mapper/rhel-root", false},
+		{"valid vg/lv path", "/dev/rhel/root", false},
+		{"valid sda path", "/dev/sda1", false},
+		{"missing /dev/ prefix", "/mapper/rhel-root", true},
+		{"relative path", "dev/mapper/rhel-root", true},
+		{"path traversal with ..", "/dev/../tmp/foo", true},
+		{"path traversal resolving outside dev", "/dev/mapper/../../etc/passwd", true},
+		{"contains newline", "/dev/mapper/rhel-root\n", true},
+		{"contains tab", "/dev/mapper/rhel\troot", true},
+		{"contains carriage return", "/dev/mapper/rhel-root\r", true},
+		{"empty string", "", true},
+		{"just /dev/", "/dev/", true},
+		{"double dot in middle", "/dev/mapper/a..b", false}, // not a path traversal, just dots in name
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLVMRootDevice(tt.device)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateLVMRootDevice(%q) error = %v, wantErr %v", tt.device, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestBuilder_Prepare(t *testing.T) {
 	type config map[string]interface{}
 
@@ -122,6 +152,57 @@ func TestBuilder_Prepare(t *testing.T) {
 				"skip_create_image": true,
 			},
 			wantErr: false,
+		},
+		{
+			name: "valid lvm_root_device accepted",
+			config: config{
+				"source":            "/subscriptions/789/resourceGroups/testrg/providers/Microsoft.Compute/disks/diskname",
+				"image_resource_id": "/subscriptions/789/resourceGroups/otherrgname/providers/Microsoft.Compute/images/MyDebianOSImage-{{timestamp}}",
+				"lvm_root_device":   "/dev/mapper/rhel-root",
+			},
+			validate: func(c Config) {
+				if c.LVMRootDevice != "/dev/mapper/rhel-root" {
+					t.Errorf("Expected LVMRootDevice %q, got %q", "/dev/mapper/rhel-root", c.LVMRootDevice)
+				}
+			},
+		},
+		{
+			name: "lvm_root_device with path traversal rejected",
+			config: config{
+				"source":            "/subscriptions/789/resourceGroups/testrg/providers/Microsoft.Compute/disks/diskname",
+				"image_resource_id": "/subscriptions/789/resourceGroups/otherrgname/providers/Microsoft.Compute/images/MyDebianOSImage-{{timestamp}}",
+				"lvm_root_device":   "/dev/../tmp/evil",
+			},
+			wantErr: true,
+		},
+		{
+			name: "lvm_root_device with newline rejected",
+			config: config{
+				"source":            "/subscriptions/789/resourceGroups/testrg/providers/Microsoft.Compute/disks/diskname",
+				"image_resource_id": "/subscriptions/789/resourceGroups/otherrgname/providers/Microsoft.Compute/images/MyDebianOSImage-{{timestamp}}",
+				"lvm_root_device":   "/dev/mapper/rhel-root\n",
+			},
+			wantErr: true,
+		},
+		{
+			name: "lvm_root_device without /dev/ prefix rejected",
+			config: config{
+				"source":            "/subscriptions/789/resourceGroups/testrg/providers/Microsoft.Compute/disks/diskname",
+				"image_resource_id": "/subscriptions/789/resourceGroups/otherrgname/providers/Microsoft.Compute/images/MyDebianOSImage-{{timestamp}}",
+				"lvm_root_device":   "/mapper/rhel-root",
+			},
+			wantErr: true,
+		},
+		{
+			name: "from_scratch with lvm_root_device rejected",
+			config: config{
+				"from_scratch":       true,
+				"os_disk_size_gb":    30,
+				"pre_mount_commands": []string{"sgdisk ..."},
+				"image_resource_id":  "/subscriptions/789/resourceGroups/otherrgname/providers/Microsoft.Compute/images/MyDebianOSImage-{{timestamp}}",
+				"lvm_root_device":    "/dev/mapper/rhel-root",
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/builder/azure/chroot/step_early_cleanup.go
+++ b/builder/azure/chroot/step_early_cleanup.go
@@ -1,0 +1,63 @@
+// Copyright IBM Corp. 2013, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package chroot
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/log"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+// earlyCleanup is a local interface to avoid import-path confusion with the
+// SDK's chroot package (our package is also named "chroot").
+type earlyCleanup interface {
+	CleanupFunc(multistep.StateBag) error
+}
+
+// StepEarlyCleanup is a custom replacement for the SDK's chroot.StepEarlyCleanup
+// that includes LVM deactivation between unmount and disk detach.
+type StepEarlyCleanup struct{}
+
+func (s *StepEarlyCleanup) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packersdk.Ui)
+
+	// Cleanup keys in order: unmount filesystem, deactivate LVM, detach disk.
+	cleanupKeys := []string{
+		"copy_files_cleanup",
+		"mount_extra_cleanup",
+		"mount_device_cleanup",
+		"lvm_cleanup",
+		"attach_cleanup",
+	}
+
+	for _, key := range cleanupKeys {
+		c := state.Get(key)
+		if c == nil {
+			log.Printf("Skipping cleanup func: %s (not set)", key)
+			continue
+		}
+
+		cleanup, ok := c.(earlyCleanup)
+		if !ok {
+			log.Printf("Skipping cleanup func: %s (does not implement CleanupFunc)", key)
+			continue
+		}
+
+		log.Printf("Running cleanup func: %s", key)
+		if err := cleanup.CleanupFunc(state); err != nil {
+			err = fmt.Errorf("error during cleanup %s: %v", key, err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *StepEarlyCleanup) Cleanup(state multistep.StateBag) {}

--- a/builder/azure/chroot/step_mount_device.go
+++ b/builder/azure/chroot/step_mount_device.go
@@ -70,12 +70,19 @@ func (s *StepMountDevice) Run(ctx context.Context, state multistep.StateBag) mul
 		}
 	}
 
+	// When LVM is active, the device is already a full LV path (e.g. /dev/mapper/rhel-root)
+	// and no partition suffix should be appended.
+	mountPartition := s.MountPartition
+	if _, ok := state.GetOk("lvm_active"); ok {
+		mountPartition = ""
+	}
+
 	var deviceMount string
 	switch runtime.GOOS {
 	case "freebsd":
-		deviceMount = fmt.Sprintf("%sp%s", device, s.MountPartition)
+		deviceMount = fmt.Sprintf("%sp%s", device, mountPartition)
 	default:
-		deviceMount = fmt.Sprintf("%s%s", device, s.MountPartition)
+		deviceMount = fmt.Sprintf("%s%s", device, mountPartition)
 	}
 
 	state.Put("deviceMount", deviceMount)

--- a/builder/azure/chroot/step_mount_device.go
+++ b/builder/azure/chroot/step_mount_device.go
@@ -78,11 +78,15 @@ func (s *StepMountDevice) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 
 	var deviceMount string
-	switch runtime.GOOS {
-	case "freebsd":
-		deviceMount = fmt.Sprintf("%sp%s", device, mountPartition)
-	default:
-		deviceMount = fmt.Sprintf("%s%s", device, mountPartition)
+	if mountPartition == "" {
+		deviceMount = device
+	} else {
+		switch runtime.GOOS {
+		case "freebsd":
+			deviceMount = fmt.Sprintf("%sp%s", device, mountPartition)
+		default:
+			deviceMount = fmt.Sprintf("%s%s", device, mountPartition)
+		}
 	}
 
 	state.Put("deviceMount", deviceMount)

--- a/builder/azure/chroot/step_mount_device_test.go
+++ b/builder/azure/chroot/step_mount_device_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,8 +25,10 @@ func TestStepMountDevice_Run(t *testing.T) {
 	}
 	mountPath, err := os.MkdirTemp("", "stepmountdevicetest")
 	if err != nil {
-		t.Errorf("Unable to create a temporary directory: %q", err)
+		t.Fatalf("Unable to create a temporary directory: %q", err)
 	}
+	defer os.Remove(mountPath)
+
 	step := &StepMountDevice{
 		MountOptions:   []string{"foo"},
 		MountPartition: "42",
@@ -73,4 +76,589 @@ func TestStepMountDevice_Run(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = getErrs
+}
+
+func TestStepMountDevice_Run_LVMActive(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		break
+	default:
+		t.Skip("Unsupported operating system")
+	}
+	mountPath, err := os.MkdirTemp("", "stepmountdevicetest-lvm")
+	if err != nil {
+		t.Fatalf("Unable to create a temporary directory: %q", err)
+	}
+	defer os.Remove(mountPath)
+
+	step := &StepMountDevice{
+		MountOptions:   []string{"nouuid"},
+		MountPartition: "1", // should be cleared by lvm_active
+		MountPath:      mountPath,
+	}
+
+	var gotCommand string
+	var wrapper common.CommandWrapper = func(ran string) (string, error) {
+		gotCommand = ran
+		return "", nil
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("wrappedCommand", wrapper)
+	state.Put("device", "/dev/mapper/rhel-root")
+	state.Put("lvm_active", true) // LVM active: mount partition should be ignored
+
+	ui, _ := testUI()
+	state.Put("ui", ui)
+
+	var config Config
+	state.Put("config", &config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	got := step.Run(ctx, state)
+	if got != multistep.ActionContinue {
+		t.Fatalf("Expected 'continue', but got '%v'", got)
+	}
+
+	// When lvm_active is set, the device should be used directly without any partition suffix
+	expectedCommand := fmt.Sprintf("mount -o nouuid %s %s", "/dev/mapper/rhel-root", mountPath)
+	if gotCommand != expectedCommand {
+		t.Errorf("Expected %q, but got %q", expectedCommand, gotCommand)
+	}
+
+	// Verify deviceMount in state bag
+	deviceMount := state.Get("deviceMount").(string)
+	if deviceMount != "/dev/mapper/rhel-root" {
+		t.Errorf("Expected deviceMount %q, but got %q", "/dev/mapper/rhel-root", deviceMount)
+	}
+}
+
+func TestStepMountDevice_CleanupFunc_Unmount(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		break
+	default:
+		t.Skip("Unsupported operating system")
+	}
+	mountPath, err := os.MkdirTemp("", "stepmountdevicetest-cleanup")
+	if err != nil {
+		t.Fatalf("Unable to create a temporary directory: %q", err)
+	}
+	defer os.Remove(mountPath)
+
+	step := &StepMountDevice{
+		MountPath: mountPath,
+	}
+
+	var gotCommand string
+	var wrapper common.CommandWrapper = func(ran string) (string, error) {
+		gotCommand = ran
+		return "", nil
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("wrappedCommand", wrapper)
+	state.Put("device", "/dev/quux")
+
+	ui, _ := testUI()
+	state.Put("ui", ui)
+
+	var config Config
+	state.Put("config", &config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	got := step.Run(ctx, state)
+	if got != multistep.ActionContinue {
+		t.Fatalf("Expected 'continue', but got '%v'", got)
+	}
+
+	// Reset gotCommand to capture cleanup command
+	gotCommand = ""
+
+	err = step.CleanupFunc(state)
+	if err != nil {
+		t.Errorf("Expected nil error from CleanupFunc, got %v", err)
+	}
+
+	expectedCommand := fmt.Sprintf("umount -R %s", mountPath)
+	if gotCommand != expectedCommand {
+		t.Errorf("Expected %q, but got %q", expectedCommand, gotCommand)
+	}
+
+	// Second call should be a no-op
+	gotCommand = ""
+	err = step.CleanupFunc(state)
+	if err != nil {
+		t.Errorf("Expected nil error from second CleanupFunc, got %v", err)
+	}
+	if gotCommand != "" {
+		t.Errorf("Expected no command on second CleanupFunc, got %q", gotCommand)
+	}
+}
+
+func TestStepMountDevice_CleanupFunc_ManualMount_SkipsUnmount(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		break
+	default:
+		t.Skip("Unsupported operating system")
+	}
+	mountPath, err := os.MkdirTemp("", "stepmountdevicetest-manual-cleanup")
+	if err != nil {
+		t.Fatalf("Unable to create a temporary directory: %q", err)
+	}
+	defer os.Remove(mountPath)
+
+	step := &StepMountDevice{
+		Command:        "custom-mount-script",
+		MountPath:      mountPath,
+		mountPath:      mountPath,
+		isManualMount:  true,
+	}
+
+	wrapperCalled := false
+	var wrapper common.CommandWrapper = func(ran string) (string, error) {
+		wrapperCalled = true
+		return "", nil
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("wrappedCommand", wrapper)
+
+	ui, _ := testUI()
+	state.Put("ui", ui)
+
+	err = step.CleanupFunc(state)
+	if err != nil {
+		t.Errorf("Expected nil error from CleanupFunc, got %v", err)
+	}
+
+	if wrapperCalled {
+		t.Errorf("Expected wrappedCommand to not be called")
+	}
+
+	if step.mountPath != "" {
+		t.Errorf("Expected step.mountPath to be reset to empty string, got %q", step.mountPath)
+	}
+}
+
+func TestStepMountDevice_CleanupFunc_NeverMounted(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		break
+	default:
+		t.Skip("Unsupported operating system")
+	}
+	step := &StepMountDevice{
+		mountPath: "",
+	}
+
+	state := new(multistep.BasicStateBag)
+	// No UI or wrappedCommand in state bag, so if it tries to use them it will panic
+
+	err := step.CleanupFunc(state)
+	if err != nil {
+		t.Errorf("Expected nil error from CleanupFunc, got %v", err)
+	}
+}
+
+func TestStepMountDevice_Run_EmptyMountPartition_NoLVM(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		break
+	default:
+		t.Skip("Unsupported operating system")
+	}
+	mountPath, err := os.MkdirTemp("", "stepmountdevicetest-empty-part")
+	if err != nil {
+		t.Fatalf("Unable to create a temporary directory: %q", err)
+	}
+	defer os.Remove(mountPath)
+
+	step := &StepMountDevice{
+		MountPartition: "",
+		MountPath:      mountPath,
+	}
+
+	var gotCommand string
+	var wrapper common.CommandWrapper = func(ran string) (string, error) {
+		gotCommand = ran
+		return "", nil
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("wrappedCommand", wrapper)
+	state.Put("device", "/dev/sda")
+
+	ui, _ := testUI()
+	state.Put("ui", ui)
+
+	var config Config
+	state.Put("config", &config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	got := step.Run(ctx, state)
+	if got != multistep.ActionContinue {
+		t.Fatalf("Expected 'continue', but got '%v'", got)
+	}
+
+	expectedCommand := fmt.Sprintf("mount  %s %s", "/dev/sda", mountPath)
+	if gotCommand != expectedCommand {
+		t.Errorf("Expected %q, but got %q", expectedCommand, gotCommand)
+	}
+
+	deviceMount := state.Get("deviceMount").(string)
+	if deviceMount != "/dev/sda" {
+		t.Errorf("Expected deviceMount %q, but got %q", "/dev/sda", deviceMount)
+	}
+}
+
+func TestStepMountDevice_Run_ManualMountCommand(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		break
+	default:
+		t.Skip("Unsupported operating system")
+	}
+	mountPath, err := os.MkdirTemp("", "stepmountdevicetest-manual")
+	if err != nil {
+		t.Fatalf("Unable to create a temporary directory: %q", err)
+	}
+	defer os.Remove(mountPath)
+
+	step := &StepMountDevice{
+		Command:   "/nonexistent-packer-test-binary-12345",
+		MountPath: mountPath,
+	}
+
+	wrapperCalled := false
+	var wrapper common.CommandWrapper = func(ran string) (string, error) {
+		wrapperCalled = true
+		return "", nil
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("wrappedCommand", wrapper)
+	state.Put("device", "/dev/quux")
+
+	ui, _ := testUI()
+	state.Put("ui", ui)
+
+	var config Config
+	state.Put("config", &config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// Note: This test verifies the manual mount code path is taken.
+	// It expects ActionHalt because the command doesn't exist.
+	// It does not explicitly verify that os.MkdirAll was skipped,
+	// but the fact that it reaches the command execution without
+	// erroring on directory creation implicitly tests this path.
+	got := step.Run(ctx, state)
+	if got != multistep.ActionHalt {
+		t.Fatalf("Expected 'halt', but got '%v'", got)
+	}
+
+	if wrapperCalled {
+		t.Errorf("Expected wrappedCommand to not be called")
+	}
+
+	errState, ok := state.GetOk("error")
+	if !ok || errState == nil {
+		t.Fatalf("Expected error in state bag")
+	}
+
+	errMsg := errState.(error).Error()
+	if !strings.Contains(errMsg, "error mounting root volume") {
+		t.Errorf("Expected error message to contain 'error mounting root volume', got %q", errMsg)
+	}
+}
+
+func TestStepMountDevice_Run_WrapperError(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		break
+	default:
+		t.Skip("Unsupported operating system")
+	}
+	mountPath, err := os.MkdirTemp("", "stepmountdevicetest-wrapper-err")
+	if err != nil {
+		t.Fatalf("Unable to create a temporary directory: %q", err)
+	}
+	defer os.Remove(mountPath)
+
+	step := &StepMountDevice{
+		MountPath: mountPath,
+	}
+
+	var wrapper common.CommandWrapper = func(ran string) (string, error) {
+		return "", fmt.Errorf("wrapper failed")
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("wrappedCommand", wrapper)
+	state.Put("device", "/dev/quux")
+
+	ui, _ := testUI()
+	state.Put("ui", ui)
+
+	var config Config
+	state.Put("config", &config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	got := step.Run(ctx, state)
+	if got != multistep.ActionHalt {
+		t.Fatalf("Expected 'halt', but got '%v'", got)
+	}
+
+	errState, ok := state.GetOk("error")
+	if !ok || errState == nil {
+		t.Fatalf("Expected error in state bag")
+	}
+
+	errMsg := errState.(error).Error()
+	if !strings.Contains(errMsg, "error creating mount command") {
+		t.Errorf("Expected error message to contain 'error creating mount command', got %q", errMsg)
+	}
+}
+
+func TestStepMountDevice_Run_StateBag_MountPath_And_Cleanup(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		break
+	default:
+		t.Skip("Unsupported operating system")
+	}
+	mountPath, err := os.MkdirTemp("", "stepmountdevicetest-statebag")
+	if err != nil {
+		t.Fatalf("Unable to create a temporary directory: %q", err)
+	}
+	defer os.Remove(mountPath)
+
+	step := &StepMountDevice{
+		MountPath: mountPath,
+	}
+
+	var wrapper common.CommandWrapper = func(ran string) (string, error) {
+		return "", nil
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("wrappedCommand", wrapper)
+	state.Put("device", "/dev/quux")
+
+	ui, _ := testUI()
+	state.Put("ui", ui)
+
+	var config Config
+	state.Put("config", &config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	got := step.Run(ctx, state)
+	if got != multistep.ActionContinue {
+		t.Fatalf("Expected 'continue', but got '%v'", got)
+	}
+
+	// Note: mountPath from MkdirTemp is already absolute, and the implementation
+	// calls filepath.Abs(). On Linux/FreeBSD these should match. If run on a system
+	// with symlinked temp dirs (e.g. macOS /tmp -> /private/tmp), they could diverge,
+	// but the OS guard at the top prevents this.
+	if state.Get("mount_path") != mountPath {
+		t.Errorf("Expected mount_path in state bag to be %q, got %q", mountPath, state.Get("mount_path"))
+	}
+
+	if state.Get("mount_device_cleanup") != step {
+		t.Errorf("Expected mount_device_cleanup in state bag to be the step instance")
+	}
+
+	expectedMountDevice := "/dev/quux"
+	if state.Get("deviceMount") != expectedMountDevice {
+		t.Errorf("Expected deviceMount in state bag to be %q, got %q", expectedMountDevice, state.Get("deviceMount"))
+	}
+}
+
+func TestStepMountDevice_Run_MultipleMountOptions(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		break
+	default:
+		t.Skip("Unsupported operating system")
+	}
+	mountPath, err := os.MkdirTemp("", "stepmountdevicetest-multi-opts")
+	if err != nil {
+		t.Fatalf("Unable to create a temporary directory: %q", err)
+	}
+	defer os.Remove(mountPath)
+
+	step := &StepMountDevice{
+		MountOptions: []string{"nouuid", "ro", "noatime"},
+		MountPath:    mountPath,
+	}
+
+	var gotCommand string
+	var wrapper common.CommandWrapper = func(ran string) (string, error) {
+		gotCommand = ran
+		return "", nil
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("wrappedCommand", wrapper)
+	state.Put("device", "/dev/quux")
+
+	ui, _ := testUI()
+	state.Put("ui", ui)
+
+	var config Config
+	state.Put("config", &config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	got := step.Run(ctx, state)
+	if got != multistep.ActionContinue {
+		t.Fatalf("Expected 'continue', but got '%v'", got)
+	}
+
+	expectedMountDevice := "/dev/quux"
+	expectedCommand := fmt.Sprintf("mount -o nouuid -o ro -o noatime %s %s", expectedMountDevice, mountPath)
+	if gotCommand != expectedCommand {
+		t.Errorf("Expected %q, but got %q", expectedCommand, gotCommand)
+	}
+}
+
+func TestStepMountDevice_Run_NoMountOptions(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		break
+	default:
+		t.Skip("Unsupported operating system")
+	}
+	mountPath, err := os.MkdirTemp("", "stepmountdevicetest-no-opts")
+	if err != nil {
+		t.Fatalf("Unable to create a temporary directory: %q", err)
+	}
+	defer os.Remove(mountPath)
+
+	step := &StepMountDevice{
+		MountOptions: []string{},
+		MountPath:    mountPath,
+	}
+
+	var gotCommand string
+	var wrapper common.CommandWrapper = func(ran string) (string, error) {
+		gotCommand = ran
+		return "", nil
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("wrappedCommand", wrapper)
+	state.Put("device", "/dev/quux")
+
+	ui, _ := testUI()
+	state.Put("ui", ui)
+
+	var config Config
+	state.Put("config", &config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	got := step.Run(ctx, state)
+	if got != multistep.ActionContinue {
+		t.Fatalf("Expected 'continue', but got '%v'", got)
+	}
+
+	expectedMountDevice := "/dev/quux"
+	expectedCommand := fmt.Sprintf("mount  %s %s", expectedMountDevice, mountPath)
+	if gotCommand != expectedCommand {
+		t.Errorf("Expected %q, but got %q", expectedCommand, gotCommand)
+	}
+}
+
+func TestStepMountDevice_Run_MountPath_Interpolation_Error(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		break
+	default:
+		t.Skip("Unsupported operating system")
+	}
+
+	step := &StepMountDevice{
+		MountPath: "{{.BadField}}",
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("device", "/dev/quux")
+
+	ui, _ := testUI()
+	state.Put("ui", ui)
+
+	var config Config
+	state.Put("config", &config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	got := step.Run(ctx, state)
+	if got != multistep.ActionHalt {
+		t.Fatalf("Expected 'halt', but got '%v'", got)
+	}
+
+	errState, ok := state.GetOk("error")
+	if !ok || errState == nil {
+		t.Fatalf("Expected error in state bag")
+	}
+
+	errMsg := errState.(error).Error()
+	if !strings.Contains(errMsg, "error preparing mount directory") {
+		t.Errorf("Expected error message to contain 'error preparing mount directory', got %q", errMsg)
+	}
+}
+
+func TestStepMountDevice_Cleanup_Error(t *testing.T) {
+	switch runtime.GOOS {
+	case "linux", "freebsd":
+		break
+	default:
+		t.Skip("Unsupported operating system")
+	}
+	mountPath, err := os.MkdirTemp("", "stepmountdevicetest-cleanup-err")
+	if err != nil {
+		t.Fatalf("Unable to create a temporary directory: %q", err)
+	}
+	defer os.Remove(mountPath)
+
+	step := &StepMountDevice{
+		MountPath: mountPath,
+		mountPath: mountPath, // simulate successful mount
+	}
+
+	var wrapper common.CommandWrapper = func(ran string) (string, error) {
+		return "", fmt.Errorf("wrapper failed")
+	}
+
+	state := new(multistep.BasicStateBag)
+	state.Put("wrappedCommand", wrapper)
+
+	ui, getErrs := testUI()
+	state.Put("ui", ui)
+
+	// Call the public Cleanup method, which wraps CleanupFunc and logs errors to UI
+	step.Cleanup(state)
+
+	errs := getErrs()
+	if !strings.Contains(errs, "error creating unmount command") {
+		t.Errorf("Expected UI error to contain 'error creating unmount command', got %q", errs)
+	}
 }

--- a/builder/azure/chroot/step_mount_device_test.go
+++ b/builder/azure/chroot/step_mount_device_test.go
@@ -27,7 +27,7 @@ func TestStepMountDevice_Run(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory: %q", err)
 	}
-	defer os.Remove(mountPath)
+	defer func() { _ = os.Remove(mountPath) }()
 
 	step := &StepMountDevice{
 		MountOptions:   []string{"foo"},
@@ -89,7 +89,7 @@ func TestStepMountDevice_Run_LVMActive(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory: %q", err)
 	}
-	defer os.Remove(mountPath)
+	defer func() { _ = os.Remove(mountPath) }()
 
 	step := &StepMountDevice{
 		MountOptions:   []string{"nouuid"},
@@ -146,7 +146,7 @@ func TestStepMountDevice_CleanupFunc_Unmount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory: %q", err)
 	}
-	defer os.Remove(mountPath)
+	defer func() { _ = os.Remove(mountPath) }()
 
 	step := &StepMountDevice{
 		MountPath: mountPath,

--- a/builder/azure/chroot/step_mount_device_test.go
+++ b/builder/azure/chroot/step_mount_device_test.go
@@ -211,7 +211,7 @@ func TestStepMountDevice_CleanupFunc_ManualMount_SkipsUnmount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory: %q", err)
 	}
-	defer os.Remove(mountPath)
+	defer func() { _ = os.Remove(mountPath) }()
 
 	step := &StepMountDevice{
 		Command:       "custom-mount-script",
@@ -277,7 +277,7 @@ func TestStepMountDevice_Run_EmptyMountPartition_NoLVM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory: %q", err)
 	}
-	defer os.Remove(mountPath)
+	defer func() { _ = os.Remove(mountPath) }()
 
 	step := &StepMountDevice{
 		MountPartition: "",
@@ -330,7 +330,7 @@ func TestStepMountDevice_Run_ManualMountCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory: %q", err)
 	}
-	defer os.Remove(mountPath)
+	defer func() { _ = os.Remove(mountPath) }()
 
 	step := &StepMountDevice{
 		Command:   "/nonexistent-packer-test-binary-12345",
@@ -392,7 +392,7 @@ func TestStepMountDevice_Run_WrapperError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory: %q", err)
 	}
-	defer os.Remove(mountPath)
+	defer func() { _ = os.Remove(mountPath) }()
 
 	step := &StepMountDevice{
 		MountPath: mountPath,
@@ -442,7 +442,7 @@ func TestStepMountDevice_Run_StateBag_MountPath_And_Cleanup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory: %q", err)
 	}
-	defer os.Remove(mountPath)
+	defer func() { _ = os.Remove(mountPath) }()
 
 	step := &StepMountDevice{
 		MountPath: mountPath,
@@ -499,7 +499,7 @@ func TestStepMountDevice_Run_MultipleMountOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory: %q", err)
 	}
-	defer os.Remove(mountPath)
+	defer func() { _ = os.Remove(mountPath) }()
 
 	step := &StepMountDevice{
 		MountOptions: []string{"nouuid", "ro", "noatime"},
@@ -548,7 +548,7 @@ func TestStepMountDevice_Run_NoMountOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory: %q", err)
 	}
-	defer os.Remove(mountPath)
+	defer func() { _ = os.Remove(mountPath) }()
 
 	step := &StepMountDevice{
 		MountOptions: []string{},
@@ -637,7 +637,7 @@ func TestStepMountDevice_Cleanup_Error(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create a temporary directory: %q", err)
 	}
-	defer os.Remove(mountPath)
+	defer func() { _ = os.Remove(mountPath) }()
 
 	step := &StepMountDevice{
 		MountPath: mountPath,

--- a/builder/azure/chroot/step_mount_device_test.go
+++ b/builder/azure/chroot/step_mount_device_test.go
@@ -214,10 +214,10 @@ func TestStepMountDevice_CleanupFunc_ManualMount_SkipsUnmount(t *testing.T) {
 	defer os.Remove(mountPath)
 
 	step := &StepMountDevice{
-		Command:        "custom-mount-script",
-		MountPath:      mountPath,
-		mountPath:      mountPath,
-		isManualMount:  true,
+		Command:       "custom-mount-script",
+		MountPath:     mountPath,
+		mountPath:     mountPath,
+		isManualMount: true,
 	}
 
 	wrapperCalled := false

--- a/builder/azure/chroot/step_pre_unmount_commands.go
+++ b/builder/azure/chroot/step_pre_unmount_commands.go
@@ -1,0 +1,60 @@
+// Copyright IBM Corp. 2013, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package chroot
+
+import (
+	"context"
+
+	"github.com/hashicorp/packer-plugin-sdk/chroot"
+	"github.com/hashicorp/packer-plugin-sdk/common"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
+)
+
+// contextProvider is a local interface to access the config's interpolation context.
+type contextProvider interface {
+	GetContext() interpolate.Context
+}
+
+// preUnmountCommandsData provides template data for pre-unmount commands.
+type preUnmountCommandsData struct {
+	Device    string
+	MountPath string
+}
+
+// StepPreUnmountCommands runs user-specified commands after provisioning but
+// before the chroot is unmounted and LVM volumes are deactivated.
+type StepPreUnmountCommands struct {
+	Commands []string
+}
+
+func (s *StepPreUnmountCommands) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	if len(s.Commands) == 0 {
+		return multistep.ActionContinue
+	}
+
+	ui := state.Get("ui").(packersdk.Ui)
+	config := state.Get("config").(contextProvider)
+	device := state.Get("device").(string)
+	mountPath := state.Get("mount_path").(string)
+	wrappedCommand := state.Get("wrappedCommand").(common.CommandWrapper)
+
+	ictx := config.GetContext()
+	ictx.Data = &preUnmountCommandsData{
+		Device:    device,
+		MountPath: mountPath,
+	}
+
+	ui.Say("Running pre-unmount commands...")
+	if err := chroot.RunLocalCommands(s.Commands, wrappedCommand, ictx, ui); err != nil {
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *StepPreUnmountCommands) Cleanup(state multistep.StateBag) {}

--- a/builder/azure/chroot/step_setup_lvm.go
+++ b/builder/azure/chroot/step_setup_lvm.go
@@ -1,0 +1,584 @@
+// Copyright IBM Corp. 2013, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux || freebsd
+
+package chroot
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/log"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+var _ multistep.Step = &StepSetupLVM{}
+
+// StepSetupLVM detects and activates LVM volume groups on the attached disk,
+// replacing the "device" state bag entry with the root logical volume path.
+// If no LVM is detected, this step is a no-op.
+type StepSetupLVM struct {
+	// device is populated from the state bag ("device") at runtime.
+	device string
+
+	// volumeGroups that were activated by this step (for cleanup).
+	volumeGroups []string
+
+	// LVMRootDevice override — if set by the user, skip auto-detection
+	// and use this path directly (e.g. "/dev/mapper/rhel-root").
+	LVMRootDevice string
+
+	// activated tracks whether LVM was detected and activated (for cleanup).
+	activated bool
+}
+
+func (s *StepSetupLVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packersdk.Ui)
+	device := state.Get("device").(string)
+	s.device = device
+
+	if s.LVMRootDevice != "" {
+		// Manual override path
+		ui.Say(fmt.Sprintf("LVM: using user-specified root device: %s", s.LVMRootDevice))
+
+		vgs, err := s.detectVolumeGroups(device)
+		if err != nil {
+			log.Printf("LVM: warning: could not detect volume groups for cleanup scoping: %v", err)
+			// Without VG names we cannot safely scope vgchange; try to
+			// extract the VG name from the user-specified device path.
+			if vg := vgFromDevicePath(s.LVMRootDevice); vg != "" {
+				s.volumeGroups = []string{vg}
+				log.Printf("LVM: inferred VG %q from lvm_root_device", vg)
+			}
+		} else {
+			s.volumeGroups = vgs
+		}
+
+		if len(s.volumeGroups) == 0 {
+			return s.halt(state, ui, fmt.Errorf(
+				"LVM: cannot activate volume groups: unable to detect VGs on %s and unable to infer VG from lvm_root_device %q; "+
+					"ensure the source disk contains LVM physical volumes",
+				device, s.LVMRootDevice))
+		}
+
+		if err := s.activateVolumeGroups(ui); err != nil {
+			return s.halt(state, ui, fmt.Errorf("LVM: error activating volume groups: %v", err))
+		}
+
+		state.Put("device", s.LVMRootDevice)
+		state.Put("lvm_active", true)
+		state.Put("lvm_cleanup", s)
+		return multistep.ActionContinue
+	}
+
+	// Auto-detection path
+	ui.Say("LVM: scanning attached disk for LVM physical volumes...")
+
+	vgs, err := s.detectVolumeGroups(device)
+	if err != nil {
+		log.Printf("LVM: warning: error detecting volume groups: %v", err)
+		ui.Say("LVM: could not detect volume groups, continuing without LVM support")
+		state.Put("lvm_cleanup", s)
+		return multistep.ActionContinue
+	}
+
+	if len(vgs) == 0 {
+		ui.Say("LVM: no volume groups found on attached disk, continuing without LVM")
+		state.Put("lvm_cleanup", s)
+		return multistep.ActionContinue
+	}
+
+	s.volumeGroups = vgs
+	ui.Say(fmt.Sprintf("LVM: found volume group(s): %s", strings.Join(vgs, ", ")))
+
+	if err := s.activateVolumeGroups(ui); err != nil {
+		return s.halt(state, ui, fmt.Errorf("LVM: error activating volume groups: %v", err))
+	}
+
+	rootLV, err := s.findRootLV(vgs, ui)
+	if err != nil {
+		return s.halt(state, ui, fmt.Errorf("LVM: error finding root logical volume: %v", err))
+	}
+
+	s.verifyDevice(ui, rootLV)
+
+	ui.Say(fmt.Sprintf("LVM: using root logical volume: %s", rootLV))
+	state.Put("device", rootLV)
+	state.Put("lvm_active", true)
+	state.Put("lvm_cleanup", s)
+	return multistep.ActionContinue
+}
+
+// detectVolumeGroups ensures partition device nodes are visible, then scans for
+// LVM physical volumes on the attached disk.
+func (s *StepSetupLVM) detectVolumeGroups(device string) ([]string, error) {
+	// Run partprobe to ensure partition device nodes exist
+	if out, err := exec.Command("partprobe", device).CombinedOutput(); err != nil {
+		log.Printf("LVM: partprobe %s: %v (output: %s)", device, err, strings.TrimSpace(string(out)))
+	}
+
+	// Wait for udev to settle
+	if out, err := exec.Command("udevadm", "settle", "--timeout=10").CombinedOutput(); err != nil {
+		log.Printf("LVM: udevadm settle: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+
+	// Refresh PV cache
+	if out, err := exec.Command("pvscan", "--cache").CombinedOutput(); err != nil {
+		log.Printf("LVM: pvscan --cache: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+
+	// Retry loop: Azure disk attachment is asynchronous — partition device nodes
+	// may not exist immediately after the disk appears.
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			log.Printf("LVM: retry attempt %d/3, waiting for device nodes...", attempt+1)
+			time.Sleep(2 * time.Second)
+
+			if out, err := exec.Command("partprobe", device).CombinedOutput(); err != nil {
+				log.Printf("LVM: partprobe %s (retry): %v (output: %s)", device, err, strings.TrimSpace(string(out)))
+			}
+			if out, err := exec.Command("udevadm", "settle", "--timeout=5").CombinedOutput(); err != nil {
+				log.Printf("LVM: udevadm settle (retry): %v (output: %s)", err, strings.TrimSpace(string(out)))
+			}
+			if out, err := exec.Command("pvscan", "--cache").CombinedOutput(); err != nil {
+				log.Printf("LVM: pvscan --cache (retry): %v (output: %s)", err, strings.TrimSpace(string(out)))
+			}
+		}
+
+		vgs, err := s.scanPVS(device)
+		if err != nil {
+			log.Printf("LVM: scanPVS attempt %d: %v", attempt+1, err)
+			continue
+		}
+		if len(vgs) > 0 {
+			return vgs, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// scanPVS runs `pvs` and returns VG names for PVs that belong to the specified device.
+func (s *StepSetupLVM) scanPVS(device string) ([]string, error) {
+	cmd := exec.Command("pvs", "--noheadings", "--nosuffix", "-o", "pv_name,vg_name", "--separator", ",")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("pvs: %v (stderr: %s)", err, strings.TrimSpace(stderr.String()))
+	}
+
+	seen := make(map[string]bool)
+	var vgs []string
+
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ",", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		pvName := strings.TrimSpace(parts[0])
+		vgName := strings.TrimSpace(parts[1])
+
+		// Scope to our disk only: check that the PV is on the attached device
+		if !strings.HasPrefix(pvName, device) {
+			continue
+		}
+
+		if vgName != "" && !seen[vgName] {
+			seen[vgName] = true
+			vgs = append(vgs, vgName)
+		}
+	}
+
+	return vgs, nil
+}
+
+// activateVolumeGroups activates the discovered volume groups.
+func (s *StepSetupLVM) activateVolumeGroups(ui packersdk.Ui) error {
+	// Scan for VGs first
+	if out, err := exec.Command("vgscan").CombinedOutput(); err != nil {
+		log.Printf("LVM: vgscan: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+
+	// Build vgchange args, scoping to our VGs if known
+	args := []string{"-ay"}
+	if len(s.volumeGroups) > 0 {
+		args = append(args, s.volumeGroups...)
+	}
+
+	cmd := exec.Command("vgchange", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("vgchange %s: %v (stdout: %s, stderr: %s)",
+			strings.Join(args, " "), err,
+			strings.TrimSpace(stdout.String()),
+			strings.TrimSpace(stderr.String()))
+	}
+	s.activated = true
+
+	// Ensure /dev/mapper/ nodes exist
+	if out, err := exec.Command("vgmknodes").CombinedOutput(); err != nil {
+		log.Printf("LVM: vgmknodes: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+
+	// Wait for udev to settle
+	if out, err := exec.Command("udevadm", "settle", "--timeout=10").CombinedOutput(); err != nil {
+		log.Printf("LVM: udevadm settle: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+
+	ui.Say("LVM: volume groups activated successfully")
+	return nil
+}
+
+// lvInfo holds parsed information about a logical volume.
+type lvInfo struct {
+	name string
+	vg   string
+	path string
+	attr string
+}
+
+// findRootLV identifies the root logical volume from the activated volume groups.
+func (s *StepSetupLVM) findRootLV(vgs []string, ui packersdk.Ui) (string, error) {
+	cmd := exec.Command("lvs", "--noheadings", "--nosuffix", "-o", "lv_name,vg_name,lv_path,lv_attr", "--separator", ",")
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("lvs: %v (stderr: %s)", err, strings.TrimSpace(stderr.String()))
+	}
+
+	vgSet := make(map[string]bool)
+	for _, vg := range vgs {
+		vgSet[vg] = true
+	}
+
+	var allLVs []lvInfo
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ",", 4)
+		if len(parts) != 4 {
+			continue
+		}
+		lv := lvInfo{
+			name: strings.TrimSpace(parts[0]),
+			vg:   strings.TrimSpace(parts[1]),
+			path: strings.TrimSpace(parts[2]),
+			attr: strings.TrimSpace(parts[3]),
+		}
+		if vgSet[lv.vg] {
+			allLVs = append(allLVs, lv)
+		}
+	}
+
+	// Log all discovered LVs
+	for _, lv := range allLVs {
+		log.Printf("LVM: discovered LV: name=%s vg=%s path=%s attr=%s", lv.name, lv.vg, lv.path, lv.attr)
+	}
+
+	// Filter by LV type: exclude non-mountable volumes
+	var mountable []lvInfo
+	for _, lv := range allLVs {
+		if isMountableLV(lv.attr) {
+			mountable = append(mountable, lv)
+		} else {
+			log.Printf("LVM: skipping LV %s (%s): %s", lv.name, lv.path, lvTypeDescription(lv.attr))
+		}
+	}
+
+	if len(mountable) == 0 {
+		return "", fmt.Errorf("no mountable logical volumes found in volume groups %v", vgs)
+	}
+
+	// Filter out swap volumes using blkid
+	var nonSwap []lvInfo
+	for _, lv := range mountable {
+		fsType := blkidType(lv.path)
+		if strings.EqualFold(fsType, "swap") {
+			log.Printf("LVM: skipping LV %s (%s): swap filesystem", lv.name, lv.path)
+			continue
+		}
+		nonSwap = append(nonSwap, lv)
+	}
+
+	// If blkid filtered everything, fall back to attribute-filtered list
+	if len(nonSwap) == 0 {
+		log.Printf("LVM: blkid filtered all candidates, falling back to attribute-filtered list")
+		nonSwap = mountable
+	}
+
+	// If exactly one candidate, return it
+	if len(nonSwap) == 1 {
+		return nonSwap[0].path, nil
+	}
+
+	// Multiple candidates: try exact name-based matching first
+	for _, lv := range nonSwap {
+		nameLower := strings.ToLower(lv.name)
+		if nameLower == "root" || nameLower == "lv_root" || nameLower == "rootlv" || nameLower == "lvroot" {
+			ui.Say(fmt.Sprintf("LVM: selected root LV by exact name match: %s (%s)", lv.name, lv.path))
+			return lv.path, nil
+		}
+	}
+
+	// Fallback: partial name match containing "root"
+	for _, lv := range nonSwap {
+		if strings.Contains(strings.ToLower(lv.name), "root") {
+			ui.Say(fmt.Sprintf("LVM: selected root LV by partial name match: %s (%s)", lv.name, lv.path))
+			return lv.path, nil
+		}
+	}
+
+	// No name match: warn user and return the first candidate
+	ui.Say("WARNING: LVM: multiple logical volumes found, unable to determine root by name:")
+	for _, lv := range nonSwap {
+		fsType := blkidType(lv.path)
+		if fsType == "" {
+			fsType = "unknown"
+		}
+		ui.Say(fmt.Sprintf("  - %s (%s) [fs: %s]", lv.name, lv.path, fsType))
+	}
+	ui.Say(fmt.Sprintf("LVM: selecting first candidate: %s", nonSwap[0].path))
+	ui.Say("LVM: if this is incorrect, set 'lvm_root_device' in your Packer template")
+	return nonSwap[0].path, nil
+}
+
+// isMountableLV returns true unless the first character of lv_attr indicates
+// a non-mountable LV type.
+func isMountableLV(attr string) bool {
+	if attr == "" {
+		return true
+	}
+	switch attr[0] {
+	case 's', 'S': // snapshot
+		return false
+	case 'v', 'V': // virtual (e.g. thin snapshot device)
+		return false
+	case 't', 'T': // thin pool
+		return false
+	case 'e', 'E': // RAID/pool metadata
+		return false
+	case 'i', 'I': // internal
+		return false
+	case 'l', 'L': // mirror log
+		return false
+	case 'd', 'D': // mirror/RAID image
+		return false
+	case 'p': // pvmove
+		return false
+	default:
+		return true
+	}
+}
+
+// lvTypeDescription returns a human-readable description of the LV type.
+func lvTypeDescription(attr string) string {
+	if attr == "" {
+		return "unknown type"
+	}
+	switch attr[0] {
+	case 's', 'S':
+		return "snapshot"
+	case 'v', 'V':
+		return "virtual volume"
+	case 't', 'T':
+		return "thin pool"
+	case 'e', 'E':
+		return "RAID/pool metadata"
+	case 'i', 'I':
+		return "internal volume"
+	case 'l', 'L':
+		return "mirror log"
+	case 'd', 'D':
+		return "mirror/RAID image"
+	case 'p':
+		return "pvmove volume"
+	default:
+		return "unknown type"
+	}
+}
+
+// blkidType runs `blkid -o value -s TYPE` on the device and returns the filesystem type.
+func blkidType(device string) string {
+	out, err := exec.Command("blkid", "-o", "value", "-s", "TYPE", device).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// verifyDevice checks that the selected LV is readable by blkid, attempting
+// a refresh if not.
+func (s *StepSetupLVM) verifyDevice(ui packersdk.Ui, device string) {
+	fsType := blkidType(device)
+	if fsType != "" {
+		log.Printf("LVM: device %s has filesystem type: %s", device, fsType)
+		return
+	}
+
+	log.Printf("LVM: device %s not immediately readable by blkid, attempting refresh...", device)
+
+	// Try to determine VG/LV for lvchange --refresh
+	vgLV := resolveVGLV(device)
+	if vgLV != "" {
+		log.Printf("LVM: running lvchange --refresh %s", vgLV)
+		if out, err := exec.Command("lvchange", "--refresh", vgLV).CombinedOutput(); err != nil {
+			log.Printf("LVM: lvchange --refresh %s: %v (output: %s)", vgLV, err, strings.TrimSpace(string(out)))
+		}
+	}
+
+	// Wait for udev and retry
+	if out, err := exec.Command("udevadm", "settle", "--timeout=10").CombinedOutput(); err != nil {
+		log.Printf("LVM: udevadm settle: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+	time.Sleep(1 * time.Second)
+
+	fsType = blkidType(device)
+	if fsType != "" {
+		log.Printf("LVM: device %s now has filesystem type: %s (after refresh)", device, fsType)
+		return
+	}
+
+	// Still unreadable — dump diagnostics
+	ui.Say(fmt.Sprintf("WARNING: LVM: device %s is not readable by blkid after refresh", device))
+
+	if out, err := exec.Command("lvs", "-a").CombinedOutput(); err != nil {
+		log.Printf("LVM: lvs -a: %v (output: %s)", err, strings.TrimSpace(string(out)))
+	} else {
+		log.Printf("LVM: lvs -a output:\n%s", string(out))
+	}
+
+	// For dmsetup table, extract the dm name from the device path
+	dmName := device
+	if strings.HasPrefix(device, "/dev/mapper/") {
+		dmName = strings.TrimPrefix(device, "/dev/mapper/")
+	}
+	if out, err := exec.Command("dmsetup", "table", dmName).CombinedOutput(); err != nil {
+		log.Printf("LVM: dmsetup table %s: %v (output: %s)", dmName, err, strings.TrimSpace(string(out)))
+	} else {
+		log.Printf("LVM: dmsetup table %s output:\n%s", dmName, string(out))
+	}
+}
+
+// resolveVGLV determines the VG/LV identifier from a device path for use with
+// lvchange --refresh. It handles both /dev/mapper/ and /dev/<vg>/<lv> paths.
+func resolveVGLV(device string) string {
+	if strings.HasPrefix(device, "/dev/mapper/") {
+		basename := device[len("/dev/mapper/"):]
+		// Try dmsetup splitname to correctly handle double-dash escaping
+		out, err := exec.Command("dmsetup", "splitname", "--noheadings", "--separator", "/", basename, "LVM").Output()
+		if err == nil {
+			// dmsetup splitname output format: "  vg/lv/layer" or "  vg/lv/"
+			result := strings.TrimSpace(string(out))
+			parts := strings.SplitN(result, "/", 3)
+			if len(parts) >= 2 && parts[0] != "" && parts[1] != "" {
+				return parts[0] + "/" + parts[1]
+			}
+		}
+		log.Printf("LVM: dmsetup splitname failed or unavailable, falling back to heuristic for %s", basename)
+
+		// Fallback heuristic: find the last single-dash boundary
+		// LVM uses double-dashes to escape dashes in VG/LV names, so
+		// "my--vg-root" means VG="my-vg", LV="root"
+		// We look for a dash that is NOT preceded or followed by another dash.
+		lastIdx := -1
+		for i := 1; i < len(basename)-1; i++ {
+			if basename[i] == '-' && basename[i-1] != '-' && basename[i+1] != '-' {
+				lastIdx = i
+			}
+		}
+		if lastIdx > 0 {
+			vg := strings.ReplaceAll(basename[:lastIdx], "--", "-")
+			lv := strings.ReplaceAll(basename[lastIdx+1:], "--", "-")
+			return vg + "/" + lv
+		}
+		return ""
+	}
+
+	// /dev/<vg>/<lv> style path
+	parts := strings.Split(device, "/")
+	if len(parts) >= 4 {
+		// parts: ["", "dev", "<vg>", "<lv>"]
+		return parts[len(parts)-2] + "/" + parts[len(parts)-1]
+	}
+
+	return ""
+}
+
+// vgFromDevicePath extracts just the VG name from a device path.
+// For /dev/mapper/rhel-root → "rhel", for /dev/rhel/root → "rhel".
+func vgFromDevicePath(device string) string {
+	vgLV := resolveVGLV(device)
+	if vgLV == "" {
+		return ""
+	}
+	parts := strings.SplitN(vgLV, "/", 2)
+	if len(parts) >= 1 && parts[0] != "" {
+		return parts[0]
+	}
+	return ""
+}
+
+func (s *StepSetupLVM) halt(state multistep.StateBag, ui packersdk.Ui, err error) multistep.StepAction {
+	log.Printf("LVM: error: %v", err)
+	state.Put("error", err)
+	ui.Error(err.Error())
+	return multistep.ActionHalt
+}
+
+func (s *StepSetupLVM) Cleanup(state multistep.StateBag) {
+	if err := s.CleanupFunc(state); err != nil {
+		ui := state.Get("ui").(packersdk.Ui)
+		ui.Error(err.Error())
+	}
+}
+
+// CleanupFunc deactivates LVM volume groups that were activated by this step.
+func (s *StepSetupLVM) CleanupFunc(state multistep.StateBag) error {
+	if !s.activated {
+		return nil
+	}
+
+	ui := state.Get("ui").(packersdk.Ui)
+	ui.Say(fmt.Sprintf("LVM: deactivating volume groups: %s", strings.Join(s.volumeGroups, ", ")))
+
+	args := []string{"-an"}
+	if len(s.volumeGroups) > 0 {
+		args = append(args, s.volumeGroups...)
+	}
+
+	cmd := exec.Command("vgchange", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("LVM: vgchange %s: %v (stdout: %s, stderr: %s)",
+			strings.Join(args, " "), err,
+			strings.TrimSpace(stdout.String()),
+			strings.TrimSpace(stderr.String()))
+	}
+
+	s.activated = false
+	ui.Say("LVM: volume groups deactivated")
+	return nil
+}

--- a/builder/azure/chroot/step_setup_lvm.go
+++ b/builder/azure/chroot/step_setup_lvm.go
@@ -82,9 +82,6 @@ func (s *StepSetupLVM) Run(ctx context.Context, state multistep.StateBag) multis
 		return multistep.ActionContinue
 	}
 
-	// Auto-detection path
-	ui.Say("LVM: scanning attached disk for LVM physical volumes...")
-
 	vgs, err := s.detectVolumeGroups(device)
 	if err != nil {
 		log.Printf("LVM: warning: error detecting volume groups: %v", err)

--- a/builder/azure/chroot/step_setup_lvm.go
+++ b/builder/azure/chroot/step_setup_lvm.go
@@ -19,6 +19,13 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
+const (
+	lvmDetectMaxRetries  = 3
+	lvmDetectRetryDelay  = 2 * time.Second
+	lvmUdevSettleTimeout = "10" // seconds, passed to udevadm settle --timeout
+	lvmDeviceVerifyDelay = 1 * time.Second
+)
+
 var _ multistep.Step = &StepSetupLVM{}
 
 // StepSetupLVM detects and activates LVM volume groups on the attached disk,
@@ -126,7 +133,7 @@ func (s *StepSetupLVM) detectVolumeGroups(device string) ([]string, error) {
 	}
 
 	// Wait for udev to settle
-	if out, err := exec.Command("udevadm", "settle", "--timeout=10").CombinedOutput(); err != nil {
+	if out, err := exec.Command("udevadm", "settle", "--timeout="+lvmUdevSettleTimeout).CombinedOutput(); err != nil {
 		log.Printf("LVM: udevadm settle: %v (output: %s)", err, strings.TrimSpace(string(out)))
 	}
 
@@ -138,15 +145,15 @@ func (s *StepSetupLVM) detectVolumeGroups(device string) ([]string, error) {
 	// Retry loop: Azure disk attachment is asynchronous — partition device nodes
 	// may not exist immediately after the disk appears.
 	var lastErr error
-	for attempt := 0; attempt < 3; attempt++ {
+	for attempt := 0; attempt < lvmDetectMaxRetries; attempt++ {
 		if attempt > 0 {
-			log.Printf("LVM: retry attempt %d/3, waiting for device nodes...", attempt+1)
-			time.Sleep(2 * time.Second)
+			log.Printf("LVM: retry attempt %d/%d, waiting for device nodes...", attempt+1, lvmDetectMaxRetries)
+			time.Sleep(lvmDetectRetryDelay)
 
 			if out, err := exec.Command("partprobe", device).CombinedOutput(); err != nil {
 				log.Printf("LVM: partprobe %s (retry): %v (output: %s)", device, err, strings.TrimSpace(string(out)))
 			}
-			if out, err := exec.Command("udevadm", "settle", "--timeout=5").CombinedOutput(); err != nil {
+			if out, err := exec.Command("udevadm", "settle", "--timeout="+lvmUdevSettleTimeout).CombinedOutput(); err != nil {
 				log.Printf("LVM: udevadm settle (retry): %v (output: %s)", err, strings.TrimSpace(string(out)))
 			}
 			if out, err := exec.Command("pvscan", "--cache").CombinedOutput(); err != nil {
@@ -243,7 +250,7 @@ func (s *StepSetupLVM) activateVolumeGroups(ui packersdk.Ui) error {
 	}
 
 	// Wait for udev to settle
-	if out, err := exec.Command("udevadm", "settle", "--timeout=10").CombinedOutput(); err != nil {
+	if out, err := exec.Command("udevadm", "settle", "--timeout="+lvmUdevSettleTimeout).CombinedOutput(); err != nil {
 		log.Printf("LVM: udevadm settle: %v (output: %s)", err, strings.TrimSpace(string(out)))
 	}
 
@@ -456,10 +463,10 @@ func (s *StepSetupLVM) verifyDevice(ui packersdk.Ui, device string) {
 	}
 
 	// Wait for udev and retry
-	if out, err := exec.Command("udevadm", "settle", "--timeout=10").CombinedOutput(); err != nil {
+	if out, err := exec.Command("udevadm", "settle", "--timeout="+lvmUdevSettleTimeout).CombinedOutput(); err != nil {
 		log.Printf("LVM: udevadm settle: %v (output: %s)", err, strings.TrimSpace(string(out)))
 	}
-	time.Sleep(1 * time.Second)
+	time.Sleep(lvmDeviceVerifyDelay)
 
 	fsType = blkidType(device)
 	if fsType != "" {

--- a/builder/azure/chroot/step_setup_lvm.go
+++ b/builder/azure/chroot/step_setup_lvm.go
@@ -55,7 +55,7 @@ func (s *StepSetupLVM) Run(ctx context.Context, state multistep.StateBag) multis
 		// Manual override path
 		ui.Say(fmt.Sprintf("LVM: using user-specified root device: %s", s.LVMRootDevice))
 
-		vgs, err := s.detectVolumeGroups(device)
+		vgs, err := s.detectVolumeGroups(ctx, device)
 		if err != nil || len(vgs) == 0 {
 			if err != nil {
 				log.Printf("LVM: warning: could not detect volume groups for cleanup scoping: %v", err)
@@ -79,7 +79,7 @@ func (s *StepSetupLVM) Run(ctx context.Context, state multistep.StateBag) multis
 				device, s.LVMRootDevice))
 		}
 
-		if err := s.activateVolumeGroups(ui); err != nil {
+		if err := s.activateVolumeGroups(ctx, ui); err != nil {
 			return s.halt(state, ui, fmt.Errorf("LVM: error activating volume groups: %v", err))
 		}
 
@@ -89,7 +89,7 @@ func (s *StepSetupLVM) Run(ctx context.Context, state multistep.StateBag) multis
 		return multistep.ActionContinue
 	}
 
-	vgs, err := s.detectVolumeGroups(device)
+	vgs, err := s.detectVolumeGroups(ctx, device)
 	if err != nil {
 		log.Printf("LVM: warning: error detecting volume groups: %v", err)
 		ui.Say("LVM: could not detect volume groups, continuing without LVM support")
@@ -106,7 +106,7 @@ func (s *StepSetupLVM) Run(ctx context.Context, state multistep.StateBag) multis
 	s.volumeGroups = vgs
 	ui.Say(fmt.Sprintf("LVM: found volume group(s): %s", strings.Join(vgs, ", ")))
 
-	if err := s.activateVolumeGroups(ui); err != nil {
+	if err := s.activateVolumeGroups(ctx, ui); err != nil {
 		return s.halt(state, ui, fmt.Errorf("LVM: error activating volume groups: %v", err))
 	}
 
@@ -126,19 +126,19 @@ func (s *StepSetupLVM) Run(ctx context.Context, state multistep.StateBag) multis
 
 // detectVolumeGroups ensures partition device nodes are visible, then scans for
 // LVM physical volumes on the attached disk.
-func (s *StepSetupLVM) detectVolumeGroups(device string) ([]string, error) {
+func (s *StepSetupLVM) detectVolumeGroups(ctx context.Context, device string) ([]string, error) {
 	// Run partprobe to ensure partition device nodes exist
-	if out, err := exec.Command("partprobe", device).CombinedOutput(); err != nil {
+	if out, err := exec.CommandContext(ctx, "partprobe", device).CombinedOutput(); err != nil {
 		log.Printf("LVM: partprobe %s: %v (output: %s)", device, err, strings.TrimSpace(string(out)))
 	}
 
 	// Wait for udev to settle
-	if out, err := exec.Command("udevadm", "settle", "--timeout="+lvmUdevSettleTimeout).CombinedOutput(); err != nil {
+	if out, err := exec.CommandContext(ctx, "udevadm", "settle", "--timeout="+lvmUdevSettleTimeout).CombinedOutput(); err != nil {
 		log.Printf("LVM: udevadm settle: %v (output: %s)", err, strings.TrimSpace(string(out)))
 	}
 
 	// Refresh PV cache
-	if out, err := exec.Command("pvscan", "--cache").CombinedOutput(); err != nil {
+	if out, err := exec.CommandContext(ctx, "pvscan", "--cache").CombinedOutput(); err != nil {
 		log.Printf("LVM: pvscan --cache: %v (output: %s)", err, strings.TrimSpace(string(out)))
 	}
 
@@ -146,22 +146,28 @@ func (s *StepSetupLVM) detectVolumeGroups(device string) ([]string, error) {
 	// may not exist immediately after the disk appears.
 	var lastErr error
 	for attempt := 0; attempt < lvmDetectMaxRetries; attempt++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
 		if attempt > 0 {
 			log.Printf("LVM: retry attempt %d/%d, waiting for device nodes...", attempt+1, lvmDetectMaxRetries)
 			time.Sleep(lvmDetectRetryDelay)
 
-			if out, err := exec.Command("partprobe", device).CombinedOutput(); err != nil {
+			if out, err := exec.CommandContext(ctx, "partprobe", device).CombinedOutput(); err != nil {
 				log.Printf("LVM: partprobe %s (retry): %v (output: %s)", device, err, strings.TrimSpace(string(out)))
 			}
-			if out, err := exec.Command("udevadm", "settle", "--timeout="+lvmUdevSettleTimeout).CombinedOutput(); err != nil {
+			if out, err := exec.CommandContext(ctx, "udevadm", "settle", "--timeout="+lvmUdevSettleTimeout).CombinedOutput(); err != nil {
 				log.Printf("LVM: udevadm settle (retry): %v (output: %s)", err, strings.TrimSpace(string(out)))
 			}
-			if out, err := exec.Command("pvscan", "--cache").CombinedOutput(); err != nil {
+			if out, err := exec.CommandContext(ctx, "pvscan", "--cache").CombinedOutput(); err != nil {
 				log.Printf("LVM: pvscan --cache (retry): %v (output: %s)", err, strings.TrimSpace(string(out)))
 			}
 		}
 
-		vgs, err := s.scanPVS(device)
+		vgs, err := s.scanPVS(ctx, device)
 		if err != nil {
 			log.Printf("LVM: scanPVS attempt %d: %v", attempt+1, err)
 			lastErr = err
@@ -179,8 +185,8 @@ func (s *StepSetupLVM) detectVolumeGroups(device string) ([]string, error) {
 }
 
 // scanPVS runs `pvs` and returns VG names for PVs that belong to the specified device.
-func (s *StepSetupLVM) scanPVS(device string) ([]string, error) {
-	cmd := exec.Command("pvs", "--noheadings", "--nosuffix", "-o", "pv_name,vg_name", "--separator", ",")
+func (s *StepSetupLVM) scanPVS(ctx context.Context, device string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "pvs", "--noheadings", "--nosuffix", "-o", "pv_name,vg_name", "--separator", ",")
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -219,9 +225,9 @@ func (s *StepSetupLVM) scanPVS(device string) ([]string, error) {
 }
 
 // activateVolumeGroups activates the discovered volume groups.
-func (s *StepSetupLVM) activateVolumeGroups(ui packersdk.Ui) error {
+func (s *StepSetupLVM) activateVolumeGroups(ctx context.Context, ui packersdk.Ui) error {
 	// Scan for VGs first
-	if out, err := exec.Command("vgscan").CombinedOutput(); err != nil {
+	if out, err := exec.CommandContext(ctx, "vgscan").CombinedOutput(); err != nil {
 		log.Printf("LVM: vgscan: %v (output: %s)", err, strings.TrimSpace(string(out)))
 	}
 
@@ -231,7 +237,7 @@ func (s *StepSetupLVM) activateVolumeGroups(ui packersdk.Ui) error {
 		args = append(args, s.volumeGroups...)
 	}
 
-	cmd := exec.Command("vgchange", args...)
+	cmd := exec.CommandContext(ctx, "vgchange", args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -245,12 +251,12 @@ func (s *StepSetupLVM) activateVolumeGroups(ui packersdk.Ui) error {
 	s.activated = true
 
 	// Ensure /dev/mapper/ nodes exist
-	if out, err := exec.Command("vgmknodes").CombinedOutput(); err != nil {
+	if out, err := exec.CommandContext(ctx, "vgmknodes").CombinedOutput(); err != nil {
 		log.Printf("LVM: vgmknodes: %v (output: %s)", err, strings.TrimSpace(string(out)))
 	}
 
 	// Wait for udev to settle
-	if out, err := exec.Command("udevadm", "settle", "--timeout="+lvmUdevSettleTimeout).CombinedOutput(); err != nil {
+	if out, err := exec.CommandContext(ctx, "udevadm", "settle", "--timeout="+lvmUdevSettleTimeout).CombinedOutput(); err != nil {
 		log.Printf("LVM: udevadm settle: %v (output: %s)", err, strings.TrimSpace(string(out)))
 	}
 

--- a/builder/azure/chroot/step_setup_lvm_helpers_test.go
+++ b/builder/azure/chroot/step_setup_lvm_helpers_test.go
@@ -1,0 +1,400 @@
+// Copyright IBM Corp. 2013, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build linux || freebsd
+
+package chroot
+
+import (
+	"testing"
+)
+
+func Test_isMountableLV(t *testing.T) {
+	tests := []struct {
+		name string
+		attr string
+		want bool
+	}{
+		{"empty attr is mountable", "", true},
+		{"normal volume -wi-a-----", "-wi-a-----", true},
+		{"origin volume owi-a-s---", "owi-a-s---", true},
+		{"snapshot", "swi-a-s---", false},
+		{"Snapshot uppercase", "Swi-a-s---", false},
+		{"virtual", "vwi-a-t---", false},
+		{"Virtual uppercase", "Vwi-a-t---", false},
+		{"thin pool", "twi-a-t---", false},
+		{"Thin pool uppercase", "Twi-a-t---", false},
+		{"RAID metadata", "ewi-a-----", false},
+		{"RAID metadata uppercase", "Ewi-a-----", false},
+		{"internal", "iwi-------", false},
+		{"Internal uppercase", "Iwi-------", false},
+		{"mirror log", "lwi-a-----", false},
+		{"Mirror log uppercase", "Lwi-a-----", false},
+		{"mirror image", "dwi-a-----", false},
+		{"Mirror image uppercase", "Dwi-a-----", false},
+		{"pvmove", "pwi-------", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isMountableLV(tt.attr)
+			if got != tt.want {
+				t.Errorf("isMountableLV(%q) = %v, want %v", tt.attr, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_lvTypeDescription(t *testing.T) {
+	tests := []struct {
+		attr string
+		want string
+	}{
+		{"", "unknown type"},
+		{"swi-a-s---", "snapshot"},
+		{"Swi-a-s---", "snapshot"},
+		{"vwi-a-t---", "virtual volume"},
+		{"twi-a-t---", "thin pool"},
+		{"ewi-a-----", "RAID/pool metadata"},
+		{"iwi-------", "internal volume"},
+		{"lwi-a-----", "mirror log"},
+		{"dwi-a-----", "mirror/RAID image"},
+		{"pwi-------", "pvmove volume"},
+		{"-wi-a-----", "unknown type"},
+		{"owi-a-s---", "unknown type"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.attr, func(t *testing.T) {
+			got := lvTypeDescription(tt.attr)
+			if got != tt.want {
+				t.Errorf("lvTypeDescription(%q) = %q, want %q", tt.attr, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_resolveMapperHeuristic(t *testing.T) {
+	tests := []struct {
+		name     string
+		basename string
+		want     string
+	}{
+		{
+			name:     "simple VG-LV",
+			basename: "rhel-root",
+			want:     "rhel/root",
+		},
+		{
+			name:     "VG with escaped dash",
+			basename: "my--vg-root",
+			want:     "my-vg/root",
+		},
+		{
+			name:     "LV with escaped dash",
+			basename: "rhel-my--lv",
+			want:     "rhel/my-lv",
+		},
+		{
+			name:     "both escaped",
+			basename: "my--vg-my--lv",
+			want:     "my-vg/my-lv",
+		},
+		{
+			name:     "multiple dashes in VG",
+			basename: "a--b--c-root",
+			want:     "a-b-c/root",
+		},
+		{
+			name:     "no dash at all",
+			basename: "nodash",
+			want:     "",
+		},
+		{
+			name:     "only double dashes (no separator)",
+			basename: "all--dashes",
+			want:     "",
+		},
+		{
+			name:     "multiple single-dash separators picks last",
+			basename: "vg-lv-extra",
+			want:     "vg-lv/extra",
+		},
+		{
+			name:     "centos style",
+			basename: "centos-root",
+			want:     "centos/root",
+		},
+		{
+			name:     "fedora style",
+			basename: "fedora_server-root",
+			want:     "fedora_server/root",
+		},
+		{
+			name:     "single char VG and LV",
+			basename: "a-b",
+			want:     "a/b",
+		},
+		{
+			name:     "empty string",
+			basename: "",
+			want:     "",
+		},
+		{
+			name:     "single char",
+			basename: "a",
+			want:     "",
+		},
+		{
+			name:     "dash at start",
+			basename: "-root",
+			want:     "",
+		},
+		{
+			name:     "dash at end",
+			basename: "vg-",
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveMapperHeuristic(tt.basename)
+			if got != tt.want {
+				t.Errorf("resolveMapperHeuristic(%q) = %q, want %q", tt.basename, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_resolveDevPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		device string
+		want   string
+	}{
+		{
+			name:   "standard /dev/vg/lv",
+			device: "/dev/rhel/root",
+			want:   "rhel/root",
+		},
+		{
+			name:   "longer path /dev/volgroup/logvol",
+			device: "/dev/mygroup/myvolume",
+			want:   "mygroup/myvolume",
+		},
+		{
+			name:   "too short /dev/foo",
+			device: "/dev/foo",
+			want:   "",
+		},
+		{
+			name:   "root path /",
+			device: "/",
+			want:   "",
+		},
+		{
+			name:   "empty",
+			device: "",
+			want:   "",
+		},
+		{
+			name:   "deep path keeps last two segments",
+			device: "/dev/some/deep/path/vg/lv",
+			want:   "vg/lv",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveDevPath(tt.device)
+			if got != tt.want {
+				t.Errorf("resolveDevPath(%q) = %q, want %q", tt.device, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_resolveVGLV(t *testing.T) {
+	// resolveVGLV tries dmsetup first (will fail on non-Linux/no-LVM systems),
+	// then falls back to the heuristic. We test the full function to exercise
+	// both code paths; on systems without dmsetup the heuristic is used.
+	tests := []struct {
+		name   string
+		device string
+		want   string
+	}{
+		{
+			name:   "mapper path simple",
+			device: "/dev/mapper/rhel-root",
+			want:   "rhel/root",
+		},
+		{
+			name:   "mapper path with escaped dashes",
+			device: "/dev/mapper/my--vg-root",
+			want:   "my-vg/root",
+		},
+		{
+			name:   "dev vg lv path",
+			device: "/dev/rhel/root",
+			want:   "rhel/root",
+		},
+		{
+			name:   "unrecognized path",
+			device: "/dev/sda1",
+			want:   "",
+		},
+		{
+			name:   "empty",
+			device: "",
+			want:   "",
+		},
+		{
+			name:   "mapper no dash",
+			device: "/dev/mapper/nodash",
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveVGLV(tt.device)
+			if got != tt.want {
+				t.Errorf("resolveVGLV(%q) = %q, want %q", tt.device, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_vgFromDevicePath(t *testing.T) {
+	tests := []struct {
+		name   string
+		device string
+		want   string
+	}{
+		{
+			name:   "mapper path",
+			device: "/dev/mapper/rhel-root",
+			want:   "rhel",
+		},
+		{
+			name:   "mapper path escaped dashes",
+			device: "/dev/mapper/my--vg-root",
+			want:   "my-vg",
+		},
+		{
+			name:   "dev path",
+			device: "/dev/rhel/root",
+			want:   "rhel",
+		},
+		{
+			name:   "unrecognized",
+			device: "/dev/sda1",
+			want:   "",
+		},
+		{
+			name:   "empty",
+			device: "",
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := vgFromDevicePath(tt.device)
+			if got != tt.want {
+				t.Errorf("vgFromDevicePath(%q) = %q, want %q", tt.device, got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_selectRootLV(t *testing.T) {
+	tests := []struct {
+		name       string
+		candidates []lvInfo
+		want       string
+	}{
+		{
+			name:       "empty list returns empty",
+			candidates: nil,
+			want:       "",
+		},
+		{
+			name: "single candidate returns it",
+			candidates: []lvInfo{
+				{name: "data", vg: "rhel", path: "/dev/rhel/data", attr: "-wi-a-----"},
+			},
+			want: "/dev/rhel/data",
+		},
+		{
+			name: "exact match root",
+			candidates: []lvInfo{
+				{name: "swap", vg: "rhel", path: "/dev/rhel/swap", attr: "-wi-a-----"},
+				{name: "root", vg: "rhel", path: "/dev/rhel/root", attr: "-wi-a-----"},
+				{name: "home", vg: "rhel", path: "/dev/rhel/home", attr: "-wi-a-----"},
+			},
+			want: "/dev/rhel/root",
+		},
+		{
+			name: "exact match lv_root",
+			candidates: []lvInfo{
+				{name: "home", vg: "centos", path: "/dev/centos/home", attr: "-wi-a-----"},
+				{name: "lv_root", vg: "centos", path: "/dev/centos/lv_root", attr: "-wi-a-----"},
+			},
+			want: "/dev/centos/lv_root",
+		},
+		{
+			name: "exact match rootlv",
+			candidates: []lvInfo{
+				{name: "data", vg: "vg0", path: "/dev/vg0/data", attr: "-wi-a-----"},
+				{name: "rootlv", vg: "vg0", path: "/dev/vg0/rootlv", attr: "-wi-a-----"},
+			},
+			want: "/dev/vg0/rootlv",
+		},
+		{
+			name: "exact match lvroot",
+			candidates: []lvInfo{
+				{name: "data", vg: "vg0", path: "/dev/vg0/data", attr: "-wi-a-----"},
+				{name: "lvroot", vg: "vg0", path: "/dev/vg0/lvroot", attr: "-wi-a-----"},
+			},
+			want: "/dev/vg0/lvroot",
+		},
+		{
+			name: "exact match is case-insensitive",
+			candidates: []lvInfo{
+				{name: "data", vg: "rhel", path: "/dev/rhel/data", attr: "-wi-a-----"},
+				{name: "Root", vg: "rhel", path: "/dev/rhel/Root", attr: "-wi-a-----"},
+			},
+			want: "/dev/rhel/Root",
+		},
+		{
+			name: "partial match containing root",
+			candidates: []lvInfo{
+				{name: "data", vg: "vg0", path: "/dev/vg0/data", attr: "-wi-a-----"},
+				{name: "my_rootfs", vg: "vg0", path: "/dev/vg0/my_rootfs", attr: "-wi-a-----"},
+				{name: "home", vg: "vg0", path: "/dev/vg0/home", attr: "-wi-a-----"},
+			},
+			want: "/dev/vg0/my_rootfs",
+		},
+		{
+			name: "exact match takes priority over partial",
+			candidates: []lvInfo{
+				{name: "my_rootfs", vg: "vg0", path: "/dev/vg0/my_rootfs", attr: "-wi-a-----"},
+				{name: "root", vg: "vg0", path: "/dev/vg0/root", attr: "-wi-a-----"},
+			},
+			want: "/dev/vg0/root",
+		},
+		{
+			name: "no root match returns first candidate",
+			candidates: []lvInfo{
+				{name: "data", vg: "vg0", path: "/dev/vg0/data", attr: "-wi-a-----"},
+				{name: "home", vg: "vg0", path: "/dev/vg0/home", attr: "-wi-a-----"},
+				{name: "var", vg: "vg0", path: "/dev/vg0/var", attr: "-wi-a-----"},
+			},
+			want: "/dev/vg0/data",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectRootLV(tt.candidates)
+			if got != tt.want {
+				t.Errorf("selectRootLV() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/builder/azure/chroot/step_setup_lvm_other.go
+++ b/builder/azure/chroot/step_setup_lvm_other.go
@@ -1,0 +1,31 @@
+// Copyright IBM Corp. 2013, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !linux && !freebsd
+
+package chroot
+
+import (
+	"context"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+)
+
+var _ multistep.Step = &StepSetupLVM{}
+
+type StepSetupLVM struct {
+	device        string
+	volumeGroups  []string
+	LVMRootDevice string
+	activated     bool
+}
+
+func (s *StepSetupLVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	return multistep.ActionContinue
+}
+
+func (s *StepSetupLVM) Cleanup(state multistep.StateBag) {}
+
+func (s *StepSetupLVM) CleanupFunc(state multistep.StateBag) error {
+	return nil
+}

--- a/builder/azure/chroot/step_setup_lvm_other.go
+++ b/builder/azure/chroot/step_setup_lvm_other.go
@@ -14,10 +14,7 @@ import (
 var _ multistep.Step = &StepSetupLVM{}
 
 type StepSetupLVM struct {
-	device        string
-	volumeGroups  []string
 	LVMRootDevice string
-	activated     bool
 }
 
 func (s *StepSetupLVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {

--- a/builder/azure/chroot/step_setup_lvm_test.go
+++ b/builder/azure/chroot/step_setup_lvm_test.go
@@ -1,0 +1,131 @@
+// Copyright IBM Corp. 2013, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package chroot
+
+import (
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-azure/builder/azure/common/client"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
+)
+
+func Test_buildsteps_LVM(t *testing.T) {
+	info := &client.ComputeInfo{
+		Location:          "northpole",
+		Name:              "unittestVM",
+		ResourceGroupName: "unittestResourceGroup",
+		SubscriptionID:    "96854241-60c7-426d-9a27-3fdeec8957f4",
+	}
+
+	tests := []struct {
+		name   string
+		config Config
+		verify func([]multistep.Step, *testing.T)
+	}{
+		{
+			name:   "StepSetupLVM always present",
+			config: Config{Source: "diskresourceid", sourceType: sourceDisk},
+			verify: func(steps []multistep.Step, t *testing.T) {
+				for _, s := range steps {
+					if _, ok := s.(*StepSetupLVM); ok {
+						return
+					}
+				}
+				t.Error("did not find a StepSetupLVM in step chain")
+			},
+		},
+		{
+			name: "LVMRootDevice passed to StepSetupLVM",
+			config: Config{
+				Source:        "diskresourceid",
+				sourceType:    sourceDisk,
+				LVMRootDevice: "/dev/mapper/rhel-root",
+			},
+			verify: func(steps []multistep.Step, t *testing.T) {
+				for _, s := range steps {
+					if lvm, ok := s.(*StepSetupLVM); ok {
+						if lvm.LVMRootDevice != "/dev/mapper/rhel-root" {
+							t.Errorf("expected LVMRootDevice to be %q, got %q",
+								"/dev/mapper/rhel-root", lvm.LVMRootDevice)
+						}
+						return
+					}
+				}
+				t.Error("did not find a StepSetupLVM in step chain")
+			},
+		},
+		{
+			name: "MountPartition preserved in StepMountDevice",
+			config: Config{
+				Source:         "diskresourceid",
+				sourceType:     sourceDisk,
+				MountPartition: "1",
+			},
+			verify: func(steps []multistep.Step, t *testing.T) {
+				for _, s := range steps {
+					if mount, ok := s.(*StepMountDevice); ok {
+						if mount.MountPartition != "1" {
+							t.Errorf("expected MountPartition to be %q, got %q",
+								"1", mount.MountPartition)
+						}
+						return
+					}
+				}
+				t.Error("did not find a StepMountDevice in step chain")
+			},
+		},
+		{
+			name:   "LVM step comes after StepAttachDisk and before StepMountDevice",
+			config: Config{Source: "diskresourceid", sourceType: sourceDisk},
+			verify: func(steps []multistep.Step, t *testing.T) {
+				attachIdx, lvmIdx, mountIdx := -1, -1, -1
+				for i, s := range steps {
+					switch s.(type) {
+					case *StepAttachDisk:
+						attachIdx = i
+					case *StepSetupLVM:
+						lvmIdx = i
+					case *StepMountDevice:
+						mountIdx = i
+					}
+				}
+				if attachIdx < 0 {
+					t.Fatal("StepAttachDisk not found in step chain")
+				}
+				if lvmIdx < 0 {
+					t.Fatal("StepSetupLVM not found in step chain")
+				}
+				if mountIdx < 0 {
+					t.Fatal("StepMountDevice not found in step chain")
+				}
+				if !(attachIdx < lvmIdx && lvmIdx < mountIdx) {
+					t.Errorf("incorrect step order: attach=%d, lvm=%d, mount=%d",
+						attachIdx, lvmIdx, mountIdx)
+				}
+			},
+		},
+		{
+			name:   "Custom StepEarlyCleanup used (not SDK version)",
+			config: Config{Source: "diskresourceid", sourceType: sourceDisk},
+			verify: func(steps []multistep.Step, t *testing.T) {
+				for _, s := range steps {
+					if _, ok := s.(*StepEarlyCleanup); ok {
+						return
+					}
+				}
+				t.Error("did not find local StepEarlyCleanup in step chain")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withMetadataStub(func() {
+				got := buildsteps(tt.config, info, &packerbuilderdata.GeneratedData{}, func(string) {})
+				tt.verify(got, t)
+			})
+		})
+	}
+}

--- a/docs-partials/builder/azure/chroot/Config-not-required.mdx
+++ b/docs-partials/builder/azure/chroot/Config-not-required.mdx
@@ -61,6 +61,16 @@
 
 - `temporary_data_disk_snapshot_id` (string) - The prefix for the resource ids of the temporary data disk snapshots that will be created. The snapshots will be suffixed with a number. Will be generated if not set.
 
+- `lvm_root_device` (string) - Explicitly specify the LVM root device path to mount (e.g., `/dev/mapper/rhel-root`).
+  When set, LVM volume groups are activated and this device is used as the mount target
+  instead of a partition on the raw disk. Normally, LVM is auto-detected and does not
+  require any configuration. Use this only when auto-detection picks the wrong logical volume.
+
+- `pre_unmount_commands` ([]string) - A series of commands to execute after provisioning but before unmounting the chroot
+  and deactivating LVM. This is useful for flushing writes or running cleanup inside the
+  chroot while the filesystem is still mounted. The device and mount path are provided
+  by `{{.Device}}` and `{{.MountPath}}`.
+
 - `skip_cleanup` (bool) - If set to `true`, leaves the temporary disks and snapshots behind in the Packer VM resource group. Defaults to `false`
 
 - `image_resource_id` (string) - The managed image to create using this build.

--- a/docs-partials/builder/azure/chroot/Config-not-required.mdx
+++ b/docs-partials/builder/azure/chroot/Config-not-required.mdx
@@ -66,10 +66,12 @@
   instead of a partition on the raw disk. Normally, LVM is auto-detected and does not
   require any configuration. Use this only when auto-detection picks the wrong logical volume.
 
-- `pre_unmount_commands` ([]string) - A series of commands to execute after provisioning but before unmounting the chroot
-  and deactivating LVM. This is useful for flushing writes or running cleanup inside the
-  chroot while the filesystem is still mounted. The device and mount path are provided
-  by `{{.Device}}` and `{{.MountPath}}`.
+- `pre_unmount_commands` ([]string) - A series of commands to execute on the **host** after provisioning but before unmounting
+  the chroot and deactivating LVM. Useful for host-side operations on the still-mounted
+  filesystem such as `fstrim` or `sync`. These commands do **not** run inside the chroot;
+  to run a command inside the chroot, use a shell provisioner or prefix with
+  `chroot {{.MountPath}}`. The device and mount path are provided by `{{.Device}}` and
+  `{{.MountPath}}`.
 
 - `skip_cleanup` (bool) - If set to `true`, leaves the temporary disks and snapshots behind in the Packer VM resource group. Defaults to `false`
 

--- a/docs/builders/chroot.mdx
+++ b/docs/builders/chroot.mdx
@@ -61,6 +61,32 @@ subscription ID from the image resource ID rather than the host VM's
 subscription. Ensure the identity used by the builder has the appropriate
 read permissions on the source gallery.
 
+### LVM Support
+
+The `azure-chroot` builder has built-in support for source disks that use LVM
+(Logical Volume Manager). After the source disk is attached, the builder
+automatically scans for LVM physical volumes, activates any volume groups found
+on the disk, and locates the root logical volume to use as the mount target.
+
+In most cases **no configuration is required** — LVM detection and activation
+happen transparently. The builder uses a multi-stage heuristic to find the root
+logical volume:
+
+1. Examines LV attributes (skipping snapshots and virtual LVs).
+2. Excludes swap volumes.
+3. Prefers LVs whose names contain `root`.
+4. Falls back to the largest remaining LV.
+
+If auto-detection picks the wrong logical volume, you can set `lvm_root_device`
+to the exact device path (e.g., `/dev/mapper/rhel-root`).
+
+During cleanup the builder deactivates the volume groups before detaching the
+disk, ensuring no device-mapper references remain on the host.
+
+~> **Note:** LVM support requires the `lvm2` package (providing `pvscan`,
+`vgscan`, `vgchange`, `lvs`) to be installed on the host VM. The `partprobe`
+and `udevadm` utilities are also used for device discovery.
+
 ## Configuration Reference
 
 There are many configuration options available for the builder. We'll start
@@ -353,3 +379,51 @@ build {
 ```
 
 
+### Using an LVM-based Source Image
+
+When the source disk uses LVM, the builder automatically detects and activates
+the volume groups. No additional configuration is needed in most cases:
+
+**HCL2**
+
+```hcl
+source "azure-chroot" "lvm-example" {
+  image_resource_id = "/subscriptions/{{vm `subscription_id`}}/resourceGroups/{{vm `resource_group`}}/providers/Microsoft.Compute/images/MyRHELImage-{{timestamp}}"
+  source            = "/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/disks/rhel-osdisk"
+}
+
+build {
+  sources = ["source.azure-chroot.lvm-example"]
+
+  provisioner "shell" {
+    inline         = ["yum update -y"]
+    inline_shebang = "/bin/sh -x"
+  }
+}
+```
+
+If auto-detection picks the wrong logical volume, set `lvm_root_device` to the
+exact path:
+
+```hcl
+source "azure-chroot" "lvm-explicit" {
+  image_resource_id = "/subscriptions/{{vm `subscription_id`}}/resourceGroups/{{vm `resource_group`}}/providers/Microsoft.Compute/images/MyRHELImage-{{timestamp}}"
+  source            = "/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/disks/rhel-osdisk"
+  lvm_root_device   = "/dev/mapper/rhel-root"
+}
+```
+
+The `pre_unmount_commands` option lets you run commands after provisioning
+but before the filesystem is unmounted and LVM is deactivated:
+
+```hcl
+source "azure-chroot" "lvm-pre-unmount" {
+  image_resource_id = "/subscriptions/{{vm `subscription_id`}}/resourceGroups/{{vm `resource_group`}}/providers/Microsoft.Compute/images/MyRHELImage-{{timestamp}}"
+  source            = "/subscriptions/.../resourceGroups/.../providers/Microsoft.Compute/disks/rhel-osdisk"
+
+  pre_unmount_commands = [
+    "sync",
+    "fstrim {{.MountPath}}"
+  ]
+}
+```

--- a/docs/builders/chroot.mdx
+++ b/docs/builders/chroot.mdx
@@ -72,10 +72,10 @@ In most cases **no configuration is required** — LVM detection and activation
 happen transparently. The builder uses a multi-stage heuristic to find the root
 logical volume:
 
-1. Examines LV attributes (skipping snapshots and virtual LVs).
+1. Examines LV attributes (skipping snapshots, thin pools, and virtual LVs).
 2. Excludes swap volumes.
-3. Prefers LVs whose names contain `root`.
-4. Falls back to the largest remaining LV.
+3. Prefers LVs whose names contain `root` (exact match first, then partial).
+4. Falls back to the first remaining candidate.
 
 If auto-detection picks the wrong logical volume, you can set `lvm_root_device`
 to the exact device path (e.g., `/dev/mapper/rhel-root`).


### PR DESCRIPTION
### Description
Adds simplified built-in LVM support to the `azure-chroot` builder.

Multiple Azure Marketplace images (i.e., RHEL 8/9/10, Oracle Linux, etc) ship with LVM-based disk layouts. Previously, the `azure-chroot` builder only supported mounting raw partitions - making these images unusable without manual workarounds which are squirreled away in Enterprise Wikis. 

This PR adds transparent LVM detection and activation so that LVM-based source disks "just work" - testing based on RHEL 8 / 9 / 10, and follows on from the changes made as part of #582. Fist bump to [VRay27](https://github.com/VRay27) for their continued support in testing 🙌

**What changed:**

- **`step_setup_lvm.go`**: New build step; leverages `partprobe` and `udevadm settle` for device discovery, alongside `pvscan` and `vgchange`. 
- **`step_pre_unmount_commands.go`**: Facilitate users in running commands on the host after provisioning but before unmount (e.g., `fstrim`, `sync`, etc - traditionally done using a shell script step)
- **`step_early_cleanup.go`**: handles teardown for LVM; built-in cleanup isn't LVM-aware.
- **`builder.go`**: addition of `lvm_root_device` to override auto-detection with explicit device paths (w/ validation), `pre_unmount_commands` for on-host commands to run before unmount. 

Updated required documentation; regenerated `hcl2spec` via `go generate` - and webdocs using `make`.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan
If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls
No changes to security controls; LVM step(s) execute standard Linux storage utilities on the host VM. No new changes introduced beyond this.

