### PR TITLE
Fix: communicator=none is incompatible with Linux VM

### DIFF
--- a/builder/azure/arm/builder.go
+++ b/builder/azure/arm/builder.go
@@ -403,11 +403,17 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			NewStepGetIPAddress(azureClient, ui, endpointConnectType),
 			NewStepGetOSDisk(azureClient, ui),
 			NewStepGetAdditionalDisks(azureClient, ui),
-			&communicator.StepConnectSSH{
-				Config:    &b.config.Comm,
-				Host:      communicator.CommHost(b.config.Comm.SSHHost, constants.SSHHost),
-				SSHConfig: b.config.Comm.SSHConfigFunc(),
-			},
+		}
+		if b.config.Comm.Type == "ssh" {
+			steps = append(steps,
+				&communicator.StepConnectSSH{
+					Config:    &b.config.Comm,
+					Host:      communicator.CommHost(b.config.Comm.SSHHost, constants.SSHHost),
+					SSHConfig: b.config.Comm.SSHConfigFunc(),
+				},
+			)
+		}
+		steps = append(steps,
 			&commonsteps.StepProvision{},
 			&commonsteps.StepCleanupTempKeys{
 				Comm: &b.config.Comm,
@@ -415,7 +421,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			NewStepPowerOffCompute(azureClient, ui),
 			NewStepSnapshotOSDisk(azureClient, ui, &b.config),
 			NewStepSnapshotDataDisks(azureClient, ui, &b.config),
-		}
+		)
 	case constants.Target_Windows:
 		steps = []multistep.Step{
 			NewStepGetSourceImageName(azureClient, ui, &b.config, generatedData),

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -959,6 +959,16 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	return warnings, nil
 }
 
