### PR TITLE
fix(winrm): respect winrm_use_ntlm setting instead of unconditionally forcing NTLM

### DIFF
--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -966,10 +966,12 @@ func setSshValues(c *Config) error {
 }
 
 func setWinRMCertificate(c *Config) error {
-	c.Comm.WinRMTransportDecorator =
-		func() winrm.Transporter {
-			return &winrm.ClientNTLM{}
-		}
+	if c.Comm.WinRMUseNTLM {
+		c.Comm.WinRMTransportDecorator =
+			func() winrm.Transporter {
+				return &winrm.ClientNTLM{}
+			}
+	}
 
 	cert, err := c.createCertificate()
 

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -665,7 +665,25 @@ func TestConfigShouldSupportPackersConfigElements(t *testing.T) {
 	}
 }
 
-func TestWinRMConfigShouldSetRoundTripDecorator(t *testing.T) {
+func TestWinRMConfigShouldSetRoundTripDecoratorWhenNTLMEnabled(t *testing.T) {
+	config := getArmBuilderConfiguration()
+	config["communicator"] = "winrm"
+	config["winrm_username"] = "username"
+	config["winrm_password"] = "Password123"
+	config["winrm_use_ntlm"] = true
+
+	var c Config
+	_, err := c.Prepare(config, getPackerConfiguration())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.Comm.WinRMTransportDecorator == nil {
+		t.Error("Expected WinRMTransportDecorator to be set when winrm_use_ntlm is true, but it was nil")
+	}
+}
+
+func TestWinRMConfigShouldNotSetRoundTripDecoratorWhenNTLMDisabled(t *testing.T) {
 	config := getArmBuilderConfiguration()
 	config["communicator"] = "winrm"
 	config["winrm_username"] = "username"
@@ -677,8 +695,8 @@ func TestWinRMConfigShouldSetRoundTripDecorator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if c.Comm.WinRMTransportDecorator == nil {
-		t.Error("Expected WinRMTransportDecorator to be set, but it was nil")
+	if c.Comm.WinRMTransportDecorator != nil {
+		t.Error("Expected WinRMTransportDecorator to be nil when winrm_use_ntlm is not set, but it was set")
 	}
 }
 

--- a/builder/azure/dtl/config.go
+++ b/builder/azure/dtl/config.go
@@ -490,10 +490,12 @@ func setSshValues(c *Config) error {
 }
 
 func setWinRMCertificate(c *Config) error {
-	c.Comm.WinRMTransportDecorator =
-		func() winrm.Transporter {
-			return &winrm.ClientNTLM{}
-		}
+	if c.Comm.WinRMUseNTLM {
+		c.Comm.WinRMTransportDecorator =
+			func() winrm.Transporter {
+				return &winrm.ClientNTLM{}
+			}
+	}
 
 	cert, password, err := c.createCertificate()
 

--- a/builder/azure/dtl/config_test.go
+++ b/builder/azure/dtl/config_test.go
@@ -189,7 +189,25 @@ func TestConfigShouldSupportPackersConfigElements(t *testing.T) {
 	}
 }
 
-func TestWinRMConfigShouldSetRoundTripDecorator(t *testing.T) {
+func TestWinRMConfigShouldSetRoundTripDecoratorWhenNTLMEnabled(t *testing.T) {
+	config_dtl := getDtlBuilderConfiguration()
+	config_dtl["communicator"] = "winrm"
+	config_dtl["winrm_username"] = "username"
+	config_dtl["winrm_password"] = "password"
+	config_dtl["winrm_use_ntlm"] = "true"
+
+	config := Config{}
+	_, err := config.Prepare(config_dtl, getPackerConfiguration())
+	if err != nil {
+		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
+	}
+
+	if config.Comm.WinRMTransportDecorator == nil {
+		t.Error("Expected WinRMTransportDecorator to be set when winrm_use_ntlm is true, but it was nil")
+	}
+}
+
+func TestWinRMConfigShouldNotSetRoundTripDecoratorWhenNTLMDisabled(t *testing.T) {
 	config_dtl := getDtlBuilderConfiguration()
 	config_dtl["communicator"] = "winrm"
 	config_dtl["winrm_username"] = "username"
@@ -201,8 +219,8 @@ func TestWinRMConfigShouldSetRoundTripDecorator(t *testing.T) {
 		t.Errorf("Expected configuration creation to succeed, but it failed (%s)!\n", err)
 	}
 
-	if config.Comm.WinRMTransportDecorator == nil {
-		t.Error("Expected WinRMTransportDecorator to be set, but it was nil")
+	if config.Comm.WinRMTransportDecorator != nil {
+		t.Error("Expected WinRMTransportDecorator to be nil when winrm_use_ntlm is not set, but it was set")
 	}
 }
 


### PR DESCRIPTION
## Summary

`setWinRMCertificate()` in both the ARM and DTL builders unconditionally sets `WinRMTransportDecorator` to `&winrm.ClientNTLM{}`, ignoring the `winrm_use_ntlm` configuration option. This makes it impossible to use Basic auth over HTTPS even when `winrm_use_ntlm` is not set (the default).

## Problem

On Windows Server 2022 images with FIPS mode enabled and DISA STIG hardening applied, HTTP.sys enforces Extended Protection for Authentication (EPA) with Channel Binding Tokens (CBT). The `go-ntlmssp` library used by `ClientNTLM` does not support CBT, causing the NTLM Type 3 authentication message to be rejected with HTTP 401.

Because the plugin unconditionally wraps WinRM with `ClientNTLM`, there is no way to fall back to Basic auth over HTTPS -- which works correctly since TLS provides the transport encryption.

The `packer-plugin-sdk` already handles this correctly in `communicator.Config.Prepare()` (line 638-640 of `config.go`), only setting the NTLM transport when `WinRMUseNTLM` is true. However, the plugin's `setWinRMCertificate()` runs before `Comm.Prepare()` and overrides this behavior.

## Fix

Wrap the NTLM transport decorator assignment in a conditional check:

```go
if c.Comm.WinRMUseNTLM {
    c.Comm.WinRMTransportDecorator = func() winrm.Transporter {
        return &winrm.ClientNTLM{}
    }
}
```

This aligns the plugin behavior with the SDK and allows users to opt out of NTLM when their target Windows images reject it.

## Testing

- Updated existing `TestWinRMConfigShouldSetRoundTripDecorator` to explicitly set `winrm_use_ntlm = true`
- Added new `TestWinRMConfigShouldNotSetRoundTripDecoratorWhenNTLMDisabled` verifying the decorator is nil when `winrm_use_ntlm` is not set
- All tests pass for both ARM and DTL builders

## Affected Builders

- `azure-arm` (`builder/azure/arm/config.go`)
- `azure-dtl` (`builder/azure/dtl/config.go`)

Fixes #617