### PR TITLE
Document required output fields for azure-arm provider

### DIFF
--- a/docs-partials/builder/azure/arm/Config-required.mdx
+++ b/docs-partials/builder/azure/arm/Config-required.mdx
@@ -25,15 +25,15 @@
 
 - `custom_managed_image_name` (string) - Name of a custom managed image to use for your base image. If this value is set, do
   not set image_publisher, image_offer, image_sku, or image_version.
-  If this value is set, the option
-  `custom_managed_image_resource_group_name` must also be set. See
+  If this value is set, the options
+  `custom_managed_image_resource_group_name`, `managed_image_name`, and `managed_image_resource_group_name` must also be set. See
   [documentation](https://docs.microsoft.com/en-us/azure/storage/storage-managed-disks-overview#images)
   to learn more about managed images.
 
 - `custom_managed_image_resource_group_name` (string) - Name of a custom managed image's resource group to use for your base image. If this
   value is set, image_publisher, image_offer, image_sku, or image_version should not be set.
-  If this value is set, the option
-  `custom_managed_image_name` must also be set. See
+  If this value is set, the options
+  `custom_managed_image_name`, `managed_image_name`, and `managed_image_resource_group_name` must also be set. See
   [documentation](https://docs.microsoft.com/en-us/azure/storage/storage-managed-disks-overview#images)
   to learn more about managed images.
 


### PR DESCRIPTION
When using the `custom_manage_image_*` fields to specify a managed image as a base image, the azure-arm provider requires that you specify the `managed_image_*` output fields. Previously, this was requirement was not documented.

The current validations can be seen here:
https://github.com/hashicorp/packer-plugin-azure/blob/f3acf28a3a3924d0089b15e5347ad49b13edcb64/builder/azure/arm/config.go#L1307-L1312

----

### Description
What code changed, and why?

Documentation for required fields within the azure-arm provider

### Resolved Issues
If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

None

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

None.