+// generateSSHKeyPair returns a new SSH authorized key and its private key.
+// It is a package var so tests can substitute a deterministic key.
+var generateSSHKeyPair = func() (authorizedKey string, privateKey []byte, err error) {
+	kp, err := NewOpenSshKeyPair()
+	if err != nil {
+		return "", nil, err
+	}
+	return kp.AuthorizedKey(), kp.PrivateKey(), nil
+}
+
 func setSshValues(c *Config) error {
 	if c.Comm.SSHTimeout == 0 {
 		c.Comm.SSHTimeout = 20 * time.Minute
@@ -982,13 +992,13 @@ func setSshValues(c *Config) error {
 		c.Comm.SSHPrivateKey = privateKeyBytes
 
 	} else {
-		sshKeyPair, err := NewOpenSshKeyPair()
+		authorizedKey, privateKey, err := generateSSHKeyPair()
 		if err != nil {
 			return err
 		}
 
-		c.sshAuthorizedKey = sshKeyPair.AuthorizedKey()
-		c.Comm.SSHPrivateKey = sshKeyPair.PrivateKey()
+		c.sshAuthorizedKey = authorizedKey
+		c.Comm.SSHPrivateKey = privateKey
 	}
 
 	return nil

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -921,10 +921,11 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		return nil, err
 	}
 
-	// NOTE: if the user did not specify a communicator, then default to both
-	// SSH and WinRM.  This is for backwards compatibility because the code did
-	// not specifically force the user to set a communicator.
-	if c.Comm.Type == "" || strings.EqualFold(c.Comm.Type, "ssh") {
+	// A Linux VM always needs a valid SSH public key in its ARM template,
+	// independent of the communicator; key off the OS so communicator="none"
+	// still gets one (otherwise keyData is empty and Azure rejects the deploy).
+	// OSType is not normalized until assertRequiredParametersSet, so use EqualFold.
+	if strings.EqualFold(c.OSType, constants.Target_Linux) {
 		err = setSshValues(c)
 		if err != nil {
 			return nil, err

--- a/builder/azure/arm/config.go
+++ b/builder/azure/arm/config.go
@@ -925,7 +925,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	// independent of the communicator; key off the OS so communicator="none"
 	// still gets one (otherwise keyData is empty and Azure rejects the deploy).
 	// OSType is not normalized until assertRequiredParametersSet, so use EqualFold.
-	if strings.EqualFold(c.OSType, constants.Target_Linux) {
+if strings.EqualFold(c.OSType, constants.Target_Linux) || strings.EqualFold(c.Comm.Type, "ssh") {
 		err = setSshValues(c)
 		if err != nil {
 			return nil, err

--- a/builder/azure/arm/config_test.go
+++ b/builder/azure/arm/config_test.go
@@ -17,6 +17,15 @@ import (
 	sdkconfig "github.com/hashicorp/packer-plugin-sdk/template/config"
 )
 
+// TestMain pins SSH key generation to a fixed value so template approval tests
+// produce deterministic keyData (the real key is random and timestamped).
+func TestMain(m *testing.M) {
+	generateSSHKeyPair = func() (string, []byte, error) {
+		return "--test-ssh-authorized-key--", []byte("--test-ssh-private-key--"), nil
+	}
+	os.Exit(m.Run())
+}
+
 // List of configuration parameters that are required by the ARM builder.
 var requiredConfigValues = []string{
 	"capture_container_name",

--- a/builder/azure/arm/template_factory_test.TestBasicSkuPublicIPVMDeployment.approved.json
+++ b/builder/azure/arm/template_factory_test.TestBasicSkuPublicIPVMDeployment.approved.json
@@ -137,7 +137,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestConfidentialVM01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestConfidentialVM01.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestConfidentialVM02.approved.json
+++ b/builder/azure/arm/template_factory_test.TestConfidentialVM02.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestConfidentialVM03.approved.json
+++ b/builder/azure/arm/template_factory_test.TestConfidentialVM03.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestEncryptionAtHost01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestEncryptionAtHost01.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestEncryptionAtHost02.approved.json
+++ b/builder/azure/arm/template_factory_test.TestEncryptionAtHost02.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestPlanInfo01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestPlanInfo01.approved.json
@@ -136,7 +136,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestPlanInfo02.approved.json
+++ b/builder/azure/arm/template_factory_test.TestPlanInfo02.approved.json
@@ -139,7 +139,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestSigSourcedWithDiskEncryptionSet.approved.json
+++ b/builder/azure/arm/template_factory_test.TestSigSourcedWithDiskEncryptionSet.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestTrustedLaunch01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestTrustedLaunch01.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment03.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment03.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment04.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment04.approved.json
@@ -119,7 +119,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment05.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment05.approved.json
@@ -98,7 +98,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment06.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment06.approved.json
@@ -129,7 +129,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment07.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment07.approved.json
@@ -121,7 +121,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment08.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment08.approved.json
@@ -119,7 +119,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment09.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment09.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment10.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment10.approved.json
@@ -122,7 +122,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment11.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment12.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment12.approved.json
@@ -119,7 +119,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment14.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment14.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment15.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment15.approved.json
@@ -124,7 +124,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeploymentAcceleratedNetworking01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeploymentAcceleratedNetworking01.approved.json
@@ -119,7 +119,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeploymentAcceleratedNetworking02.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeploymentAcceleratedNetworking02.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeploymentDiskControllerTypeDefault.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeploymentDiskControllerTypeDefault.approved.json
@@ -119,7 +119,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeploymentDiskControllerTypeNVMe.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeploymentDiskControllerTypeNVMe.approved.json
@@ -119,7 +119,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeploymentLicenseType01.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeploymentLicenseType01.approved.json
@@ -119,7 +119,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeploymentLicenseType02.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeploymentLicenseType02.approved.json
@@ -120,7 +120,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment_ExistingVNetPublicIP_AttachesNsgToNic.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment_ExistingVNetPublicIP_AttachesNsgToNic.approved.json
@@ -122,7 +122,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment_ExistingVNetWithPublicIP_WithAllowedInboundIpAddresses_AttachesNsgToNic.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment_ExistingVNetWithPublicIP_WithAllowedInboundIpAddresses_AttachesNsgToNic.approved.json
@@ -122,7 +122,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment_ExistingVNet_WithAllowedInboundIpAddresses_AttachesNsgToNic.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment_ExistingVNet_WithAllowedInboundIpAddresses_AttachesNsgToNic.approved.json
@@ -102,7 +102,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment_ExistingVNet_WithOutboundDenyRule_KeepsSameUserFacingSemantics.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment_ExistingVNet_WithOutboundDenyRule_KeepsSameUserFacingSemantics.approved.json
@@ -102,7 +102,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]

--- a/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment_ExistingVNet_WithoutAllowedInboundIpAddresses_DoesNotCreateExtraNsg.approved.json
+++ b/builder/azure/arm/template_factory_test.TestVirtualMachineDeployment_ExistingVNet_WithoutAllowedInboundIpAddresses_DoesNotCreateExtraNsg.approved.json
@@ -97,7 +97,7 @@
             "ssh": {
               "publicKeys": [
                 {
-                  "keyData": "",
+                  "keyData": "--test-ssh-authorized-key--",
                   "path": "[variables('sshKeyPath')]"
                 }
               ]


### PR DESCRIPTION
### Description

Linux `azure-arm` builds with `communicator = "none"` currently fail at the VM deployment step with:

```
==> azure-arm.builder: ERROR: -> InvalidParameter : The value of parameter
    linuxConfiguration.ssh.publicKeys.keyData is invalid.
```

**Root cause:** the Linux VM ARM template always emits `linuxConfiguration.ssh.publicKeys.keyData`, populated from `config.sshAuthorizedKey`. That field is only set by `setSshValues()`, which `Config.Prepare` invokes **only when the communicator was `ssh` or unset**. With `communicator = "none"` the key is never generated, so `keyData` ships empty and Azure rejects the deployment. In effect, `communicator = "none"` is unusable for the Linux builder today.

This prevents images that are provisioned entirely out-of-band (e.g. via `az vm run-command`, `user_data`/cloud-init, or other control-plane mechanisms) where a Packer SSH/WinRM connection to the build VM is neither needed nor desired.

**Fix:**

- **Generate the SSH authorized key based on `os_type == Linux` instead of the communicator.** A Linux VM template always requires a valid public key, so keying off the OS (rather than the communicator) means `communicator = "none"` Linux builds now receive a valid throwaway key. Windows builds are unchanged; they use the WinRM certificate and ignore `sshAuthorizedKey`.
- **Make the Linux `StepConnectSSH` conditional on `communicator == "ssh"`** (mirroring the existing Windows path). With `communicator = "none"` the VM is created with a valid key, but Packer does not attempt an SSH connection.
- **Add a small test seam** (an overridable `generateSSHKeyPair` package var plus a `TestMain`) so the generated key is deterministic in unit tests. The real key is random and timestamped, which would otherwise make the template approval fixtures non-deterministic. The affected `*.approved.json` template snapshots are regenerated; the only field that changes in each is `keyData`.

#### Reproduction

Minimal template (`os_type = "Linux"`, `communicator = "none"`, any `shell-local` provisioner) fails at the deployment step before this change and succeeds after it.

#### Testing

```
make test
go test ./builder/azure/arm/... ./builder/azure/common/...
go build ./...
go fmt ./...
```